### PR TITLE
Sync dark class to <html> to fix white bars on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -200,6 +200,17 @@ function AppContent() {
   const [activeView, setActiveView] = useState<'Board' | 'Team' | 'Matchup' | 'Waivers' | 'Home' | 'GameSlate' | 'Trends' | 'Research' | 'Playoffs' | 'Settings' | 'Profile' | 'Login' | 'AllPlayers' | 'Pricing'>(() => getViewFromURL() as any);
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
   const isDarkMode = user?.darkMode ?? true;
+
+  // Sync dark class to <html> so CSS variables apply to html/body
+  // (prevents white bars on mobile in dark mode)
+  useEffect(() => {
+    if (isDarkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [isDarkMode]);
+
   const [allPlayersSource, setAllPlayersSource] = useState<'board' | 'waivers'>('board');
   const [authView, setAuthView] = useState<'login' | 'register' | 'forgot' | 'reset'>('login');
   const [resetToken, setResetToken] = useState<string | null>(null);


### PR DESCRIPTION
The .dark class was only on an inner div, so CSS variables on html/body still resolved to the light theme #ffffff background. Now isDarkMode toggles the dark class on document.documentElement so html/body background correctly uses #0a0a0a in dark mode.

https://claude.ai/code/session_01U9DAgEunqiX1h4EgbDzgFz