### PR TITLE
Fix SPA route refresh by creating directory-based routes in build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,12 @@ jobs:
           cd build
           cp index.html app.html
           cp ../landing.html index.html
+          # Create directory-based routes so Cloudflare Pages serves the SPA
+          # for each app route (e.g. /trade-analyzer -> trade-analyzer/index.html)
+          for route in board team matchup waivers game-slate trends research playoff-predictor trade-analyzer draft-rankings all-players pricing settings profile home login register forgot-password; do
+            mkdir -p "$route"
+            cp app.html "$route/index.html"
+          done
 
       - name: Install backend dependencies
         working-directory: server


### PR DESCRIPTION
Cloudflare Pages _redirects 200-rewrites to app.html weren't being applied, causing all SPA routes to serve the landing page on refresh.

Fix: during CI build, create a directory for each SPA route containing a copy of app.html as index.html (e.g. trade-analyzer/index.html). Cloudflare Pages natively serves directory/index.html for path requests, so /trade-analyzer now reliably serves the SPA with the correct URL.

https://claude.ai/code/session_01AAkZjYpjXrkhcXeGXz5A2V