### PR TITLE
Add SPA router to landing page for reliable Cloudflare Pages routing

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -3,6 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+    // SPA route detection: if not on root, load the React app instead of the landing page.
+    // This handles Cloudflare Pages serving index.html (landing) for SPA routes.
+    (function() {
+      var p = location.pathname;
+      if (p !== '/' && p !== '/index.html') {
+        var x = new XMLHttpRequest();
+        x.open('GET', '/app.html', false);
+        x.send();
+        if (x.status === 200) {
+          document.open();
+          document.write(x.responseText);
+          document.close();
+        }
+      }
+    })();
+    </script>
     <title>FilmRoom Fantasy — Fantasy Football Rankings, Projections & Analysis</title>
     <meta name="description" content="Fantasy football rankings driven by Vegas lines — not expert opinions. Projections built on how the betting market prices every game. Sync your Sleeper, Yahoo, or ESPN league instantly.">
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6355054767351119" crossorigin="anonymous"></script>


### PR DESCRIPTION
Cloudflare Pages serves index.html (landing page) for all unmatched routes, bypassing _redirects rewrites to app.html. This caused SPA routes like /trade-analyzer to show the landing page on refresh.

Fix: add an inline script at the top of landing.html that detects non-root paths and synchronously loads app.html via document.write, replacing the landing page with the SPA before any content renders. The URL is preserved so the React router reads the correct path.

https://claude.ai/code/session_01AAkZjYpjXrkhcXeGXz5A2V