### PR TITLE
fix: use SameSite=None in production so auth cookies work cross-site

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -18,14 +18,22 @@ function setAuthCookie(c: any, token: string) {
   setCookie(c, AUTH_COOKIE_NAME, token, {
     httpOnly: true,
     secure: isProduction,
-    sameSite: 'Lax',
+    // In production the frontend and API are on different domains, so we need
+    // SameSite=None (requires Secure) to allow cross-site cookie sending.
+    // In dev they share localhost via Vite proxy, so Lax is fine.
+    sameSite: isProduction ? 'None' : 'Lax',
     path: '/api',
     maxAge: AUTH_COOKIE_MAX_AGE,
   });
 }
 
 function clearAuthCookie(c: any) {
-  deleteCookie(c, AUTH_COOKIE_NAME, { path: '/api' });
+  const isProduction = c.env.ENVIRONMENT === 'production';
+  deleteCookie(c, AUTH_COOKIE_NAME, {
+    path: '/api',
+    secure: isProduction,
+    sameSite: isProduction ? 'None' : 'Lax',
+  });
 }
 
 export const authRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();


### PR DESCRIPTION
The frontend (filmroomfantasy.com) and API (*.workers.dev) are on different domains. SameSite=Lax blocks cookies on cross-site fetch() requests, which meant the auth cookie was never sent with API calls in production — causing 'Unauthorized - No token provided' on every authenticated endpoint. SameSite=None + Secure allows cross-site cookies over HTTPS. CORS origin whitelist still restricts which sites can make credentialed requests. Lax is kept for local dev where Vite proxies same-origin.

https://claude.ai/code/session_01LrZKZyD1AYfb8tnjmuZzSa