### PR TITLE
Fix Sleeper league connect "Unauthorized - No token provided"

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -196,10 +196,12 @@ authRoutes.post('/register', authRateLimit, async (c) => {
       expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h
     });
 
-    // Set httpOnly cookie — token is NOT returned in the response body
+    // Set httpOnly cookie (primary auth) + return token in body (fallback for
+    // browsers that block cross-origin cookies)
     setAuthCookie(c, token);
 
     return c.json({
+      token,
       user: {
         id: userId,
         email: email.toLowerCase(),
@@ -256,10 +258,12 @@ authRoutes.post('/login', authRateLimit, async (c) => {
       expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h
     });
 
-    // Set httpOnly cookie — token is NOT returned in the response body
+    // Set httpOnly cookie (primary auth) + return token in body (fallback for
+    // browsers that block cross-origin cookies)
     setAuthCookie(c, token);
 
     return c.json({
+      token,
       user: {
         id: user.id,
         email: user.email,
@@ -558,10 +562,12 @@ authRoutes.post('/google', authRateLimit, async (c) => {
       expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h
     });
 
-    // Set httpOnly cookie — token is NOT returned in the response body
+    // Set httpOnly cookie (primary auth) + return token in body (fallback for
+    // browsers that block cross-origin cookies)
     setAuthCookie(c, token);
 
     return c.json({
+      token,
       user: {
         id: user.id,
         email: user.email,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,6 +2,18 @@
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 
+// In-memory auth token — fallback for browsers that block cross-origin cookies.
+// The httpOnly cookie remains the primary auth mechanism; this supplements it.
+let authToken: string | null = null;
+
+export function setAuthToken(token: string | null) {
+  authToken = token;
+}
+
+export function getAuthToken(): string | null {
+  return authToken;
+}
+
 // API Error class
 export class ApiError extends Error {
   constructor(
@@ -14,7 +26,7 @@ export class ApiError extends Error {
   }
 }
 
-// Base fetch wrapper with auth via httpOnly cookies
+// Base fetch wrapper with auth via httpOnly cookies + Authorization header fallback
 export async function apiFetch<T>(
   endpoint: string,
   options: RequestInit = {}
@@ -23,6 +35,11 @@ export async function apiFetch<T>(
     'Content-Type': 'application/json',
     ...options.headers,
   };
+
+  // Attach Bearer token as fallback for browsers blocking cross-origin cookies
+  if (authToken && !(headers as Record<string, string>)['Authorization']) {
+    (headers as Record<string, string>)['Authorization'] = `Bearer ${authToken}`;
+  }
 
   let response: Response;
   try {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,5 +1,5 @@
 // Authentication API services
-import { api } from './api';
+import { api, setAuthToken } from './api';
 
 // Types
 export type ScoringFormat = 'ppr' | 'half_ppr' | 'standard';
@@ -40,10 +40,12 @@ export interface League {
 
 export interface AuthResponse {
   user: User;
+  token?: string;
 }
 
 export interface GoogleAuthResponse {
   user?: User;
+  token?: string;
   needsUsername?: boolean;
   email?: string;
 }
@@ -57,21 +59,23 @@ export interface MeResponse {
 export const authService = {
   // Register a new user
   register: async (email: string, password: string, username: string): Promise<AuthResponse> => {
-    // Server sets httpOnly cookie automatically — no token handling needed
-    return api.post<AuthResponse>('/auth/register', {
+    const res = await api.post<AuthResponse>('/auth/register', {
       email,
       password,
       username,
     });
+    if (res.token) setAuthToken(res.token);
+    return res;
   },
 
   // Login user
   login: async (email: string, password: string): Promise<AuthResponse> => {
-    // Server sets httpOnly cookie automatically — no token handling needed
-    return api.post<AuthResponse>('/auth/login', {
+    const res = await api.post<AuthResponse>('/auth/login', {
       email,
       password,
     });
+    if (res.token) setAuthToken(res.token);
+    return res;
   },
 
   // Logout user — revoke session server-side; server clears the cookie
@@ -81,6 +85,7 @@ export const authService = {
     } catch {
       // If server call fails (e.g. token already expired), cookie is already gone
     }
+    setAuthToken(null);
   },
 
   // Get current user
@@ -106,8 +111,9 @@ export const authService = {
   googleLogin: async (credential: string, username?: string): Promise<GoogleAuthResponse> => {
     const body: Record<string, string> = { credential };
     if (username) body.username = username;
-    // Server sets httpOnly cookie automatically — no token handling needed
-    return api.post<GoogleAuthResponse>('/auth/google', body);
+    const res = await api.post<GoogleAuthResponse>('/auth/google', body);
+    if (res.token) setAuthToken(res.token);
+    return res;
   },
 
   // Forgot password — request a reset link


### PR DESCRIPTION
## Summary

- **Root cause**: The app relies exclusively on httpOnly cookies for auth, but in production the frontend and API are on different domains. Modern browsers increasingly block third-party cross-origin cookies, so the auth cookie isn't sent with API requests — causing "Unauthorized - No token provided" when connecting a Sleeper league.
- **Fix**: Return the JWT token in auth response bodies (login, register, Google OAuth) and store it in memory on the frontend. It's sent as a `Bearer` token in the `Authorization` header alongside the existing cookie. The auth middleware already supports both mechanisms — the cookie remains the primary auth method, with the header as a fallback.
- **Files changed**: `server/src/routes/auth.ts`, `src/services/api.ts`, `src/services/auth.ts`

## Test plan

- [ ] Log in and connect a Sleeper league — should no longer get "Unauthorized"
- [ ] Verify login, register, and Google OAuth still work correctly
- [ ] Verify logout clears the in-memory token
- [ ] Test in Chrome with third-party cookies blocked to confirm the fallback works

https://claude.ai/code/session_01AonWHVY6UCMa9XXLRfvtA1