### PR TITLE
fix: detect HTTPS from request URL instead of ENVIRONMENT var for coo…

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -72,12 +72,26 @@ app.use('*', cors({
   origin: (origin, _c) => {
     if (!origin) return allowedOrigins[0];
     if (allowedOrigins.includes(origin)) return origin;
-    // Allow only our specific Cloudflare Pages/Workers subdomains
-    if (origin.endsWith('.filmroomfantasy.pages.dev') || origin.endsWith('.filmroomfantasy.workers.dev')) return origin;
-    // Allow custom production domains:
-    if (origin === 'https://filmroomfantasy.com' || origin === 'https://www.filmroomfantasy.com') return origin;
-    if (origin === 'https://filmroom.app' || origin === 'https://www.filmroom.app') return origin;
-    return allowedOrigins[0];
+    try {
+      const { hostname } = new URL(origin);
+      // Allow Cloudflare Pages/Workers domains (base domain + subdomains)
+      if (
+        hostname === 'filmroomfantasy.pages.dev' ||
+        hostname.endsWith('.filmroomfantasy.pages.dev') ||
+        hostname === 'filmroomfantasy.workers.dev' ||
+        hostname.endsWith('.filmroomfantasy.workers.dev')
+      ) return origin;
+      // Allow custom production domains
+      if (
+        hostname === 'filmroomfantasy.com' ||
+        hostname === 'www.filmroomfantasy.com' ||
+        hostname === 'filmroom.app' ||
+        hostname === 'www.filmroom.app'
+      ) return origin;
+    } catch {
+      // Invalid URL — fall through to deny
+    }
+    return null as unknown as string;
   },
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
   allowHeaders: ['Content-Type', 'Authorization', 'X-Admin-Key'],

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -14,25 +14,26 @@ const AUTH_COOKIE_NAME = 'auth_token';
 const AUTH_COOKIE_MAX_AGE = 24 * 60 * 60; // 24h in seconds
 
 function setAuthCookie(c: any, token: string) {
-  const isProduction = c.env.ENVIRONMENT === 'production';
+  // Detect HTTPS from the request itself rather than relying on ENVIRONMENT var.
+  // Cloudflare Workers always serve HTTPS in production; local dev uses HTTP.
+  const isSecure = c.req.url.startsWith('https://');
   setCookie(c, AUTH_COOKIE_NAME, token, {
     httpOnly: true,
-    secure: isProduction,
-    // In production the frontend and API are on different domains, so we need
-    // SameSite=None (requires Secure) to allow cross-site cookie sending.
-    // In dev they share localhost via Vite proxy, so Lax is fine.
-    sameSite: isProduction ? 'None' : 'Lax',
+    secure: isSecure,
+    // Cross-site cookies (frontend ≠ API domain) require SameSite=None + Secure.
+    // Local dev uses same-origin via Vite proxy, so Lax is fine over HTTP.
+    sameSite: isSecure ? 'None' : 'Lax',
     path: '/api',
     maxAge: AUTH_COOKIE_MAX_AGE,
   });
 }
 
 function clearAuthCookie(c: any) {
-  const isProduction = c.env.ENVIRONMENT === 'production';
+  const isSecure = c.req.url.startsWith('https://');
   deleteCookie(c, AUTH_COOKIE_NAME, {
     path: '/api',
-    secure: isProduction,
-    sameSite: isProduction ? 'None' : 'Lax',
+    secure: isSecure,
+    sameSite: isSecure ? 'None' : 'Lax',
   });
 }
 


### PR DESCRIPTION
…kies

The previous fix relied on ENVIRONMENT === 'production' to set SameSite=None, but deploying without --env production left it as 'development' so the fix never applied. Now detects HTTPS directly from the request URL — Cloudflare Workers always serve HTTPS in production, local wrangler dev uses HTTP.

Also fixed CORS: the base Pages domain (filmroomfantasy.pages.dev) didn't match the endsWith('.filmroomfantasy.pages.dev') check, only branch preview subdomains did. Now parses hostname properly to match both. Changed unmatched origins to return null instead of leaking localhost:3000 as an allowed origin.

https://claude.ai/code/session_01LrZKZyD1AYfb8tnjmuZzSa