### PR TITLE
Add role-based admin auth with dual JWT + X-Admin-Key support

### DIFF
--- a/server/migrations/0022_add_user_role.sql
+++ b/server/migrations/0022_add_user_role.sql
@@ -1,0 +1,2 @@
+-- Add role column to users table (non-destructive)
+ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user';

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -22,6 +22,7 @@ export const users = sqliteTable('users', {
   stripeCustomerId: text('stripe_customer_id'),
   stripeSubscriptionId: text('stripe_subscription_id'),
   subscriptionExpiresAt: text('subscription_expires_at'),
+  role: text('role').notNull().default('user'), // 'user' | 'admin'
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
   updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
 });

--- a/server/src/middleware/adminAuth.ts
+++ b/server/src/middleware/adminAuth.ts
@@ -1,0 +1,32 @@
+import { Context, Next } from 'hono';
+import { timingSafeEqual } from '../utils/crypto';
+import type { Env, Variables } from '../index';
+
+/**
+ * Admin authentication middleware — dual auth support:
+ * 1. JWT auth: If the request has a valid Bearer token AND the user's role is 'admin'
+ * 2. X-Admin-Key: If the request has X-Admin-Key matching SYNC_SECRET (for the local dashboard)
+ *
+ * At least one must pass. This lets the app's UI use JWT-based admin,
+ * while the standalone dashboard keeps working with the shared key.
+ */
+export const adminAuthMiddleware = async (
+  c: Context<{ Bindings: Env; Variables: Variables }>,
+  next: Next
+) => {
+  // Path 1: X-Admin-Key (shared secret — for dashboard and cron jobs)
+  const adminKey = c.req.header('X-Admin-Key');
+  if (adminKey && c.env.SYNC_SECRET && timingSafeEqual(adminKey, c.env.SYNC_SECRET)) {
+    await next();
+    return;
+  }
+
+  // Path 2: JWT — user must be logged in AND have role === 'admin'
+  const user = c.get('user');
+  if (user && user.role === 'admin') {
+    await next();
+    return;
+  }
+
+  return c.json({ error: 'Unauthorized — admin access required' }, 403);
+};

--- a/server/src/routes/admin-stats.ts
+++ b/server/src/routes/admin-stats.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono';
-import { timingSafeEqual } from '../utils/crypto';
+import { eq } from 'drizzle-orm';
+import * as schema from '../db/schema';
+import { adminAuthMiddleware } from '../middleware/adminAuth';
 import type { Env, Variables } from '../index';
 
 export const adminStatsRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
