### PR TITLE
Add AI Trade Analyzer with Claude API integration

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,6 +19,7 @@ import { feedbackRoutes } from './routes/feedback';
 import { yahooRoutes } from './routes/yahoo';
 import { billingRoutes } from './routes/billing';
 import { adminStatsRoutes } from './routes/admin-stats';
+import { tradesRoutes } from './routes/trades';
 
 // Types
 export type Env = {
@@ -29,6 +30,7 @@ export type Env = {
   ODDS_API_KEY?: string; // Optional: The Odds API key for fetching NFL odds
   TWITTER_RSS_URLS?: string; // Comma-separated RSS URLs, e.g. https://nitter.net/AdamSchefter/rss
   OPENAI_API_KEY?: string; // For AI relevance filtering of player news
+  ANTHROPIC_API_KEY?: string; // For AI trade analysis (Claude API)
   GOOGLE_CLIENT_ID?: string; // Google OAuth client ID — get from https://console.cloud.google.com/apis/credentials
   YAHOO_CLIENT_ID?: string; // Yahoo OAuth client ID — get from https://developer.yahoo.com/apps/
   YAHOO_CLIENT_SECRET?: string; // Yahoo OAuth client secret
@@ -160,6 +162,7 @@ app.route('/api/admin', adminRoutes);
 app.route('/api/feedback', feedbackRoutes);
 app.route('/api/yahoo', yahooRoutes);
 app.route('/api/billing', billingRoutes);
+app.route('/api/trades', tradesRoutes);
 app.route('/api/admin', adminStatsRoutes);
 
 // 404 handler

--- a/server/src/routes/trades.ts
+++ b/server/src/routes/trades.ts
@@ -1,0 +1,224 @@
+import { Hono } from 'hono';
+import type { Env, Variables } from '../index';
+import { authMiddleware } from '../middleware/auth';
+import { rateLimit } from '../middleware/rateLimit';
+
+const tradesRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface TradeAssetInput {
+  type: 'player' | 'pick';
+  name: string;
+  position?: string;
+  team?: string;
+}
+
+interface TradeTeamInput {
+  label: string;
+  sends: TradeAssetInput[];
+}
+
+interface AnalyzeTradeBody {
+  teams: TradeTeamInput[];
+  leagueType: 'redraft' | 'dynasty' | 'keeper';
+  strategy?: 'win-now' | 'rebuilding' | 'balanced';
+  context?: string;
+}
+
+interface TeamGrade {
+  team: string;
+  grade: string;
+  summary: string;
+}
+
+interface TradeAnalysisResult {
+  winner: string;
+  winnerExplanation: string;
+  teamGrades: TeamGrade[];
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function buildTradeDescription(body: AnalyzeTradeBody): string {
+  const teamDescriptions = body.teams.map((t) => {
+    const assets = t.sends
+      .map((a) => {
+        if (a.type === 'player') {
+          return `${a.name}${a.position ? ` (${a.position}` : ''}${a.team ? `, ${a.team})` : a.position ? ')' : ''}`;
+        }
+        return a.name;
+      })
+      .join(', ');
+    return `${t.label} sends: ${assets}`;
+  });
+
+  return teamDescriptions.join('\n');
+}
+
+function buildSystemPrompt(body: AnalyzeTradeBody): string {
+  const leagueLabel =
+    body.leagueType === 'redraft'
+      ? 'Redraft'
+      : body.leagueType === 'dynasty'
+      ? 'Dynasty'
+      : 'Keeper';
+
+  const strategyNote =
+    body.strategy && body.leagueType !== 'redraft'
+      ? `\nThe user's team strategy: ${body.strategy === 'win-now' ? 'Win Now (prioritize current season production)' : body.strategy === 'rebuilding' ? 'Rebuilding (prioritize youth, upside, and future assets)' : 'Balanced (equal weight on present and future value)'}.`
+      : '';
+
+  return `You are an expert fantasy football trade analyst. You have deep knowledge of NFL players, their current values, injury histories, injury timelines, team situations, depth charts, coaching schemes, and fantasy football strategy.
+
+When evaluating trades you MUST consider:
+- Current player value and recent performance trends
+- Injury status, injury history, and expected return timelines
+- Age and long-term outlook (especially important for dynasty/keeper)
+- NFL team changes that affect player value (coaching changes, offensive line changes, QB changes, new skill position additions via draft/FA)
+- Target share, snap counts, and opportunity metrics
+- Strength of schedule and upcoming matchups
+- Positional scarcity and replacement-level value
+- Draft pick value based on round and year (future picks are inherently uncertain)
+- The specific league format impacts how players should be valued
+
+League format: ${leagueLabel}${strategyNote}
+
+You must respond with ONLY valid JSON in this exact format (no markdown, no extra text):
+{
+  "winner": "Team name that wins the trade",
+  "winnerExplanation": "2-3 sentence explanation of why this team wins the trade overall",
+  "teamGrades": [
+    {
+      "team": "Team label",
+      "grade": "Letter grade (A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F)",
+      "summary": "2-3 sentence analysis of what this team gains/loses and why they got this grade"
+    }
+  ]
+}
+
+Rules:
+- teamGrades MUST have one entry for EACH team in the trade
+- Grades should be realistic — not every trade is great for everyone
+- The winner field must match one of the team labels exactly
+- Be specific: reference actual player strengths, weaknesses, injuries, and situations
+- If draft picks are involved, assess their value relative to the players being traded
+- Consider the current NFL landscape and fantasy football context`;
+}
+
+// ── Route ──────────────────────────────────────────────────────────────
+
+tradesRoutes.post(
+  '/analyze',
+  authMiddleware,
+  rateLimit(10, 60_000), // 10 requests per minute per user
+  async (c) => {
+    const anthropicKey = c.env.ANTHROPIC_API_KEY;
+    if (!anthropicKey) {
+      return c.json({ error: 'Trade analysis is not configured. Missing API key.' }, 503);
+    }
+
+    let body: AnalyzeTradeBody;
+    try {
+      body = await c.req.json<AnalyzeTradeBody>();
+    } catch {
+      return c.json({ error: 'Invalid request body' }, 400);
+    }
+
+    // Validate
+    if (!body.teams || !Array.isArray(body.teams) || body.teams.length < 2 || body.teams.length > 4) {
+      return c.json({ error: 'Trade must involve 2-4 teams' }, 400);
+    }
+
+    for (const team of body.teams) {
+      if (!team.sends || !Array.isArray(team.sends) || team.sends.length === 0) {
+        return c.json({ error: `Each team must send at least one asset` }, 400);
+      }
+      if (team.sends.length > 10) {
+        return c.json({ error: 'Maximum 10 assets per team' }, 400);
+      }
+    }
+
+    if (!['redraft', 'dynasty', 'keeper'].includes(body.leagueType)) {
+      return c.json({ error: 'Invalid league type' }, 400);
+    }
+
+    // Truncate context to prevent prompt injection abuse
+    const userContext = body.context ? body.context.slice(0, 1000) : '';
+
+    const tradeDescription = buildTradeDescription(body);
+    const systemPrompt = buildSystemPrompt(body);
+
+    const userMessage = `Analyze this ${body.teams.length}-team fantasy football trade:
+
+${tradeDescription}${userContext ? `\n\nAdditional context from the user:\n${userContext}` : ''}
+
+Provide your analysis as JSON.`;
+
+    try {
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': anthropicKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: 'claude-sonnet-4-20250514',
+          max_tokens: 1024,
+          system: systemPrompt,
+          messages: [{ role: 'user', content: userMessage }],
+          temperature: 0.3,
+        }),
+        signal: AbortSignal.timeout(30000),
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        console.error('Anthropic API error:', res.status, errText);
+        return c.json({ error: 'AI analysis failed. Please try again later.' }, 502);
+      }
+
+      const data = (await res.json()) as {
+        content?: { type: string; text?: string }[];
+      };
+
+      const textBlock = data.content?.find((b) => b.type === 'text');
+      const rawText = textBlock?.text?.trim();
+      if (!rawText) {
+        return c.json({ error: 'AI returned an empty response. Please try again.' }, 502);
+      }
+
+      // Parse JSON (handle potential markdown wrapping)
+      const jsonStr = rawText.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+      let parsed: TradeAnalysisResult;
+      try {
+        parsed = JSON.parse(jsonStr);
+      } catch {
+        console.error('Failed to parse AI response:', rawText.slice(0, 500));
+        return c.json({ error: 'AI returned an invalid response. Please try again.' }, 502);
+      }
+
+      // Validate shape
+      if (
+        !parsed.winner ||
+        !parsed.winnerExplanation ||
+        !Array.isArray(parsed.teamGrades) ||
+        parsed.teamGrades.length !== body.teams.length
+      ) {
+        console.error('AI response missing fields:', JSON.stringify(parsed).slice(0, 500));
+        return c.json({ error: 'AI returned an incomplete response. Please try again.' }, 502);
+      }
+
+      return c.json(parsed);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return c.json({ error: 'Analysis timed out. Please try again.' }, 504);
+      }
+      console.error('Trade analysis error:', err);
+      return c.json({ error: 'An unexpected error occurred during analysis.' }, 500);
+    }
+  }
+);
+
+export { tradesRoutes };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { ForgotPasswordView, ResetPasswordView } from './components/ForgotPasswo
 import { ProfileView } from './components/ProfileView';
 import { AllPlayersView } from './components/AllPlayersView';
 import { ComingSoonView } from './components/ComingSoonView';
