### PR TITLE
Fix Stripe checkout session creation by using bracket notation for fo…

### DIFF
--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -62,7 +62,7 @@ billingRoutes.post('/create-checkout', authMiddleware, async (c) => {
         },
         body: new URLSearchParams({
           email: user.email,
-          metadata: JSON.stringify({ userId: user.id }),
+          'metadata[userId]': user.id,
         }),
       });
 
@@ -91,12 +91,8 @@ billingRoutes.post('/create-checkout', authMiddleware, async (c) => {
       },
       body: new URLSearchParams({
         customer: stripeCustomerId,
-        line_items: JSON.stringify([
-          {
-            price: stripePriceId,
-            quantity: 1,
-          },
-        ]),
+        'line_items[0][price]': stripePriceId,
+        'line_items[0][quantity]': '1',
         mode: 'subscription',
         success_url: successUrl,
         cancel_url: cancelUrl,


### PR DESCRIPTION
…rm-encoded params

Stripe's API requires bracket notation (e.g. line_items[0][price]) for nested parameters in form-encoded requests. The code was incorrectly passing line_items as a JSON string and metadata as JSON.stringify(), which Stripe cannot parse.

https://claude.ai/code/session_018Q4FMWXwenjsf79pHQha6W