### PR TITLE
Rename Board to Player Rankings with season year for SEO

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -7,4 +7,5 @@
 /sitemap.xml    /sitemap.xml    200
 /sw.js    /sw.js    200
 /apple-touch-icon.png    /apple-touch-icon.png    200
+/board    /player-rankings    301
 /*    /index.html    200

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,7 +151,7 @@ export interface Player {
 const VIEW_TO_PATH: Record<string, string> = {
   Landing: '/',
   Home: '/home',
-  Board: '/board',
+  Board: '/player-rankings',
   Matchup: '/matchup',
   Team: '/team',
   Waivers: '/waivers',
@@ -227,7 +227,7 @@ function AppContent() {
 
   // Sync URL when activeView changes (BUG-001 fix: URL now updates on sidebar nav)
   useEffect(() => {
-    const targetPath = VIEW_TO_PATH[activeView] || '/board';
+    const targetPath = VIEW_TO_PATH[activeView] || '/player-rankings';
     if (window.location.pathname !== targetPath) {
       window.history.pushState({ view: activeView }, '', targetPath);
     }
@@ -247,7 +247,7 @@ function AppContent() {
   useEffect(() => {
     const titles: Record<string, string> = {
       Home: 'Dashboard | FilmRoom',
-      Board: 'Player Rankings | FilmRoom',
+      Board: `${league?.seasonYear ?? new Date().getFullYear()} Player Rankings | FilmRoom`,
       Team: 'My Team | FilmRoom',
       Matchup: 'Matchup | FilmRoom',
       Waivers: 'Waivers | FilmRoom',

--- a/src/components/PlayerTable.tsx
+++ b/src/components/PlayerTable.tsx
@@ -307,7 +307,7 @@ export function PlayerTable({
         {/* Header */}
         <div className={`p-3 sm:p-4 md:p-6 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
           <h2 className={`font-bold mb-1 text-sm sm:text-base ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
-            Player Rankings — Week {currentWeek} {pointsType === 'actual' ? '(Final)' : '(Projections)'}
+            {seasonYear} Player Rankings — Week {currentWeek} {pointsType === 'actual' ? '(Final)' : '(Projections)'}
           </h2>
           <p className={`text-xs sm:text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
             {pointsType === 'actual' ? 'Actual points scored' : 'Top players based on season stats and projections'}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,7 +19,7 @@ interface SidebarProps {
 export function Sidebar({ activeView, onViewChange, isDarkMode, isAuthenticated = false, selectedLeagueId, onLeagueSelect, onConnectLeague, mobileOpen = false, onMobileClose, userTier = 'free' }: SidebarProps) {
   const menuItems = [
     { icon: Home, label: 'Home', view: 'Home' as const },
-    { icon: LayoutDashboard, label: 'Board', view: 'Board' as const },
+    { icon: LayoutDashboard, label: 'Player Rankings', view: 'Board' as const },
     { icon: Swords, label: 'Matchup', view: 'Matchup' as const },
     { icon: UsersIcon, label: 'Team', view: 'Team' as const },
     { icon: ListPlus, label: 'Waivers', view: 'Waivers' as const },


### PR DESCRIPTION
- URL path: /board -> /player-rankings
- Sidebar label: Board -> Player Rankings
- Page title: "2025 Player Rankings | FilmRoom" (dynamic year from league)
- PlayerTable heading: "2025 Player Rankings - Week X (Projections)"
- 301 redirect from /board to /player-rankings for old bookmarks

https://claude.ai/code/session_01AAkZjYpjXrkhcXeGXz5A2V