+import { TradeAnalyzerView } from './components/TradeAnalyzerView';
 import { PricingView } from './components/PricingView';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AuthProvider, useAuth } from './context/AuthContext';
@@ -567,7 +568,7 @@ function AppContent() {
             ) : activeView === 'DraftRankings' ? (
               <ComingSoonView title="Draft Rankings" description="AI-powered draft rankings with ADP tracking, tier breakdowns, and custom scoring projections." icon="draft" isDarkMode={isDarkMode} />
             ) : activeView === 'TradeAnalyzer' ? (
-              <ComingSoonView title="AI Trade Analyzer" description="Evaluate trade offers with AI analysis, player value comparisons, and roster impact projections." icon="trade" isDarkMode={isDarkMode} />
+              <TradeAnalyzerView isDarkMode={isDarkMode} />
             ) : activeView === 'Pricing' ? (
               <PricingView isDarkMode={isDarkMode} userTier={user?.subscriptionTier as 'free' | 'pro' | 'elite'} isAuthenticated={isAuthenticated} onNavigate={(view) => setActiveView(view as any)} />
             ) : (

--- a/src/components/TradeAnalyzerView.tsx
+++ b/src/components/TradeAnalyzerView.tsx
@@ -1,0 +1,742 @@
+import { useState, useCallback } from 'react';
+import {
+  ArrowRightLeft,
+  Plus,
+  X,
+  Loader2,
+  Trophy,
+  Users,
+  Search,
+  AlertCircle,
+} from 'lucide-react';
+import { api } from '../services/api';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface TradeTeam {
+  id: number;
+  label: string;
+  sends: TradeAsset[];
+}
+
+interface TradeAsset {
+  id: string;
+  type: 'player' | 'pick';
+  /** Display name (e.g. "Ja'Marr Chase" or "2025 1st Round Pick") */
+  name: string;
+  /** Only for players */
+  position?: string;
+  team?: string;
+}
+
+interface TeamGrade {
+  team: string;
+  grade: string;
+  summary: string;
+}
+
+interface TradeResult {
+  winner: string;
+  winnerExplanation: string;
+  teamGrades: TeamGrade[];
+}
+
+type LeagueType = 'redraft' | 'dynasty' | 'keeper';
+type TeamStrategy = 'win-now' | 'rebuilding' | 'balanced';
+
+// ── Player Search ──────────────────────────────────────────────────────
+
+function PlayerSearchInput({
+  isDarkMode,
+  onSelect,
+  placeholder,
+}: {
+  isDarkMode: boolean;
+  onSelect: (asset: TradeAsset) => void;
+  placeholder?: string;
+}) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<TradeAsset[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  const handleSearch = useCallback(
+    async (q: string) => {
+      setQuery(q);
+      if (q.trim().length < 2) {
+        setResults([]);
+        setShowDropdown(false);
+        return;
+      }
+      setIsSearching(true);
+      try {
+        const data = await api.get<
+          { id: string; fullName: string; position: string; team: string }[]
+        >(`/players/search?q=${encodeURIComponent(q)}&limit=8`);
+        setResults(
+          data.map((p) => ({
+            id: p.id,
+            type: 'player' as const,
+            name: p.fullName,
+            position: p.position,
+            team: p.team,
+          }))
+        );
+        setShowDropdown(true);
+      } catch {
+        setResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    },
+    []
+  );
+
+  return (
+    <div className="relative">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => handleSearch(e.target.value)}
+          onFocus={() => results.length > 0 && setShowDropdown(true)}
+          onBlur={() => setTimeout(() => setShowDropdown(false), 200)}
+          placeholder={placeholder || 'Search player...'}
+          className={`w-full pl-8 pr-3 py-2 text-sm rounded-lg border transition-colors ${
+            isDarkMode
+              ? 'bg-slate-800 border-slate-600 text-white placeholder:text-slate-500 focus:border-blue-500'
+              : 'bg-white border-slate-300 text-slate-900 placeholder:text-slate-400 focus:border-blue-500'
+          } outline-none`}
+        />
+        {isSearching && (
+          <Loader2 className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 animate-spin" />
+        )}
+      </div>
+      {showDropdown && results.length > 0 && (
+        <div
+          className={`absolute z-50 mt-1 w-full rounded-lg border shadow-lg max-h-48 overflow-y-auto ${
+            isDarkMode ? 'bg-slate-800 border-slate-600' : 'bg-white border-slate-200'
+          }`}
+        >
+          {results.map((r) => (
+            <button
+              key={r.id}
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                onSelect(r);
+                setQuery('');
+                setResults([]);
+                setShowDropdown(false);
+              }}
+              className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 transition-colors ${
+                isDarkMode ? 'hover:bg-slate-700 text-slate-200' : 'hover:bg-slate-50 text-slate-800'
+              }`}
+            >
+              <span
+                className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
+                  r.position === 'QB'
+                    ? 'bg-red-500/20 text-red-400'
+                    : r.position === 'RB'
+                    ? 'bg-green-500/20 text-green-400'
+                    : r.position === 'WR'
+                    ? 'bg-blue-500/20 text-blue-400'
+                    : r.position === 'TE'
+                    ? 'bg-amber-500/20 text-amber-400'
+                    : 'bg-slate-500/20 text-slate-400'
+                }`}
+              >
+                {r.position}
+              </span>
+              <span className="font-medium">{r.name}</span>
+              <span className={`ml-auto text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+                {r.team}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Draft Pick Input ───────────────────────────────────────────────────
+
+function DraftPickInput({
+  isDarkMode,
+  onAdd,
+}: {
+  isDarkMode: boolean;
+  onAdd: (asset: TradeAsset) => void;
+}) {
+  const [year, setYear] = useState('2025');
+  const [round, setRound] = useState('1');
+
+  const handleAdd = () => {
+    const ordinal =
+      round === '1' ? '1st' : round === '2' ? '2nd' : round === '3' ? '3rd' : `${round}th`;
+    onAdd({
+      id: `pick-${year}-${round}-${Date.now()}`,
+      type: 'pick',
+      name: `${year} ${ordinal} Round Pick`,
+    });
+  };
+
+  const selectClasses = `px-2 py-1.5 text-sm rounded-lg border transition-colors ${
+    isDarkMode
+      ? 'bg-slate-800 border-slate-600 text-white'
+      : 'bg-white border-slate-300 text-slate-900'
+  } outline-none`;
+
+  return (
+    <div className="flex items-center gap-2">
+      <select value={year} onChange={(e) => setYear(e.target.value)} className={selectClasses}>
+        {[2025, 2026, 2027, 2028].map((y) => (
+          <option key={y} value={y}>
+            {y}
+          </option>
+        ))}
+      </select>
+      <select value={round} onChange={(e) => setRound(e.target.value)} className={selectClasses}>
+        {[1, 2, 3, 4, 5].map((r) => (
+          <option key={r} value={r}>
+            Round {r}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="px-3 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors font-medium"
+      >
+        Add Pick
+      </button>
+    </div>
+  );
+}
+
+// ── Asset Chip ─────────────────────────────────────────────────────────
+
+function AssetChip({
+  asset,
+  isDarkMode,
+  onRemove,
+}: {
+  asset: TradeAsset;
+  isDarkMode: boolean;
+  onRemove: () => void;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-sm font-medium ${
+        asset.type === 'player'
+          ? isDarkMode
+            ? 'bg-blue-500/20 text-blue-300'
+            : 'bg-blue-50 text-blue-700'
+          : isDarkMode
+          ? 'bg-amber-500/20 text-amber-300'
+          : 'bg-amber-50 text-amber-700'
+      }`}
+    >
+      {asset.position && (
+        <span className="text-[10px] font-bold opacity-70">{asset.position}</span>
+      )}
+      {asset.name}
+      <button
+        type="button"
+        onClick={onRemove}
+        className="ml-0.5 hover:opacity-70 transition-opacity"
+      >
+        <X className="w-3 h-3" />
+      </button>
+    </span>
+  );
+}
+
+// ── Trade Team Card ────────────────────────────────────────────────────
+
+function TradeTeamCard({
+  team,
+  teamIndex,
+  isDarkMode,
+  onAddAsset,
+  onRemoveAsset,
+  onLabelChange,
+}: {
+  team: TradeTeam;
+  teamIndex: number;
+  isDarkMode: boolean;
+  onAddAsset: (teamId: number, asset: TradeAsset) => void;
+  onRemoveAsset: (teamId: number, assetId: string) => void;
+  onLabelChange: (teamId: number, label: string) => void;
+}) {
+  const [showPickInput, setShowPickInput] = useState(false);
+  const colors = [
+    { border: 'border-blue-500/30', bg: isDarkMode ? 'bg-blue-500/5' : 'bg-blue-50/50', accent: 'text-blue-500' },
+    { border: 'border-emerald-500/30', bg: isDarkMode ? 'bg-emerald-500/5' : 'bg-emerald-50/50', accent: 'text-emerald-500' },
+    { border: 'border-purple-500/30', bg: isDarkMode ? 'bg-purple-500/5' : 'bg-purple-50/50', accent: 'text-purple-500' },
+    { border: 'border-orange-500/30', bg: isDarkMode ? 'bg-orange-500/5' : 'bg-orange-50/50', accent: 'text-orange-500' },
+  ];
+  const color = colors[teamIndex % colors.length];
+
+  return (
+    <div className={`rounded-xl border ${color.border} ${color.bg} p-4`}>
+      <div className="flex items-center gap-2 mb-3">
+        <Users className={`w-4 h-4 ${color.accent}`} />
+        <input
+          type="text"
+          value={team.label}
+          onChange={(e) => onLabelChange(team.id, e.target.value)}
+          placeholder={`Team ${teamIndex + 1}`}
+          className={`text-sm font-semibold bg-transparent border-none outline-none ${
+            isDarkMode ? 'text-white placeholder:text-slate-500' : 'text-slate-900 placeholder:text-slate-400'
+          }`}
+        />
+      </div>
+
+      <p className={`text-xs mb-2 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+        Sends away:
+      </p>
+
+      {/* Current assets */}
+      {team.sends.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {team.sends.map((asset) => (
+            <AssetChip
+              key={asset.id}
+              asset={asset}
+              isDarkMode={isDarkMode}
+              onRemove={() => onRemoveAsset(team.id, asset.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Add player */}
+      <PlayerSearchInput
+        isDarkMode={isDarkMode}
+        onSelect={(asset) => onAddAsset(team.id, asset)}
+        placeholder="Search player to add..."
+      />
+
+      {/* Add pick toggle */}
+      <div className="mt-2">
+        {showPickInput ? (
+          <div className="space-y-2">
+            <DraftPickInput
+              isDarkMode={isDarkMode}
+              onAdd={(asset) => {
+                onAddAsset(team.id, asset);
+                setShowPickInput(false);
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => setShowPickInput(false)}
+              className={`text-xs ${isDarkMode ? 'text-slate-400 hover:text-slate-300' : 'text-slate-500 hover:text-slate-600'}`}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setShowPickInput(true)}
+            className={`flex items-center gap-1 text-xs font-medium mt-1 transition-colors ${
+              isDarkMode ? 'text-slate-400 hover:text-slate-300' : 'text-slate-500 hover:text-slate-600'
+            }`}
+          >
+            <Plus className="w-3 h-3" /> Add Draft Pick
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Grade Badge ────────────────────────────────────────────────────────
+
+function GradeBadge({ grade, isDarkMode }: { grade: string; isDarkMode: boolean }) {
+  const gradeColor = (() => {
+    const g = grade.toUpperCase();
+    if (g.startsWith('A')) return isDarkMode ? 'bg-green-500/20 text-green-400 border-green-500/30' : 'bg-green-50 text-green-700 border-green-200';
+    if (g.startsWith('B')) return isDarkMode ? 'bg-blue-500/20 text-blue-400 border-blue-500/30' : 'bg-blue-50 text-blue-700 border-blue-200';
+    if (g.startsWith('C')) return isDarkMode ? 'bg-amber-500/20 text-amber-400 border-amber-500/30' : 'bg-amber-50 text-amber-700 border-amber-200';
+    if (g.startsWith('D')) return isDarkMode ? 'bg-orange-500/20 text-orange-400 border-orange-500/30' : 'bg-orange-50 text-orange-700 border-orange-200';
+    return isDarkMode ? 'bg-red-500/20 text-red-400 border-red-500/30' : 'bg-red-50 text-red-700 border-red-200';
+  })();
+
+  return (
+    <span className={`inline-flex items-center justify-center w-12 h-12 rounded-xl border text-xl font-bold ${gradeColor}`}>
+      {grade}
+    </span>
+  );
+}
+
+// ── Results Card ───────────────────────────────────────────────────────
+
+function TradeResultsCard({
+  result,
+  isDarkMode,
+}: {
+  result: TradeResult;
+  isDarkMode: boolean;
+}) {
+  return (
+    <div className={`rounded-xl border p-6 space-y-6 ${isDarkMode ? 'bg-slate-900/50 border-slate-700' : 'bg-white border-slate-200'}`}>
+      {/* Winner callout */}
+      <div className={`flex items-start gap-3 p-4 rounded-lg ${isDarkMode ? 'bg-emerald-500/10 border border-emerald-500/20' : 'bg-emerald-50 border border-emerald-200'}`}>
+        <Trophy className={`w-5 h-5 mt-0.5 flex-shrink-0 ${isDarkMode ? 'text-emerald-400' : 'text-emerald-600'}`} />
+        <div>
+          <p className={`text-sm font-semibold mb-1 ${isDarkMode ? 'text-emerald-300' : 'text-emerald-700'}`}>
+            Trade Winner: {result.winner}
+          </p>
+          <p className={`text-sm ${isDarkMode ? 'text-slate-300' : 'text-slate-600'}`}>
+            {result.winnerExplanation}
+          </p>
+        </div>
+      </div>
+
+      {/* Per-team grades */}
+      <div className="space-y-4">
+        <h4 className={`text-sm font-semibold ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}>
+          Team Grades
+        </h4>
+        {result.teamGrades.map((tg, i) => (
+          <div
+            key={i}
+            className={`flex items-start gap-4 p-4 rounded-lg ${isDarkMode ? 'bg-slate-800/50' : 'bg-slate-50'}`}
+          >
+            <GradeBadge grade={tg.grade} isDarkMode={isDarkMode} />
+            <div className="flex-1 min-w-0">
+              <p className={`text-sm font-semibold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+                {tg.team}
+              </p>
+              <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
+                {tg.summary}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Main View ──────────────────────────────────────────────────────────
+
+interface TradeAnalyzerViewProps {
+  isDarkMode: boolean;
+}
+
+const MAX_CONTEXT_WORDS = 150;
+
+function createInitialTeams(count: number): TradeTeam[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i,
+    label: `Team ${i + 1}`,
+    sends: [],
+  }));
+}
+
+export function TradeAnalyzerView({ isDarkMode }: TradeAnalyzerViewProps) {
+  const [teamCount, setTeamCount] = useState<2 | 3 | 4>(2);
+  const [teams, setTeams] = useState<TradeTeam[]>(createInitialTeams(2));
+  const [leagueType, setLeagueType] = useState<LeagueType>('redraft');
+  const [strategy, setStrategy] = useState<TeamStrategy>('balanced');
+  const [context, setContext] = useState('');
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [result, setResult] = useState<TradeResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const wordCount = context.trim() ? context.trim().split(/\s+/).length : 0;
+
+  const handleTeamCountChange = useCallback((count: 2 | 3 | 4) => {
+    setTeamCount(count);
+    setTeams((prev) => {
+      if (count > prev.length) {
+        return [
+          ...prev,
+          ...Array.from({ length: count - prev.length }, (_, i) => ({
+            id: prev.length + i,
+            label: `Team ${prev.length + i + 1}`,
+            sends: [],
+          })),
+        ];
+      }
+      return prev.slice(0, count);
+    });
+    setResult(null);
+  }, []);
+
+  const handleAddAsset = useCallback((teamId: number, asset: TradeAsset) => {
+    setTeams((prev) =>
+      prev.map((t) =>
+        t.id === teamId
+          ? { ...t, sends: [...t.sends, asset] }
+          : t
+      )
+    );
+    setResult(null);
+  }, []);
+
+  const handleRemoveAsset = useCallback((teamId: number, assetId: string) => {
+    setTeams((prev) =>
+      prev.map((t) =>
+        t.id === teamId
+          ? { ...t, sends: t.sends.filter((a) => a.id !== assetId) }
+          : t
+      )
+    );
+    setResult(null);
+  }, []);
+
+  const handleLabelChange = useCallback((teamId: number, label: string) => {
+    setTeams((prev) =>
+      prev.map((t) => (t.id === teamId ? { ...t, label } : t))
+    );
+  }, []);
+
+  const canAnalyze = teams.every((t) => t.sends.length > 0) && !isAnalyzing;
+
+  const handleAnalyze = async () => {
+    if (!canAnalyze) return;
+    setIsAnalyzing(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const payload = {
+        teams: teams.map((t) => ({
+          label: t.label || `Team ${t.id + 1}`,
+          sends: t.sends.map((a) => ({
+            type: a.type,
+            name: a.name,
+            position: a.position,
+            team: a.team,
+          })),
+        })),
+        leagueType,
+        strategy: leagueType !== 'redraft' ? strategy : undefined,
+        context: context.trim() || undefined,
+      };
+
+      const data = await api.post<TradeResult>('/trades/analyze', payload);
+      setResult(data);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to analyze trade. Please try again.'
+      );
+    } finally {
+      setIsAnalyzing(false);
+    }
+  };
+
+  const handleContextChange = (text: string) => {
+    const words = text.trim().split(/\s+/);
+    if (text.trim() === '' || words.length <= MAX_CONTEXT_WORDS) {
+      setContext(text);
+    }
+  };
+
+  const handleReset = () => {
+    setTeams(createInitialTeams(teamCount));
+    setContext('');
+    setResult(null);
+    setError(null);
+  };
+
+  // ── Option button helper ─────────────────────────────────────────
+
+  const optionBtn = (
+    active: boolean,
+    onClick: () => void,
+    label: string
+  ) => (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1.5 text-sm rounded-lg font-medium transition-all ${
+        active
+          ? 'bg-blue-600 text-white shadow-sm'
+          : isDarkMode
+          ? 'bg-slate-800 text-slate-400 hover:bg-slate-700 hover:text-slate-300'
+          : 'bg-slate-100 text-slate-600 hover:bg-slate-200 hover:text-slate-800'
+      }`}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-4">
+        <div className="flex items-center gap-3">
+          <div
+            className={`w-10 h-10 rounded-xl flex items-center justify-center ${
+              isDarkMode ? 'bg-blue-600/20' : 'bg-blue-50'
+            }`}
+          >
+            <ArrowRightLeft className={`w-5 h-5 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`} />
+          </div>
+          <div>
+            <h1 className={`text-xl font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+              AI Trade Analyzer
+            </h1>
+            <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+              Get AI-powered trade analysis with grades and insights
+            </p>
+          </div>
+        </div>
+        {(teams.some((t) => t.sends.length > 0) || context) && (
+          <button
+            type="button"
+            onClick={handleReset}
+            className={`text-sm font-medium px-3 py-1.5 rounded-lg transition-colors ${
+              isDarkMode
+                ? 'text-slate-400 hover:text-white hover:bg-slate-800'
+                : 'text-slate-500 hover:text-slate-700 hover:bg-slate-100'
+            }`}
+          >
+            Reset
+          </button>
+        )}
+      </div>
+
+      {/* Configuration Row */}
+      <div
+        className={`rounded-xl border p-4 space-y-4 ${
+          isDarkMode ? 'bg-slate-900/50 border-slate-700' : 'bg-white border-slate-200'
+        }`}
+      >
+        {/* Trade Type (team count) */}
+        <div>
+          <label className={`block text-xs font-semibold mb-2 uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+            Trade Type
+          </label>
+          <div className="flex gap-2">
+            {([2, 3, 4] as const).map((n) =>
+              optionBtn(teamCount === n, () => handleTeamCountChange(n), `${n}-Team Trade`)
+            )}
+          </div>
+        </div>
+
+        {/* League Type */}
+        <div>
+          <label className={`block text-xs font-semibold mb-2 uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+            League Format
+          </label>
+          <div className="flex gap-2">
+            {optionBtn(leagueType === 'redraft', () => { setLeagueType('redraft'); setResult(null); }, 'Redraft')}
+            {optionBtn(leagueType === 'dynasty', () => { setLeagueType('dynasty'); setResult(null); }, 'Dynasty')}
+            {optionBtn(leagueType === 'keeper', () => { setLeagueType('keeper'); setResult(null); }, 'Keeper')}
+          </div>
+        </div>
+
+        {/* Strategy (dynasty/keeper only) */}
+        {leagueType !== 'redraft' && (
+          <div>
+            <label className={`block text-xs font-semibold mb-2 uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+              Your Team Strategy
+            </label>
+            <div className="flex gap-2">
+              {optionBtn(strategy === 'win-now', () => { setStrategy('win-now'); setResult(null); }, 'Win Now')}
+              {optionBtn(strategy === 'rebuilding', () => { setStrategy('rebuilding'); setResult(null); }, 'Rebuilding')}
+              {optionBtn(strategy === 'balanced', () => { setStrategy('balanced'); setResult(null); }, 'Balanced')}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Trade Teams */}
+      <div className={`grid gap-4 ${teamCount <= 2 ? 'md:grid-cols-2' : teamCount === 3 ? 'md:grid-cols-3' : 'md:grid-cols-2 lg:grid-cols-4'}`}>
+        {teams.map((team, i) => (
+          <TradeTeamCard
+            key={team.id}
+            team={team}
+            teamIndex={i}
+            isDarkMode={isDarkMode}
+            onAddAsset={handleAddAsset}
+            onRemoveAsset={handleRemoveAsset}
+            onLabelChange={handleLabelChange}
+          />
+        ))}
+      </div>
+
+      {/* Context */}
+      <div
+        className={`rounded-xl border p-4 ${
+          isDarkMode ? 'bg-slate-900/50 border-slate-700' : 'bg-white border-slate-200'
+        }`}
+      >
+        <label className={`block text-xs font-semibold mb-2 uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+          Additional Context{' '}
+          <span className="font-normal normal-case">(optional)</span>
+        </label>
+        <textarea
+          value={context}
+          onChange={(e) => handleContextChange(e.target.value)}
+          placeholder="Add context about your league, roster needs, scoring settings, or anything else the AI should consider..."
+          rows={3}
+          className={`w-full px-3 py-2 text-sm rounded-lg border resize-none transition-colors ${
+            isDarkMode
+              ? 'bg-slate-800 border-slate-600 text-white placeholder:text-slate-500 focus:border-blue-500'
+              : 'bg-white border-slate-300 text-slate-900 placeholder:text-slate-400 focus:border-blue-500'
+          } outline-none`}
+        />
+        <p className={`text-xs mt-1 ${wordCount >= MAX_CONTEXT_WORDS ? (isDarkMode ? 'text-amber-400' : 'text-amber-600') : isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+          {wordCount}/{MAX_CONTEXT_WORDS} words
+        </p>
+      </div>
+
+      {/* Analyze Button */}
+      <div className="flex flex-col items-center gap-3">
+        <button
+          type="button"
+          onClick={handleAnalyze}
+          disabled={!canAnalyze}
+          className={`w-full sm:w-auto px-8 py-3 rounded-xl text-sm font-semibold transition-all flex items-center justify-center gap-2 ${
+            canAnalyze
+              ? 'bg-blue-600 text-white hover:bg-blue-700 shadow-lg shadow-blue-600/20'
+              : isDarkMode
+              ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
+              : 'bg-slate-200 text-slate-400 cursor-not-allowed'
+          }`}
+        >
+          {isAnalyzing ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Analyzing Trade...
+            </>
+          ) : (
+            <>
+              <ArrowRightLeft className="w-4 h-4" />
+              Analyze Trade
+            </>
+          )}
+        </button>
+
+        {!canAnalyze && !isAnalyzing && (
+          <p className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+            Each team must send at least one player or pick
+          </p>
+        )}
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className={`flex items-start gap-3 p-4 rounded-xl border ${isDarkMode ? 'bg-red-500/10 border-red-500/20 text-red-400' : 'bg-red-50 border-red-200 text-red-600'}`}>
+          <AlertCircle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+          <p className="text-sm">{error}</p>
+        </div>
+      )}
+
+      {/* Results */}
+      {result && <TradeResultsCard result={result} isDarkMode={isDarkMode} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Frontend**: Full `TradeAnalyzerView` component replacing the Coming Soon placeholder — supports 2/3/4-team trades, player search via existing API, draft pick selection (year + round), league format toggle (redraft/dynasty/keeper), team strategy selector (win-now/rebuilding/balanced for dynasty/keeper), optional context input (150 word limit), and a results display with letter grades and winner analysis
- **Backend**: New `/api/trades/analyze` POST route that calls the Claude API (Sonnet) with a detailed fantasy football system prompt covering injuries, return timelines, team changes, player value, positional scarcity, and draft pick valuation — returns structured JSON with per-team grades and trade winner
- **Infrastructure**: Added `ANTHROPIC_API_KEY` to server env types, wired up trades route in `index.ts`, rate limited to 10 req/min per user, requires auth

## Setup
Add `ANTHROPIC_API_KEY` to `server/.dev.vars` (local) and as a Cloudflare secret for production:
```
wrangler secret put ANTHROPIC_API_KEY --env production
```

## Test plan
- [ ] Verify Trade Analyzer tab loads instead of Coming Soon
- [ ] Test 2-team trade with player search and analyze button
- [ ] Test 3 and 4-team trades
- [ ] Test draft pick addition
- [ ] Toggle dynasty/keeper and verify strategy selector appears
- [ ] Add context text and verify word limit enforced
- [ ] Submit analysis and verify grades/winner display
- [ ] Verify rate limiting kicks in after 10 rapid requests
- [ ] Verify unauthenticated users get 401

https://claude.ai/code/session_01AAkZjYpjXrkhcXeGXz5A2V