### PR TITLE
Allow elite tier users to connect multiple leagues

### DIFF
--- a/server/src/routes/leagues.ts
+++ b/server/src/routes/leagues.ts
@@ -450,7 +450,7 @@ leagueRoutes.post('/connect', authMiddleware, async (c) => {
       if (userLeagues.length >= 1) {
         return c.json(
           {
-            error: 'Upgrade to Pro to connect multiple leagues',
+            error: 'Upgrade to Pro or Elite to connect multiple leagues',
             code: 'LEAGUE_LIMIT_EXCEEDED',
             tier: 'free',
             maxLeagues: 1,

--- a/src/components/PricingView.tsx
+++ b/src/components/PricingView.tsx
@@ -100,6 +100,7 @@ export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = f
       description: 'Advanced tools for serious competitors.',
       features: [
         { text: 'Everything in Pro', highlight: true },
+        { text: 'Unlimited league syncs', highlight: true },
         { text: 'Deeper player research — stats, Vegas props, game logs, matchup grades', highlight: true },
         { text: 'Unlimited trade analyses', highlight: true },
         { text: '3-day free trial', highlight: true },

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -374,8 +374,8 @@ export function SettingsView({ isDarkMode = true, onToggleDarkMode, onLeagueSync
           </div>
           <button
             onClick={() => {
-              if (user?.subscriptionTier !== 'pro' && leagues.length >= 1) {
-                setConnectError('Upgrade to Pro to connect multiple leagues. Free accounts are limited to 1 league.');
+              if (user?.subscriptionTier !== 'pro' && user?.subscriptionTier !== 'elite' && leagues.length >= 1) {
+                setConnectError('Upgrade to Pro or Elite to connect multiple leagues. Free accounts are limited to 1 league.');
                 return;
               }
               setConnectError(null);


### PR DESCRIPTION
The frontend tier check in SettingsView only allowed 'pro' users to connect multiple leagues, blocking 'elite' users despite the backend already permitting it. Updated the check to include both pro and elite tiers, added unlimited league syncs to the Elite pricing features list, and updated error messages to mention both tiers.

https://claude.ai/code/session_01WU6cETknXafCYQyhi4DLN5