@@ -15,7 +17,7 @@ adminStatsRoutes.use('*', async (c, next) => {
   const allowedOrigin = origin && allowedAdminOrigins.includes(origin) ? origin : allowedAdminOrigins[0];
   c.header('Access-Control-Allow-Origin', allowedOrigin);
   c.header('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  c.header('Access-Control-Allow-Headers', 'Content-Type, X-Admin-Key');
+  c.header('Access-Control-Allow-Headers', 'Content-Type, X-Admin-Key, Authorization');
   c.header('Access-Control-Max-Age', '86400');
   c.header('Vary', 'Origin');
 
@@ -25,17 +27,37 @@ adminStatsRoutes.use('*', async (c, next) => {
   await next();
 });
 
-// Admin auth middleware — requires SYNC_SECRET
+// Dual auth: X-Admin-Key (dashboard) or JWT admin user (app UI)
 adminStatsRoutes.use('*', async (c, next) => {
-  const syncSecret = c.env.SYNC_SECRET;
-  if (!syncSecret) {
-    return c.json({ error: 'SYNC_SECRET not configured' }, 500);
+  if (c.req.method === 'OPTIONS') {
+    await next();
+    return;
   }
-  const adminKey = c.req.header('X-Admin-Key');
-  if (!adminKey || !timingSafeEqual(adminKey, syncSecret)) {
-    return c.json({ error: 'Unauthorized' }, 401);
+
+  // Try to extract user from JWT if present
+  const { getCookie } = await import('hono/cookie');
+  const cookieToken = getCookie(c, 'auth_token');
+  const authHeader = c.req.header('Authorization');
+  const token = cookieToken || (authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null);
+
+  if (token) {
+    try {
+      const { jwtVerify } = await import('jose');
+      const secret = new TextEncoder().encode(c.env.JWT_SECRET);
+      const { payload } = await jwtVerify(token, secret, { algorithms: ['HS256'] });
+      if (payload.sub) {
+        const db = c.get('db');
+        const user = await db.query.users.findFirst({
+          where: eq(schema.users.id, payload.sub as string),
+        });
+        if (user) c.set('user', user);
+      }
+    } catch {
+      // Invalid token — fall through to key check
+    }
   }
-  await next();
+
+  await adminAuthMiddleware(c, next);
 });
 
 adminStatsRoutes.get('/stats', async (c) => {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -8,22 +8,42 @@ import { generateId } from '../utils/id';
 import { invalidateCache } from '../utils/cache';
 import { fetchCurrentOdds, fetchHistoricalOdds, parseOddsResponse, fetchPlayerProps, parsePlayerProps } from '../services/odds';
 import { generateProjectionsFromProps } from '../services/projections';
-import { timingSafeEqual } from '../utils/crypto';
+import { adminAuthMiddleware } from '../middleware/adminAuth';
 import type { Env, Variables } from '../index';
 
 export const adminRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
 
-// Admin auth middleware — always requires SYNC_SECRET
+// Dual auth: X-Admin-Key (dashboard/cron) or JWT admin user (app UI)
 adminRoutes.use('*', async (c, next) => {
-  const syncSecret = c.env.SYNC_SECRET;
-  if (!syncSecret) {
-    return c.json({ error: 'SYNC_SECRET not configured' }, 500);
+  if (c.req.method === 'OPTIONS') {
+    await next();
+    return;
   }
-  const adminKey = c.req.header('X-Admin-Key');
-  if (!adminKey || !timingSafeEqual(adminKey, syncSecret)) {
-    return c.json({ error: 'Unauthorized' }, 401);
+
+  // Try to extract user from JWT if present (non-failing)
+  const { getCookie } = await import('hono/cookie');
+  const cookieToken = getCookie(c, 'auth_token');
+  const authHeader = c.req.header('Authorization');
+  const token = cookieToken || (authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null);
+
+  if (token) {
+    try {
+      const { jwtVerify } = await import('jose');
+      const secret = new TextEncoder().encode(c.env.JWT_SECRET);
+      const { payload } = await jwtVerify(token, secret, { algorithms: ['HS256'] });
+      if (payload.sub) {
+        const db = c.get('db');
+        const user = await db.query.users.findFirst({
+          where: eq(schema.users.id, payload.sub as string),
+        });
+        if (user) c.set('user', user);
+      }
+    } catch {
+      // Invalid token — fall through to X-Admin-Key check
+    }
   }
-  await next();
+
+  await adminAuthMiddleware(c, next);
 });
 
 /**

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -304,6 +304,7 @@ authRoutes.get('/me', authMiddleware, async (c) => {
       hasPassword: !!user.passwordHash,
       subscriptionTier: user.subscriptionTier ?? 'free',
       subscriptionExpiresAt: user.subscriptionExpiresAt ?? null,
+      role: user.role ?? 'user',
     },
     leagues: memberships.map(m => ({
       ...m.league,


### PR DESCRIPTION
- Add `role` column to users table (default 'user') in Drizzle schema
- Create D1 migration 0022_add_user_role.sql (non-destructive ALTER TABLE)
- Create adminAuth middleware supporting both JWT admin role and X-Admin-Key
- Update admin routes and admin-stats routes to use dual auth
- Add `role` field to GET /api/auth/me response for frontend use
- CORS headers updated to allow Authorization header on admin-stats

Existing X-Admin-Key auth is preserved as fallback for dashboard/cron.

https://claude.ai/code/session_0196vhJiPU2ghGLtaVjUiBSY