### PR TITLE
Default rankings to latest season with data, not league year

### DIFF
--- a/src/components/AllPlayersView.tsx
+++ b/src/components/AllPlayersView.tsx
@@ -4,7 +4,7 @@ import { Player } from '../App';
 import { useLeagueContext } from '../context/LeagueContext';
 import api from '../services/api';
 import { useOdds } from '../hooks/useOdds';
-import { type APIPlayer, convertAPIPlayerToPlayer, getDefaultSeason, scoringToFormat, NFL_WEEKS } from '../utils/playerUtils';
+import { type APIPlayer, convertAPIPlayerToPlayer, getEffectiveSeason, scoringToFormat, NFL_WEEKS } from '../utils/playerUtils';
 
 const ALL_PLAYERS_PAGE_SIZE = 350;
 
@@ -122,7 +122,7 @@ export function AllPlayersView({
   const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const weekDropdownRef = useRef<HTMLDivElement>(null);
 
-  const seasonYear = league?.seasonYear ?? getDefaultSeason();
+  const seasonYear = getEffectiveSeason(league?.seasonYear);
   const scoringFormat = scoringToFormat(selectedScoring);
 
   // Fetch odds for the current week

--- a/src/components/BiggestMovers.tsx
+++ b/src/components/BiggestMovers.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { TrendingUp, TrendingDown, Loader2 } from 'lucide-react';
 import { useLeagueContext } from '../context/LeagueContext';
 import api from '../services/api';
-import { type APIPlayer, getDefaultSeason } from '../utils/playerUtils';
+import { type APIPlayer, getEffectiveSeason } from '../utils/playerUtils';
 
 interface BiggestMoversProps {
   currentWeek: number;
@@ -36,7 +36,7 @@ export function BiggestMovers({ currentWeek, isDarkMode }: BiggestMoversProps) {
   const [moversData, setMoversData] = useState<MoverData[]>([]);
   const [performersData, setPerformersData] = useState<PerformerData[]>([]);
 
-  const seasonYear = league?.seasonYear ?? getDefaultSeason();
+  const seasonYear = getEffectiveSeason(league?.seasonYear);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/components/PlayerTable.tsx
+++ b/src/components/PlayerTable.tsx
@@ -5,7 +5,7 @@ import { useLeagueContext } from '../context/LeagueContext';
 import api from '../services/api';
 import { useOdds } from '../hooks/useOdds';
 import { usePlayerProps, formatPropLine } from '../hooks/usePlayerProps';
-import { type APIPlayer, convertAPIPlayerToPlayer, getDefaultSeason, scoringToFormat, NFL_WEEKS } from '../utils/playerUtils';
+import { type APIPlayer, convertAPIPlayerToPlayer, getEffectiveSeason, scoringToFormat, NFL_WEEKS } from '../utils/playerUtils';
 import { AdUnit } from './AdUnit';
 
 // Memoized table row component to prevent unnecessary re-renders
@@ -179,7 +179,7 @@ export function PlayerTable({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showWeekDropdown]);
 
-  const seasonYear = league?.seasonYear ?? getDefaultSeason();
+  const seasonYear = getEffectiveSeason(league?.seasonYear);
   const scoringFormat = scoringToFormat(selectedScoring);
 
   // Fetch players from API

--- a/src/components/TrendsView.tsx
+++ b/src/components/TrendsView.tsx
@@ -3,6 +3,7 @@ import { TrendingUp, TrendingDown, Activity, Loader2, RefreshCw, ArrowUpRight, A
 import { Player } from '../App';
 import { useLeagueContext } from '../context/LeagueContext';
 import api from '../services/api';
+import { getEffectiveSeason } from '../utils/playerUtils';
 
 interface TrendsViewProps {
   onPlayerClick: (player: Player) => void;
@@ -57,11 +58,7 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
   const [error, setError] = useState<string | null>(null);
 
   const currentWeek = league?.currentWeek ?? 1;
-  const getDefaultSeason = () => {
-    const d = new Date();
-    return d.getMonth() <= 3 ? d.getFullYear() - 1 : d.getFullYear();
-  };
-  const seasonYear = league?.seasonYear ?? getDefaultSeason();
+  const seasonYear = getEffectiveSeason(league?.seasonYear);
 
   const leagueParam = useMemo(() => league?.id ? `&leagueId=${league.id}` : '', [league?.id]);
 

--- a/src/components/WaiversView.tsx
+++ b/src/components/WaiversView.tsx
@@ -3,6 +3,7 @@ import { Player } from '../App';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useLeagueContext } from '../context/LeagueContext';
 import api from '../services/api';
+import { getEffectiveSeason } from '../utils/playerUtils';
 
 interface WaiversViewProps {
   onPlayerClick: (player: Player) => void;
@@ -51,11 +52,7 @@ export function WaiversView({ onPlayerClick, onViewAll, isDarkMode }: WaiversVie
   const scoringOptions: Array<'PPR' | 'Half PPR' | 'Standard'> = ['PPR', 'Half PPR', 'Standard'];
   const positions = ['ALL', 'QB', 'RB', 'WR', 'TE', 'K', 'DEF'];
 
-  const getDefaultSeason = () => {
-    const d = new Date();
-    return d.getMonth() <= 2 ? d.getFullYear() - 1 : d.getFullYear();
-  };
-  const seasonYear = league?.seasonYear ?? getDefaultSeason();
+  const seasonYear = getEffectiveSeason(league?.seasonYear);
 
   // In the offseason (Feb-Aug), default to week 18 (last regular season week)
   const currentWeek = (() => {

--- a/src/utils/playerUtils.ts
+++ b/src/utils/playerUtils.ts
@@ -87,6 +87,19 @@ export function getDefaultSeason(): number {
 }
 
 /**
+ * Get the effective season year for displaying rankings/stats.
+ * Uses the league's season year if it has data (not in the future),
+ * otherwise falls back to the latest season with data.
+ */
+export function getEffectiveSeason(leagueSeasonYear?: number | null): number {
+  const latestSeason = getDefaultSeason();
+  if (leagueSeasonYear != null && leagueSeasonYear <= latestSeason) {
+    return leagueSeasonYear;
+  }
+  return latestSeason;
+}
+
+/**
  * Convert scoring label to API format string.
  */
 export function scoringToFormat(scoring: 'PPR' | 'Half PPR' | 'Standard'): string {


### PR DESCRIPTION
Added getEffectiveSeason() that caps the league's season year to the latest season that has projections/stats. Fixes blank rankings when joining a future-year league (e.g. 2026) where no data exists yet.

Updated all 5 components that used league?.seasonYear ?? getDefaultSeason().

https://claude.ai/code/session_0196vhJiPU2ghGLtaVjUiBSY