### PR TITLE
Fix SPA routing: hash redirect instead of document.write, Home path fix

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -4,19 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
-    // SPA route detection: if not on root, load the React app instead of the landing page.
-    // This handles Cloudflare Pages serving index.html (landing) for SPA routes.
+    // SPA route detection: if not on the landing page root, redirect to the React app.
+    // Cloudflare Pages serves this file (index.html) for unmatched routes via SPA fallback.
+    // We encode the original path in a hash so the SPA can restore it.
     (function() {
       var p = location.pathname;
       if (p !== '/' && p !== '/index.html') {
-        var x = new XMLHttpRequest();
-        x.open('GET', '/app.html', false);
-        x.send();
-        if (x.status === 200) {
-          document.open();
-          document.write(x.responseText);
-          document.close();
-        }
+        location.replace('/app.html#redirect=' + encodeURIComponent(p + location.search));
       }
     })();
     </script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,7 +148,7 @@ export interface Player {
 
 // URL path <-> view mapping for client-side routing (BUG-001/002 fix)
 const VIEW_TO_PATH: Record<string, string> = {
-  Home: '/',
+  Home: '/home',
   Board: '/board',
   Matchup: '/matchup',
   Team: '/team',
@@ -173,7 +173,20 @@ const PATH_TO_VIEW: Record<string, string> = Object.fromEntries(
 
 /** Read the current URL pathname and return the matching view, defaulting to 'Board'. */
 function getViewFromURL(): string {
+  // Handle redirect from landing page: landing.html encodes the original path
+  // in a hash fragment when Cloudflare Pages serves it for SPA routes.
+  const hash = window.location.hash;
+  if (hash.startsWith('#redirect=')) {
+    const redirectPath = decodeURIComponent(hash.substring('#redirect='.length));
+    // Restore the correct URL (strip the hash, show the real path)
+    window.history.replaceState({}, '', redirectPath);
+  }
+
   const path = window.location.pathname.toLowerCase().replace(/\/+$/, '') || '/';
+
+  // Root path: show Board (landing page handles marketing homepage at /)
+  if (path === '/') return 'Board';
+
   const view = PATH_TO_VIEW[path] ?? 'Board';
   // /register is handled within the Login view via authView state
   if (view === 'Register') return 'Login';


### PR DESCRIPTION
Root cause: document.write doesn't reliably execute <script type="module">
tags, so the SPA loaded but fell back to Board. Also Home was mapped to '/' which collides with the landing page.

Fixes:
- landing.html: replace document.write with location.replace to /app.html#redirect=<encoded-path>. This is reliable across all browsers and preserves the original path in the hash.
- App.tsx getViewFromURL: detect #redirect= hash, decode the original path, and replaceState to restore the correct URL before routing.
- Change Home route from '/' to '/home' so refreshing Home doesn't serve the landing page. Root '/' now maps to Board in the SPA.

https://claude.ai/code/session_01AAkZjYpjXrkhcXeGXz5A2V