### PR TITLE
Optimize player cards and matchup view for mobile

### DIFF
--- a/src/components/MatchupView.tsx
+++ b/src/components/MatchupView.tsx
@@ -204,10 +204,10 @@ export function MatchupView({ onPlayerClick, isDarkMode }: MatchupViewProps) {
       )}
 
       {/* Header Card */}
-      <div className={`rounded-lg border p-8 ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
-        <div className="flex items-start justify-between mb-6">
+      <div className={`rounded-lg border p-4 sm:p-8 ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
+        <div className="flex items-start justify-between mb-4 sm:mb-6">
           <div>
-            <h1 className={`text-2xl font-bold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Fantasy Matchup</h1>
+            <h1 className={`text-xl sm:text-2xl font-bold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Fantasy Matchup</h1>
             <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{isComplete ? 'Final results' : 'Side-by-side projections and biggest edges'}</p>
           </div>
           <div
@@ -219,31 +219,31 @@ export function MatchupView({ onPlayerClick, isDarkMode }: MatchupViewProps) {
         </div>
 
         {/* Matchup Overview */}
-        <div className={`rounded-lg p-6 border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-50 border-slate-200'}`}>
-          <div className="flex items-center justify-between mb-6">
+        <div className={`rounded-lg p-4 sm:p-6 border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-50 border-slate-200'}`}>
+          <div className="flex items-center justify-between mb-4 sm:mb-6">
             {/* Your Team */}
             <div className="text-center flex-1">
-              <div className={`text-sm mb-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>You</div>
-              <div className={`text-4xl font-bold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{isComplete && matchup?.userTeam?.score ? matchup.userTeam.score.toFixed(1) : yourTotal.toFixed(1)}</div>
-              <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{isComplete ? 'Final Score' : 'Projected Points'}</div>
+              <div className={`text-xs sm:text-sm mb-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>You</div>
+              <div className={`text-2xl sm:text-4xl font-bold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{isComplete && matchup?.userTeam?.score ? matchup.userTeam.score.toFixed(1) : yourTotal.toFixed(1)}</div>
+              <div className={`text-[10px] sm:text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{isComplete ? 'Final Score' : 'Projected Points'}</div>
             </div>
 
             {/* VS Badge */}
-            <div className="px-8">
-              <div className={`w-16 h-16 rounded-full border-2 flex items-center justify-center ${isDarkMode ? 'bg-slate-900 border-slate-600' : 'bg-white border-slate-300'}`}>
-                <span className={`font-bold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>VS</span>
+            <div className="px-3 sm:px-8">
+              <div className={`w-10 h-10 sm:w-16 sm:h-16 rounded-full border-2 flex items-center justify-center ${isDarkMode ? 'bg-slate-900 border-slate-600' : 'bg-white border-slate-300'}`}>
+                <span className={`text-xs sm:text-base font-bold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>VS</span>
               </div>
             </div>
 
             {/* Opponent */}
             <div className="text-center flex-1">
-              <div className={`text-sm mb-1 ${!hasMatchup ? (isDarkMode ? 'text-slate-600' : 'text-slate-400') : (isDarkMode ? 'text-slate-400' : 'text-slate-500')}`}>
+              <div className={`text-xs sm:text-sm mb-1 truncate ${!hasMatchup ? (isDarkMode ? 'text-slate-600' : 'text-slate-400') : (isDarkMode ? 'text-slate-400' : 'text-slate-500')}`}>
                 {opponentName}
               </div>
-              <div className={`text-4xl font-bold mb-1 ${!hasMatchup ? (isDarkMode ? 'text-slate-700' : 'text-slate-300') : (isDarkMode ? 'text-white' : 'text-slate-900')}`}>
+              <div className={`text-2xl sm:text-4xl font-bold mb-1 ${!hasMatchup ? (isDarkMode ? 'text-slate-700' : 'text-slate-300') : (isDarkMode ? 'text-white' : 'text-slate-900')}`}>
                 {hasMatchup ? (isComplete && matchup?.opponent?.score ? matchup.opponent.score.toFixed(1) : opponentTotal.toFixed(1)) : '-'}
               </div>
-              <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+              <div className={`text-[10px] sm:text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
                 {!hasMatchup ? 'No opponent' : isComplete ? 'Final Score' : 'Projected Points'}
               </div>
             </div>
@@ -292,7 +292,7 @@ export function MatchupView({ onPlayerClick, isDarkMode }: MatchupViewProps) {
           )}
 
           {/* Quick Stats */}
-          <div className="grid grid-cols-3 gap-4 mt-6">
+          <div className="grid grid-cols-3 gap-2 sm:gap-4 mt-4 sm:mt-6">
             <div className={`rounded-lg p-3 text-center border ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
               <div className="flex items-center justify-center gap-1 mb-1">
                 <Target className="w-4 h-4 text-blue-500" aria-hidden="true" />
@@ -322,80 +322,80 @@ export function MatchupView({ onPlayerClick, isDarkMode }: MatchupViewProps) {
 
       {/* Position-by-Position Comparison */}
       <div className={`rounded-lg border overflow-hidden ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
-        <div className={`p-6 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
+        <div className={`p-4 sm:p-6 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
           <h2 className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Position-by-Position Breakdown</h2>
-          <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{isComplete ? 'Final points at each roster spot' : 'Compare projections at each roster spot'}</p>
+          <p className={`text-xs sm:text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{isComplete ? 'Final points at each roster spot' : 'Compare projections at each roster spot'}</p>
         </div>
 
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
               <tr className={`border-b ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-50 border-slate-200'}`}>
-                <th scope="col" className={`text-left px-6 py-3 text-xs w-16 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>POS</th>
-                <th scope="col" className={`text-left px-4 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Your Player</th>
-                <th scope="col" className={`text-center px-4 py-3 text-xs w-24 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{isComplete ? 'Pts' : 'Proj'}</th>
-                <th scope="col" className={`text-center px-4 py-3 text-xs w-20 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Edge</th>
-                <th scope="col" className={`text-center px-4 py-3 text-xs w-24 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{isComplete ? 'Pts' : 'Proj'}</th>
-                <th scope="col" className={`text-right px-4 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Their Player</th>
+                <th scope="col" className={`text-left px-2 sm:px-6 py-3 text-xs w-10 sm:w-16 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>POS</th>
+                <th scope="col" className={`text-left px-2 sm:px-4 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Your Player</th>
+                <th scope="col" className={`text-center px-2 sm:px-4 py-3 text-xs w-14 sm:w-24 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{isComplete ? 'Pts' : 'Proj'}</th>
+                <th scope="col" className={`text-center px-1 sm:px-4 py-3 text-xs w-14 sm:w-20 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Edge</th>
+                <th scope="col" className={`text-center px-2 sm:px-4 py-3 text-xs w-14 sm:w-24 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{isComplete ? 'Pts' : 'Proj'}</th>
+                <th scope="col" className={`text-right px-2 sm:px-4 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Their Player</th>
               </tr>
             </thead>
             <tbody>
               {positionComparison.map((comp, index) => (
                 <tr key={`${comp.yourPlayer.id || comp.position}-${index}`} className={`border-b transition-colors ${isDarkMode ? 'border-slate-800 hover:bg-slate-800/50' : 'border-slate-100 hover:bg-slate-50'}`}>
-                  <td className="px-6 py-4">
-                    <span className={`text-xs font-medium px-2 py-1 rounded ${isDarkMode ? 'text-slate-500 bg-slate-800' : 'text-slate-500 bg-slate-100'}`}>
+                  <td className="px-2 sm:px-6 py-3 sm:py-4">
+                    <span className={`text-[10px] sm:text-xs font-medium px-1.5 sm:px-2 py-0.5 sm:py-1 rounded ${isDarkMode ? 'text-slate-500 bg-slate-800' : 'text-slate-500 bg-slate-100'}`}>
                       {comp.position}
                     </span>
                   </td>
-                  <td className="px-4 py-4">
+                  <td className="px-2 sm:px-4 py-3 sm:py-4">
                     <button
                       onClick={() => onPlayerClick(convertToPlayer(comp.yourPlayer, index))}
                       className="text-left hover:text-blue-500 transition-colors group"
                     >
                       <div className="flex items-center gap-2">
-                        <div className={`w-9 aspect-[3/4] rounded flex items-center justify-center text-sm font-bold border overflow-hidden flex-shrink-0 group-hover:border-blue-500 transition-colors ${isDarkMode ? 'bg-slate-800 text-slate-400 border-slate-700' : 'bg-slate-100 text-slate-500 border-slate-200'}`}>
+                        <div className={`hidden sm:flex w-9 aspect-[3/4] rounded items-center justify-center text-sm font-bold border overflow-hidden flex-shrink-0 group-hover:border-blue-500 transition-colors ${isDarkMode ? 'bg-slate-800 text-slate-400 border-slate-700' : 'bg-slate-100 text-slate-500 border-slate-200'}`}>
                           <span className={`text-sm font-bold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{comp.yourPlayer.name.split(' ').map(n => n[0]).join('').slice(0, 2)}</span>
                         </div>
-                        <div>
-                          <div className="flex items-center gap-4">
-                            <span className={`font-bold group-hover:text-blue-500 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{comp.yourPlayer.name}</span>
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2 sm:gap-4">
+                            <span className={`text-xs sm:text-sm font-bold group-hover:text-blue-500 truncate ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{comp.yourPlayer.name}</span>
                             <span
-                              className={`text-xs font-medium px-2 py-1 rounded border shrink-0 ${getMatchupGradeColor(comp.yourPlayer.matchupGrade, isDarkMode)}`}
+                              className={`hidden md:inline text-xs font-medium px-2 py-1 rounded border shrink-0 ${getMatchupGradeColor(comp.yourPlayer.matchupGrade, isDarkMode)}`}
                               title={`${getMatchupGradeLabel(comp.yourPlayer.matchupGrade)} projection for position`}
                             >
                               Matchup {comp.yourPlayer.matchupGrade || '—'}
                             </span>
                           </div>
-                          <div className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{comp.yourPlayer.team}</div>
+                          <div className={`text-[10px] sm:text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{comp.yourPlayer.team}</div>
                         </div>
                       </div>
                     </button>
                   </td>
-                  <td className="px-4 py-4 text-center">
-                    <span className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{comp.yourPlayer.projection.toFixed(1)}</span>
+                  <td className="px-2 sm:px-4 py-3 sm:py-4 text-center">
+                    <span className={`text-xs sm:text-sm font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{comp.yourPlayer.projection.toFixed(1)}</span>
                   </td>
-                  <td className="px-4 py-4 text-center">
-                    <div className={`inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-bold ${
+                  <td className="px-1 sm:px-4 py-3 sm:py-4 text-center">
+                    <div className={`inline-flex items-center gap-0.5 sm:gap-1 px-1.5 sm:px-2 py-0.5 sm:py-1 rounded-full text-[10px] sm:text-xs font-bold ${
                       comp.diff > 1 ? 'bg-green-500/20 text-green-500' :
                       comp.diff < -1 ? 'bg-red-500/20 text-red-500' :
                       isDarkMode ? 'bg-slate-700 text-slate-400' : 'bg-slate-200 text-slate-500'
                     }`}>
-                      {comp.diff > 0 ? <TrendingUp className="w-3 h-3" aria-hidden="true" /> : comp.diff < 0 ? <TrendingDown className="w-3 h-3" aria-hidden="true" /> : null}
+                      {comp.diff > 0 ? <TrendingUp className="w-3 h-3 hidden sm:block" aria-hidden="true" /> : comp.diff < 0 ? <TrendingDown className="w-3 h-3 hidden sm:block" aria-hidden="true" /> : null}
                       {comp.diff > 0 ? '+' : ''}{comp.diff.toFixed(1)}
                     </div>
                   </td>
-                  <td className="px-4 py-4 text-center">
-                    <span className={`font-bold ${comp.oppPlayer.name === EMPTY_SLOT_NAME ? (isDarkMode ? 'text-slate-600' : 'text-slate-300') : (isDarkMode ? 'text-white' : 'text-slate-900')}`}>
+                  <td className="px-2 sm:px-4 py-3 sm:py-4 text-center">
+                    <span className={`text-xs sm:text-sm font-bold ${comp.oppPlayer.name === EMPTY_SLOT_NAME ? (isDarkMode ? 'text-slate-600' : 'text-slate-300') : (isDarkMode ? 'text-white' : 'text-slate-900')}`}>
                       {comp.oppPlayer.name === EMPTY_SLOT_NAME ? '-' : comp.oppPlayer.projection.toFixed(1)}
                     </span>
                   </td>
-                  <td className="px-4 py-4 text-right">
+                  <td className="px-2 sm:px-4 py-3 sm:py-4 text-right">
                     {comp.oppPlayer.name === EMPTY_SLOT_NAME ? (
                       <div className="text-right">
                         <div className={`flex items-center gap-2 justify-end ${isDarkMode ? 'text-slate-600' : 'text-slate-300'}`}>
-                          <span className="font-bold italic">{EMPTY_SLOT_NAME}</span>
+                          <span className="text-xs sm:text-sm font-bold italic">{EMPTY_SLOT_NAME}</span>
                         </div>
-                        <div className={`text-xs ${isDarkMode ? 'text-slate-700' : 'text-slate-300'}`}>No opponent</div>
+                        <div className={`text-[10px] sm:text-xs ${isDarkMode ? 'text-slate-700' : 'text-slate-300'}`}>No opponent</div>
                       </div>
                     ) : (
                       <button
@@ -403,19 +403,19 @@ export function MatchupView({ onPlayerClick, isDarkMode }: MatchupViewProps) {
                         className="text-right hover:text-blue-500 transition-colors group"
                       >
                         <div className="flex items-center gap-2 justify-end">
-                          <div>
-                            <div className="flex items-center gap-4 justify-end">
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-2 sm:gap-4 justify-end">
                               <span
-                                className={`text-xs font-medium px-2 py-1 rounded border shrink-0 ${getMatchupGradeColor(comp.oppPlayer.matchupGrade, isDarkMode)}`}
+                                className={`hidden md:inline text-xs font-medium px-2 py-1 rounded border shrink-0 ${getMatchupGradeColor(comp.oppPlayer.matchupGrade, isDarkMode)}`}
                                 title={`${getMatchupGradeLabel(comp.oppPlayer.matchupGrade)} projection for position`}
                               >
                                 Matchup {comp.oppPlayer.matchupGrade || '—'}
                               </span>
-                              <span className={`font-bold group-hover:text-blue-500 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{comp.oppPlayer.name}</span>
+                              <span className={`text-xs sm:text-sm font-bold group-hover:text-blue-500 truncate ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{comp.oppPlayer.name}</span>
                             </div>
-                            <div className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{comp.oppPlayer.team}</div>
+                            <div className={`text-[10px] sm:text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{comp.oppPlayer.team}</div>
                           </div>
-                          <div className={`w-9 aspect-[3/4] rounded flex items-center justify-center text-sm font-bold border overflow-hidden flex-shrink-0 group-hover:border-blue-500 transition-colors ${isDarkMode ? 'bg-slate-800 text-slate-400 border-slate-700' : 'bg-slate-100 text-slate-500 border-slate-200'}`}>
+                          <div className={`hidden sm:flex w-9 aspect-[3/4] rounded items-center justify-center text-sm font-bold border overflow-hidden flex-shrink-0 group-hover:border-blue-500 transition-colors ${isDarkMode ? 'bg-slate-800 text-slate-400 border-slate-700' : 'bg-slate-100 text-slate-500 border-slate-200'}`}>
                             <span className={`text-sm font-bold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{comp.oppPlayer.name.split(' ').map(n => n[0]).join('').slice(0, 2)}</span>
                           </div>
                         </div>
@@ -430,7 +430,7 @@ export function MatchupView({ onPlayerClick, isDarkMode }: MatchupViewProps) {
       </div>
 
       {/* Bench Comparison */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
         {/* Your Bench */}
         <div className={`rounded-lg border overflow-hidden ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
           <div className={`p-4 border-b ${isDarkMode ? 'border-slate-700 bg-slate-800/50' : 'border-slate-200 bg-slate-50'}`}>
@@ -446,27 +446,27 @@ export function MatchupView({ onPlayerClick, isDarkMode }: MatchupViewProps) {
                 <button
                   key={player.id || `bench-${player.name}-${player.team}`}
                   onClick={() => onPlayerClick(convertToPlayer(player, yourStarters.length))}
-                  className={`w-full rounded-lg px-4 py-3 border hover:border-blue-500 transition-all text-left group ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-50 border-slate-200'}`}
+                  className={`w-full rounded-lg px-3 sm:px-4 py-2.5 sm:py-3 border hover:border-blue-500 transition-all text-left group ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-50 border-slate-200'}`}
                 >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <span className={`text-xs w-8 font-medium ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.position}</span>
-                      <div className={`w-9 aspect-[3/4] rounded flex items-center justify-center text-xs font-bold overflow-hidden flex-shrink-0 transition-colors ${isDarkMode ? 'bg-slate-700 text-slate-400' : 'bg-slate-200 text-slate-500'}`}>
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+                      <span className={`text-[10px] sm:text-xs w-7 sm:w-8 font-medium shrink-0 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.position}</span>
+                      <div className={`hidden sm:flex w-9 aspect-[3/4] rounded items-center justify-center text-xs font-bold overflow-hidden flex-shrink-0 transition-colors ${isDarkMode ? 'bg-slate-700 text-slate-400' : 'bg-slate-200 text-slate-500'}`}>
                         <span className={`text-xs font-bold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.name.split(' ').map(n => n[0]).join('').slice(0, 2)}</span>
                       </div>
-                      <div>
-                        <span className={`font-bold transition-colors ${isDarkMode ? 'text-slate-300 group-hover:text-white' : 'text-slate-700 group-hover:text-slate-900'}`}>{player.name}</span>
-                        <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.team}</div>
+                      <div className="min-w-0">
+                        <span className={`text-xs sm:text-sm font-bold transition-colors truncate block ${isDarkMode ? 'text-slate-300 group-hover:text-white' : 'text-slate-700 group-hover:text-slate-900'}`}>{player.name}</span>
+                        <div className={`text-[10px] sm:text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.team}</div>
                       </div>
                     </div>
-                    <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-2 sm:gap-4 shrink-0">
                       <span
-                        className={`text-xs font-medium px-2 py-1 rounded border shrink-0 ${getMatchupGradeColor(player.matchupGrade, isDarkMode)}`}
+                        className={`hidden md:inline text-xs font-medium px-2 py-1 rounded border shrink-0 ${getMatchupGradeColor(player.matchupGrade, isDarkMode)}`}
                         title={`${getMatchupGradeLabel(player.matchupGrade)} projection for position`}
                       >
                         Matchup {player.matchupGrade || '—'}
                       </span>
-                      <span className={`text-sm font-semibold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.projection.toFixed(1)}</span>
+                      <span className={`text-xs sm:text-sm font-semibold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.projection.toFixed(1)}</span>
                     </div>
                   </div>
                 </button>
@@ -494,27 +494,27 @@ export function MatchupView({ onPlayerClick, isDarkMode }: MatchupViewProps) {
                 <button
                   key={player.id || `opp-bench-${player.name}-${player.team}`}
                   onClick={() => onPlayerClick(convertToPlayer(player, yourStarters.length + opponentStarters.length))}
-                  className={`w-full rounded-lg px-4 py-3 border hover:border-blue-500 transition-all text-left group ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-50 border-slate-200'}`}
+                  className={`w-full rounded-lg px-3 sm:px-4 py-2.5 sm:py-3 border hover:border-blue-500 transition-all text-left group ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-50 border-slate-200'}`}
                 >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <span className={`text-xs w-8 font-medium ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.position}</span>
-                      <div className={`w-9 aspect-[3/4] rounded flex items-center justify-center text-xs font-bold overflow-hidden flex-shrink-0 transition-colors ${isDarkMode ? 'bg-slate-700 text-slate-400' : 'bg-slate-200 text-slate-500'}`}>
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+                      <span className={`text-[10px] sm:text-xs w-7 sm:w-8 font-medium shrink-0 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.position}</span>
+                      <div className={`hidden sm:flex w-9 aspect-[3/4] rounded items-center justify-center text-xs font-bold overflow-hidden flex-shrink-0 transition-colors ${isDarkMode ? 'bg-slate-700 text-slate-400' : 'bg-slate-200 text-slate-500'}`}>
                         <span className={`text-xs font-bold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.name.split(' ').map(n => n[0]).join('').slice(0, 2)}</span>
                       </div>
-                      <div>
-                        <span className={`font-bold transition-colors ${isDarkMode ? 'text-slate-300 group-hover:text-white' : 'text-slate-700 group-hover:text-slate-900'}`}>{player.name}</span>
-                        <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.team}</div>
+                      <div className="min-w-0">
+                        <span className={`text-xs sm:text-sm font-bold transition-colors truncate block ${isDarkMode ? 'text-slate-300 group-hover:text-white' : 'text-slate-700 group-hover:text-slate-900'}`}>{player.name}</span>
+                        <div className={`text-[10px] sm:text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.team}</div>
                       </div>
                     </div>
-                    <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-2 sm:gap-4 shrink-0">
                       <span
-                        className={`text-xs font-medium px-2 py-1 rounded border shrink-0 ${getMatchupGradeColor(player.matchupGrade, isDarkMode)}`}
+                        className={`hidden md:inline text-xs font-medium px-2 py-1 rounded border shrink-0 ${getMatchupGradeColor(player.matchupGrade, isDarkMode)}`}
                         title={`${getMatchupGradeLabel(player.matchupGrade)} projection for position`}
                       >
                         Matchup {player.matchupGrade || '—'}
                       </span>
-                      <span className={`text-sm font-semibold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.projection.toFixed(1)}</span>
+                      <span className={`text-xs sm:text-sm font-semibold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.projection.toFixed(1)}</span>
                     </div>
                   </div>
                 </button>

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -316,24 +316,24 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
 
   return (
     <div
-      className={`fixed inset-0 backdrop-blur-sm z-[100] flex items-start justify-center overflow-y-auto p-4 transition-opacity duration-200 ${isDarkMode ? 'bg-slate-950/80' : 'bg-slate-900/50'} ${
+      className={`fixed inset-0 backdrop-blur-sm z-[100] flex items-start justify-center overflow-y-auto p-2 sm:p-4 transition-opacity duration-200 ${isDarkMode ? 'bg-slate-950/80' : 'bg-slate-900/50'} ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}
       onClick={(e) => e.target === e.currentTarget && handleClose()}
     >
-      <div className={`w-full max-w-5xl mt-8 mb-8 transition-all duration-300 ${
+      <div className={`w-full max-w-5xl mt-2 mb-2 sm:mt-8 sm:mb-8 transition-all duration-300 ${
         isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
       }`}>
         {/* Breadcrumb */}
-        <div className="mb-4 flex items-center justify-between">
+        <div className="mb-2 sm:mb-4 flex items-center justify-between">
           <button
             onClick={handleClose}
             className={`flex items-center gap-2 transition-colors group ${isDarkMode ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'}`}
           >
             <ArrowLeft className="w-4 h-4 group-hover:-translate-x-1 transition-transform" />
             <span className="text-sm">Back</span>
-            <span className={isDarkMode ? 'text-slate-600' : 'text-slate-400'}>/</span>
-            <span className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Player Card</span>
+            <span className={`hidden sm:inline ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>/</span>
+            <span className={`hidden sm:inline text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Player Card</span>
           </button>
           <button
             onClick={handleClose}
@@ -347,23 +347,23 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
           {/* Main Card */}
           <div className={`lg:col-span-2 rounded-lg border overflow-hidden shadow-2xl ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
             {/* Player Header */}
-            <div className={`p-6 border-b ${isDarkMode ? 'bg-gradient-to-br from-slate-800 to-slate-900 border-slate-700' : 'bg-gradient-to-br from-slate-50 to-white border-slate-200'}`}>
-              <div className="flex items-start justify-between">
-                <div className="flex items-center gap-4">
-                  <div className={`w-14 h-16 flex-shrink-0 rounded-lg overflow-hidden border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-100 border-slate-200'}`}>
+            <div className={`p-4 sm:p-6 border-b ${isDarkMode ? 'bg-gradient-to-br from-slate-800 to-slate-900 border-slate-700' : 'bg-gradient-to-br from-slate-50 to-white border-slate-200'}`}>
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-3 sm:gap-4 min-w-0">
+                  <div className={`w-10 h-12 sm:w-14 sm:h-16 flex-shrink-0 rounded-lg overflow-hidden border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-100 border-slate-200'}`}>
                     {player.headshotUrl ? (
                       <img src={player.headshotUrl} alt={player.name} className="w-full h-full object-contain" />
                     ) : (
                       <div className="w-full h-full flex items-center justify-center">
-                        <span className={`text-sm font-bold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.name.split(' ').map(n => n[0]).join('').slice(0, 2)}</span>
+                        <span className={`text-xs sm:text-sm font-bold ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.name.split(' ').map(n => n[0]).join('').slice(0, 2)}</span>
                       </div>
                     )}
                   </div>
-                  <div>
-                    <div className="flex items-center gap-3 mb-1">
-                      <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{player.name}</h1>
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 sm:gap-3 mb-1 flex-wrap">
+                      <h1 className={`text-lg sm:text-2xl font-bold truncate ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{player.name}</h1>
                       {player.status && player.status !== 'active' && (
-                        <span className={`text-[9px] font-bold uppercase px-2 py-0.5 rounded ${
+                        <span className={`text-[9px] font-bold uppercase px-2 py-0.5 rounded shrink-0 ${
                           player.status === 'injured_reserve' || player.status === 'out' ? 'bg-red-500/20 text-red-400' :
                           player.status === 'questionable' ? 'bg-yellow-500/20 text-yellow-400' :
                           player.status === 'doubtful' ? 'bg-orange-500/20 text-orange-400' :
@@ -373,19 +373,27 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
                         </span>
                       )}
                     </div>
-                    <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.team} • {player.position}{propsCurrentWeek ? ` • Week ${propsCurrentWeek}` : ''}</p>
+                    <p className={`text-xs sm:text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>{player.team} • {player.position}{propsCurrentWeek ? ` • Week ${propsCurrentWeek}` : ''}</p>
                   </div>
                 </div>
                 {matchupGrade && (
-                  <span className="text-xs font-medium px-3 py-1.5 rounded-md border shrink-0" style={getGradeStyle(matchupGrade)} title={matchupData?.message || `${getMatchupGradeLabel(matchupGrade)} matchup`}>
+                  <span className="hidden sm:inline text-xs font-medium px-3 py-1.5 rounded-md border shrink-0" style={getGradeStyle(matchupGrade)} title={matchupData?.message || `${getMatchupGradeLabel(matchupGrade)} matchup`}>
                     {matchupData?.opponent ? `vs ${matchupData.opponent} ` : 'Matchup '}{matchupGrade}
                   </span>
                 )}
               </div>
+              {/* Matchup grade - shown below on mobile */}
+              {matchupGrade && (
+                <div className="sm:hidden mt-3">
+                  <span className="text-xs font-medium px-3 py-1.5 rounded-md border" style={getGradeStyle(matchupGrade)} title={matchupData?.message || `${getMatchupGradeLabel(matchupGrade)} matchup`}>
+                    {matchupData?.opponent ? `vs ${matchupData.opponent} ` : 'Matchup '}{matchupGrade}
+                  </span>
+                </div>
+              )}
             </div>
 
             {/* News Section */}
-            <div className={`p-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
+            <div className={`p-3 sm:p-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
               <div className="flex items-center gap-2 mb-3">
                 <svg className={`w-4 h-4 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`} viewBox="0 0 24 24" fill="currentColor">
                   <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
@@ -447,7 +455,7 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
             </div>
 
             {/* Tab Content */}
-            <div className="p-6">
+            <div className="p-3 sm:p-6">
               {activeTab === 'props' && (() => {
                 const MARKET_LABELS: Record<string, string> = {
                   passyds: 'Passing Yards', rushyds: 'Rushing Yards', receptionyds: 'Receiving Yards',
@@ -1129,7 +1137,7 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
           {/* Right Sidebar */}
           <div className="space-y-6">
             {/* FilmRoom Insights */}
-            <div className={`rounded-lg border p-6 ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
+            <div className={`rounded-lg border p-4 sm:p-6 ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
               <div className="flex items-center gap-2 mb-4">
                 <Zap className="w-4 h-4 text-yellow-500" />
                 <h3 className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>FilmRoom Insights</h3>
@@ -1206,7 +1214,7 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
             {player.keyLine ? (() => {
               const hasActualStats = weeklyStats?.some(s => s.week === propsCurrentWeek);
               return (
-              <div className={`bg-gradient-to-br ${hasActualStats ? 'from-emerald-600 to-emerald-800 border-emerald-500/30' : 'from-blue-600 to-blue-800 border-blue-500/30'} rounded-lg p-6 border`}>
+              <div className={`bg-gradient-to-br ${hasActualStats ? 'from-emerald-600 to-emerald-800 border-emerald-500/30' : 'from-blue-600 to-blue-800 border-blue-500/30'} rounded-lg p-4 sm:p-6 border`}>
                 <h4 className="text-white font-bold mb-2">{hasActualStats ? `Week ${propsCurrentWeek} Stats` : 'Key Line'}</h4>
                 <p className="text-2xl font-bold text-white mb-1">{player.keyLine}</p>
                 <p className={`${hasActualStats ? 'text-emerald-200' : 'text-blue-200'} text-sm`}>

--- a/src/components/PlayerTable.tsx
+++ b/src/components/PlayerTable.tsx
@@ -45,16 +45,16 @@ const PlayerRow = memo(function PlayerRow({ player, onClick, isDarkMode, oddsDat
       }}
       className={`border-b transition-colors cursor-pointer group ${isDarkMode ? 'border-slate-800 hover:bg-slate-800' : 'border-slate-100 hover:bg-slate-50'}`}
     >
-      <td className="px-6 py-4">
-        <span className={`font-medium ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.rank}</span>
+      <td className="px-2 sm:px-6 py-3 sm:py-4">
+        <span className={`text-xs sm:text-sm font-medium ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{player.rank}</span>
       </td>
-      <td className="px-4 py-4">
-        <div>
-          <div className={`font-bold group-hover:text-blue-500 transition-colors ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{player.name}</div>
-          <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+      <td className="px-2 sm:px-4 py-3 sm:py-4">
+        <div className="min-w-0">
+          <div className={`text-sm sm:text-base font-bold group-hover:text-blue-500 transition-colors truncate ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{player.name}</div>
+          <div className={`text-[10px] sm:text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
             {player.team} <span className="sm:hidden">• {player.position}</span>
             {oddsDisplay && (
-              <div className={`text-xs ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>
+              <div className={`text-[10px] sm:text-xs ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>
                 {oddsDisplay}
               </div>
             )}
@@ -74,8 +74,8 @@ const PlayerRow = memo(function PlayerRow({ player, onClick, isDarkMode, oddsDat
           </div>
         )}
       </td>
-      <td className="px-4 py-4 text-right">
-        <span className={`font-bold text-lg ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{player.projectedPoints.toFixed(1)}</span>
+      <td className="px-2 sm:px-4 py-3 sm:py-4 text-right">
+        <span className={`font-bold text-sm sm:text-lg ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{player.projectedPoints.toFixed(1)}</span>
       </td>
       <td className="px-6 py-4 text-right hidden sm:table-cell">
         {pointsType === 'actual' && player.weeklyProjectedPoints !== undefined ? (
@@ -434,7 +434,7 @@ export function PlayerTable({
                     scope="col"
                     onClick={() => handleSort('rank')}
                     aria-sort={sortField === 'rank' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
-                    className={`text-left px-6 py-4 text-xs font-semibold cursor-pointer transition-colors w-16 ${isDarkMode ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'}`}
+                    className={`text-left px-2 sm:px-6 py-3 sm:py-4 text-xs font-semibold cursor-pointer transition-colors w-8 sm:w-16 ${isDarkMode ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'}`}
                   >
                     <div className="flex items-center gap-1.5">
                       RK
@@ -445,7 +445,7 @@ export function PlayerTable({
                     scope="col"
                     onClick={() => handleSort('name')}
                     aria-sort={sortField === 'name' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
-                    className={`text-left px-4 py-4 text-xs font-semibold cursor-pointer transition-colors ${isDarkMode ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'}`}
+                    className={`text-left px-2 sm:px-4 py-3 sm:py-4 text-xs font-semibold cursor-pointer transition-colors ${isDarkMode ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'}`}
                   >
                     <div className="flex items-center gap-1.5">
                       PLAYER
@@ -468,7 +468,7 @@ export function PlayerTable({
                     scope="col"
                     onClick={() => handleSort('projectedPoints')}
                     aria-sort={sortField === 'projectedPoints' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
-                    className={`text-right px-4 py-4 text-xs font-semibold cursor-pointer transition-colors w-24 ${isDarkMode ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'}`}
+                    className={`text-right px-2 sm:px-4 py-3 sm:py-4 text-xs font-semibold cursor-pointer transition-colors w-16 sm:w-24 ${isDarkMode ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'}`}
                   >
                     <div className="flex items-center gap-1.5 justify-end">
                       {pointsType === 'actual' ? 'PTS' : 'PROJ'}


### PR DESCRIPTION
- PlayerCard: reduce padding (p-6 -> p-4/p-3 on mobile), smaller headshot, smaller title text (text-lg on mobile), move matchup grade below header on small screens, tighter breadcrumb and outer margins
- MatchupView: compact score display (text-2xl on mobile), smaller VS badge, reduced table cell padding, hide initials avatars and matchup grade badges on small screens, truncate player names, smaller font sizes throughout
- PlayerTable: reduce rank/name/points column padding on mobile, smaller text sizes for rank numbers and player names, tighter header cells

https://claude.ai/code/session_018Q4FMWXwenjsf79pHQha6W