### PR TITLE
Show 'Week X Stats' instead of 'Key Line' on PlayerCard after game fi…

### DIFF
--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -1203,13 +1203,18 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
             </div>
 
             {/* Key Line Spotlight — only show when real data exists */}
-            {player.keyLine ? (
-              <div className="bg-gradient-to-br from-blue-600 to-blue-800 rounded-lg p-6 border border-blue-500/30">
-                <h4 className="text-white font-bold mb-2">Key Line</h4>
+            {player.keyLine ? (() => {
+              const hasActualStats = weeklyStats?.some(s => s.week === propsCurrentWeek);
+              return (
+              <div className={`bg-gradient-to-br ${hasActualStats ? 'from-emerald-600 to-emerald-800 border-emerald-500/30' : 'from-blue-600 to-blue-800 border-blue-500/30'} rounded-lg p-6 border`}>
+                <h4 className="text-white font-bold mb-2">{hasActualStats ? `Week ${propsCurrentWeek} Stats` : 'Key Line'}</h4>
                 <p className="text-2xl font-bold text-white mb-1">{player.keyLine}</p>
-                <p className="text-blue-200 text-sm">Market consensus across major sportsbooks</p>
+                <p className={`${hasActualStats ? 'text-emerald-200' : 'text-blue-200'} text-sm`}>
+                  {hasActualStats ? 'Final results' : 'Market consensus across major sportsbooks'}
+                </p>
               </div>
-            ) : null}
+              );
+            })() : null}
 
             {/* AdSense Ad Unit */}
             <div className="my-4 rounded-lg overflow-hidden">


### PR DESCRIPTION
…nishes

When a player has actual stats for the current week, the Key Line section now displays "Week X Stats" with a green gradient instead of the blue "Key Line" with sportsbook messaging. The subtitle changes to "Final results".

https://claude.ai/code/session_018Q4FMWXwenjsf79pHQha6W