### PR TITLE
fix: migrate JWT storage from localStorage to httpOnly cookies

### DIFF
--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,20 +1,40 @@
 import { Context, Next } from 'hono';
+import { getCookie } from 'hono/cookie';
 import { jwtVerify } from 'jose';
 import { eq, and, gt } from 'drizzle-orm';
 import * as schema from '../db/schema';
 import type { Env, Variables } from '../index';
 
+const AUTH_COOKIE_NAME = 'auth_token';
+
+/**
+ * Extract the auth token from the request.
+ * Reads from httpOnly cookie first (secure, preferred).
+ * Falls back to Authorization header for backwards compatibility during migration.
+ */
+function getAuthToken(c: Context): string | undefined {
+  // Prefer httpOnly cookie (not accessible to JavaScript — XSS-safe)
+  const cookieToken = getCookie(c, AUTH_COOKIE_NAME);
+  if (cookieToken) return cookieToken;
+
+  // Fallback: Authorization header (for API clients, mobile apps, etc.)
+  const authHeader = c.req.header('Authorization');
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    return authHeader.substring(7);
+  }
+
+  return undefined;
+}
+
 export const authMiddleware = async (
   c: Context<{ Bindings: Env; Variables: Variables }>,
   next: Next
 ) => {
-  const authHeader = c.req.header('Authorization');
+  const token = getAuthToken(c);
 
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  if (!token) {
     return c.json({ error: 'Unauthorized - No token provided' }, 401);
   }
-
-  const token = authHeader.substring(7);
 
   try {
     const secret = new TextEncoder().encode(c.env.JWT_SECRET);
@@ -61,11 +81,9 @@ export const optionalAuthMiddleware = async (
   c: Context<{ Bindings: Env; Variables: Variables }>,
   next: Next
 ) => {
-  const authHeader = c.req.header('Authorization');
+  const token = getAuthToken(c);
 
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    const token = authHeader.substring(7);
-
+  if (token) {
     try {
       const secret = new TextEncoder().encode(c.env.JWT_SECRET);
       const { payload } = await jwtVerify(token, secret, {

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import { SignJWT, jwtVerify, createRemoteJWKSet } from 'jose';
 import { eq, and, isNull, gt } from 'drizzle-orm';
 import * as schema from '../db/schema';
@@ -7,6 +8,25 @@ import { rateLimit } from '../middleware/rateLimit';
 import { hashPassword, verifyPassword } from '../utils/password';
 import { generateId } from '../utils/id';
 import type { Env, Variables } from '../index';
+
+// Cookie configuration for auth token
+const AUTH_COOKIE_NAME = 'auth_token';
+const AUTH_COOKIE_MAX_AGE = 24 * 60 * 60; // 24h in seconds
+
+function setAuthCookie(c: any, token: string) {
+  const isProduction = c.env.ENVIRONMENT === 'production';
+  setCookie(c, AUTH_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'Lax',
+    path: '/api',
+    maxAge: AUTH_COOKIE_MAX_AGE,
+  });
+}
+
+function clearAuthCookie(c: any) {
+  deleteCookie(c, AUTH_COOKIE_NAME, { path: '/api' });
+}
 
 export const authRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
 
@@ -167,13 +187,15 @@ authRoutes.post('/register', authRateLimit, async (c) => {
       expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h
     });
 
+    // Set httpOnly cookie — token is NOT returned in the response body
+    setAuthCookie(c, token);
+
     return c.json({
       user: {
         id: userId,
         email: email.toLowerCase(),
         username,
       },
-      token,
     }, 201);
   } catch (error) {
     console.error('Registration error:', error);
@@ -225,6 +247,9 @@ authRoutes.post('/login', authRateLimit, async (c) => {
       expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h
     });
 
+    // Set httpOnly cookie — token is NOT returned in the response body
+    setAuthCookie(c, token);
+
     return c.json({
       user: {
         id: user.id,
@@ -232,7 +257,6 @@ authRoutes.post('/login', authRateLimit, async (c) => {
         username: user.username,
         avatarUrl: user.avatarUrl,
       },
-      token,
     });
   } catch (error) {
     console.error('Login error:', error);
@@ -524,6 +548,9 @@ authRoutes.post('/google', authRateLimit, async (c) => {
       expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h
     });
 
+    // Set httpOnly cookie — token is NOT returned in the response body
+    setAuthCookie(c, token);
+
     return c.json({
       user: {
         id: user.id,
@@ -531,7 +558,6 @@ authRoutes.post('/google', authRateLimit, async (c) => {
         username: user.username,
         avatarUrl: user.avatarUrl,
       },
-      token,
     });
   } catch (error) {
     console.error('Google auth error:', error);
@@ -542,8 +568,10 @@ authRoutes.post('/google', authRateLimit, async (c) => {
 // Logout — revoke the current session token
 authRoutes.post('/logout', authMiddleware, async (c) => {
   try {
+    // Read token from cookie (primary) or Authorization header (fallback for migration)
+    const cookieToken = getCookie(c, AUTH_COOKIE_NAME);
     const authHeader = c.req.header('Authorization');
-    const token = authHeader?.substring(7);
+    const token = cookieToken || authHeader?.substring(7);
 
     if (!token) {
       return c.json({ error: 'No token provided' }, 400);
@@ -553,6 +581,9 @@ authRoutes.post('/logout', authMiddleware, async (c) => {
 
     // Delete the session matching this token
     await db.delete(schema.sessions).where(eq(schema.sessions.token, token));
+
+    // Clear the httpOnly auth cookie
+    clearAuthCookie(c);
 
     return c.json({ message: 'Logged out successfully' });
   } catch (error) {

--- a/src/components/LeagueManager.tsx
+++ b/src/components/LeagueManager.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { Link2, Loader2, ChevronDown, Check } from 'lucide-react';
 import { useLeaguesContext } from '../context/LeaguesContext';
 import { UpgradeModal } from './UpgradeModal';
-import { getToken } from '../services/api';
+// Auth cookie is sent automatically via credentials: 'include'
 
 interface LeagueManagerProps {
   isDarkMode: boolean;
@@ -164,21 +164,14 @@ export function LeagueManager({ isDarkMode, onLeagueSelect, selectedLeagueId, is
 
   const handleUpgradeClick = async (priceId: string) => {
     try {
-      // Get auth token from localStorage
-      const token = getToken();
-      if (!token) {
-        alert('Please sign in first');
-        return;
-      }
-
       // Create checkout session
       const apiBase = import.meta.env.VITE_API_URL || '/api';
       const response = await fetch(`${apiBase}/billing/create-checkout`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
+        credentials: 'include',
         body: JSON.stringify({
           priceId,
           successUrl: `${window.location.origin}?billing=success`,

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { authService, getToken, removeToken } from '../services';
+import { authService } from '../services';
 import type { User, League, UpdateProfileData, GoogleAuthResponse } from '../services/auth';
 
 interface AuthContextType {
@@ -24,19 +24,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const isAuthenticated = !!user;
 
-  // Check for existing token and load user on mount
+  // Check for existing session on mount by calling /auth/me
+  // The httpOnly cookie is sent automatically — no localStorage check needed
   useEffect(() => {
     const initAuth = async () => {
-      const token = getToken();
-      if (token) {
-        try {
-          const response = await authService.me();
-          setUser(response.user);
-          setLeagues(response.leagues);
-        } catch {
-          // Token invalid or expired
-          removeToken();
-        }
+      try {
+        const response = await authService.me();
+        setUser(response.user);
+        setLeagues(response.leagues);
+      } catch {
+        // No valid session — user stays null
       }
       setIsLoading(false);
     };
@@ -46,7 +43,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const login = useCallback(async (email: string, password: string) => {
     const response = await authService.login(email, password);
-    // Fetch full user with preferences and leagues (token already set by login)
+    // Fetch full user with preferences and leagues (cookie already set by server)
     try {
       const meResponse = await authService.me();
       setUser(meResponse.user);
@@ -59,7 +56,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const register = useCallback(async (email: string, password: string, username: string) => {
     const response = await authService.register(email, password, username);
-    // Fetch full user with preferences (authService.register already calls setToken)
+    // Fetch full user with preferences (cookie already set by server)
     try {
       const meResponse = await authService.me();
       setUser(meResponse.user);
@@ -78,7 +75,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return response;
     }
 
-    // Fetch full user with preferences and leagues (token already set by googleLogin)
+    // Fetch full user with preferences and leagues (cookie already set by server)
     if (response.user) {
       try {
         const meResponse = await authService.me();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,4 +3,7 @@ import App from "./App.tsx";
 import "./index.css";
 import "./styles/globals.css";
 
+// One-time migration: clear legacy localStorage token (auth now uses httpOnly cookies)
+localStorage.removeItem('filmroom_token');
+
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,21 +2,6 @@
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 
-// Token storage
-const TOKEN_KEY = 'filmroom_token';
-
-export const getToken = (): string | null => {
-  return localStorage.getItem(TOKEN_KEY);
-};
-
-export const setToken = (token: string): void => {
-  localStorage.setItem(TOKEN_KEY, token);
-};
-
-export const removeToken = (): void => {
-  localStorage.removeItem(TOKEN_KEY);
-};
-
 // API Error class
 export class ApiError extends Error {
   constructor(
@@ -29,27 +14,22 @@ export class ApiError extends Error {
   }
 }
 
-// Base fetch wrapper with auth
+// Base fetch wrapper with auth via httpOnly cookies
 export async function apiFetch<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<T> {
-  const token = getToken();
-
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
     ...options.headers,
   };
-
-  if (token) {
-    (headers as Record<string, string>)['Authorization'] = `Bearer ${token}`;
-  }
 
   let response: Response;
   try {
     response = await fetch(`${API_BASE_URL}${endpoint}`, {
       ...options,
       headers,
+      credentials: 'include', // Send httpOnly cookies with every request
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'Network error';
@@ -68,10 +48,6 @@ export async function apiFetch<T>(
   }
 
   if (!response.ok) {
-    // Auto-clear stale token on 401 Unauthorized to prevent infinite auth loops
-    if (response.status === 401) {
-      removeToken();
-    }
     const errorObj = data as { error?: string };
     throw new ApiError(response.status, errorObj.error || 'An error occurred', data);
   }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,5 +1,5 @@
 // Authentication API services
-import { api, setToken, removeToken } from './api';
+import { api } from './api';
 
 // Types
 export type ScoringFormat = 'ppr' | 'half_ppr' | 'standard';
@@ -40,12 +40,10 @@ export interface League {
 
 export interface AuthResponse {
   user: User;
-  token: string;
 }
 
 export interface GoogleAuthResponse {
   user?: User;
-  token?: string;
   needsUsername?: boolean;
   email?: string;
 }
@@ -59,33 +57,30 @@ export interface MeResponse {
 export const authService = {
   // Register a new user
   register: async (email: string, password: string, username: string): Promise<AuthResponse> => {
-    const response = await api.post<AuthResponse>('/auth/register', {
+    // Server sets httpOnly cookie automatically — no token handling needed
+    return api.post<AuthResponse>('/auth/register', {
       email,
       password,
       username,
     });
-    setToken(response.token);
-    return response;
   },
 
   // Login user
   login: async (email: string, password: string): Promise<AuthResponse> => {
-    const response = await api.post<AuthResponse>('/auth/login', {
+    // Server sets httpOnly cookie automatically — no token handling needed
+    return api.post<AuthResponse>('/auth/login', {
       email,
       password,
     });
-    setToken(response.token);
-    return response;
   },
 
-  // Logout user — revoke session server-side, then clear local token
+  // Logout user — revoke session server-side; server clears the cookie
   logout: async (): Promise<void> => {
     try {
       await api.post('/auth/logout', {});
     } catch {
-      // If server call fails (e.g. token already expired), still clear locally
+      // If server call fails (e.g. token already expired), cookie is already gone
     }
-    removeToken();
   },
 
   // Get current user
@@ -111,11 +106,8 @@ export const authService = {
   googleLogin: async (credential: string, username?: string): Promise<GoogleAuthResponse> => {
     const body: Record<string, string> = { credential };
     if (username) body.username = username;
-    const response = await api.post<GoogleAuthResponse>('/auth/google', body);
-    if (response.token) {
-      setToken(response.token);
-    }
-    return response;
+    // Server sets httpOnly cookie automatically — no token handling needed
+    return api.post<GoogleAuthResponse>('/auth/google', body);
   },
 
   // Forgot password — request a reset link
@@ -127,7 +119,6 @@ export const authService = {
   resetPassword: async (token: string, newPassword: string): Promise<{ message: string }> => {
     return api.post<{ message: string }>('/auth/reset-password', { token, newPassword });
   },
-
 };
 
 export default authService;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,5 @@
 // Export all services
-export { default as api, getToken, setToken, removeToken, ApiError } from './api';
+export { default as api, ApiError } from './api';
 export { default as authService } from './auth';
 export { default as playerService } from './players';
 export { default as leagueService } from './leagues';


### PR DESCRIPTION
Eliminates the #1 security vulnerability (XSS token theft) by moving auth tokens out of JavaScript-accessible localStorage into httpOnly cookies that the browser manages automatically.

Server changes:
- Auth endpoints (login, register, google) now set httpOnly cookie instead of returning token in response body
- Cookie settings: HttpOnly, Secure (prod), SameSite=Lax, Path=/api
- Auth middleware reads from cookie first, falls back to Authorization header for backwards compatibility with API clients
- Logout endpoint clears the auth cookie
- Uses Hono's built-in cookie helpers (getCookie/setCookie/deleteCookie)

Frontend changes:
- Removed getToken/setToken/removeToken from localStorage
- Removed Authorization header injection from API client
- Added credentials: 'include' to all fetch requests
- AuthContext now always calls /auth/me on mount (cookie sent automatically)
- LeagueManager uses credentials: 'include' for direct fetch calls
- One-time cleanup of legacy 'filmroom_token' from localStorage

https://claude.ai/code/session_01LrZKZyD1AYfb8tnjmuZzSa