### PR TITLE
Fix theme toggle: merge profile response and support unauthenticated …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,7 +209,12 @@ function AppContent() {
   // Initialize activeView from URL so direct navigation works
   const [activeView, setActiveView] = useState<'Landing' | 'Board' | 'Team' | 'Matchup' | 'Waivers' | 'Home' | 'GameSlate' | 'Trends' | 'Research' | 'Playoffs' | 'Settings' | 'Profile' | 'Login' | 'AllPlayers' | 'Pricing' | 'TradeAnalyzer' | 'DraftRankings' | 'Admin'>(() => getViewFromURL() as any);
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
-  const isDarkMode = user?.darkMode ?? true;
+  // Local dark mode state for unauthenticated users (initialized from localStorage)
+  const [localDarkMode, setLocalDarkMode] = useState<boolean>(() => {
+    const stored = localStorage.getItem('darkMode');
+    return stored !== null ? stored === 'true' : true;
+  });
+  const isDarkMode = isAuthenticated ? (user?.darkMode ?? true) : localDarkMode;
 
   // Sync dark class to <html> so CSS variables apply to html/body
   // (prevents white bars on mobile in dark mode)
@@ -302,6 +307,10 @@ function AppContent() {
   const handleToggleDarkMode = useCallback(() => {
     if (isAuthenticated) {
       updateProfile({ darkMode: !isDarkMode });
+    } else {
+      const newValue = !isDarkMode;
+      setLocalDarkMode(newValue);
+      localStorage.setItem('darkMode', String(newValue));
     }
   }, [isAuthenticated, isDarkMode, updateProfile]);
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -107,7 +107,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const updateProfile = useCallback(async (data: UpdateProfileData) => {
     const response = await authService.updateProfile(data);
-    setUser(response.user);
+    // Merge with existing user to preserve fields not returned by /auth/profile
+    // (e.g. subscriptionTier, role, hasGoogle, hasPassword, createdAt)
+    setUser(prev => prev ? { ...prev, ...response.user } : response.user);
   }, []);
 
   const value: AuthContextType = {


### PR DESCRIPTION
…users

Two bugs fixed:
- updateProfile was replacing the full user state with a partial response from /auth/profile (missing subscriptionTier, role, etc.), causing state loss after toggling dark mode. Now merges with existing user.
- Unauthenticated users were blocked from toggling dark mode entirely. Now falls back to localStorage for guest users.

https://claude.ai/code/session_014WoVtHV6Z2jjSVLEMmNEAm