### PR TITLE
Fix spacing on pricing page between FAQ and CTA sections

### DIFF
--- a/src/components/PricingView.tsx
+++ b/src/components/PricingView.tsx
@@ -286,7 +286,7 @@ export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = f
         </div>
 
         {/* FAQ Section */}
-        <div className="max-w-3xl mx-auto">
+        <div className="max-w-3xl mx-auto mt-20">
           <h2 className={`text-3xl font-bold mb-8 text-center ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
             Frequently asked questions
           </h2>
@@ -327,7 +327,7 @@ export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = f
         </div>
 
         {/* Bottom CTA */}
-        <div className={`mt-16 text-center py-12 rounded-xl border ${isDarkMode ? 'bg-slate-900 border-slate-800' : 'bg-slate-50 border-slate-200'}`}>
+        <div className={`mt-20 text-center py-12 rounded-xl border ${isDarkMode ? 'bg-slate-900 border-slate-800' : 'bg-slate-50 border-slate-200'}`}>
           <p className={`text-lg font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
             Ready to level up your fantasy game?
           </p>


### PR DESCRIPTION
Added mt-20 to FAQ section to separate it from the pricing cards, and matched the bottom CTA spacing (mt-16 → mt-20) for consistent vertical rhythm.

https://claude.ai/code/session_0196vhJiPU2ghGLtaVjUiBSY