### PR TITLE
Fix league sidebar shift when switching tabs

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -65,7 +65,7 @@ export function Sidebar({ activeView, onViewChange, isDarkMode, isAuthenticated 
               <li key={index}>
                 <button
                   onClick={() => handleNavClick(item.view)}
-                  className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all ${
+                  className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors ${
                     item.view === activeView
                       ? 'bg-blue-600 text-white shadow-sm'
                       : isDarkMode
@@ -74,7 +74,7 @@ export function Sidebar({ activeView, onViewChange, isDarkMode, isAuthenticated 
                   }`}
                 >
                   <item.icon className="w-5 h-5" />
-                  <span className={`text-sm ${item.view === activeView ? 'font-semibold' : ''}`}>{item.label}</span>
+                  <span className={`text-sm font-medium`}>{item.label}</span>
                 </button>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- Changed sidebar nav buttons from `transition-all` to `transition-colors` to prevent layout-affecting properties from animating
- Replaced conditional `font-semibold` on active nav items with consistent `font-medium` on all items, eliminating the text width change that caused the league section to shift position

## Root Cause
The nav buttons toggled `font-semibold` on the active item, which changes text width. Combined with `transition-all` (which animates all CSS properties including layout ones), this caused the league manager section at the bottom of the sidebar to visibly shift each time a different tab was clicked.

## Test plan
- [ ] Click through each sidebar nav item and verify the league section at the bottom stays perfectly still
- [ ] Verify active tab is still clearly distinguishable (blue background + white text)
- [ ] Test on both mobile overlay sidebar and desktop fixed sidebar

https://claude.ai/code/session_0196vhJiPU2ghGLtaVjUiBSY