### PR TITLE
Add FEEDBACK_EMAIL and RESEND_API_KEY to config docs

### DIFF
--- a/server/.dev.vars.example
+++ b/server/.dev.vars.example
@@ -7,4 +7,5 @@
 # GOOGLE_CLIENT_ID=...           # optional: Google OAuth
 # YAHOO_CLIENT_ID=...            # optional: Yahoo Fantasy
 # YAHOO_CLIENT_SECRET=...        # optional: Yahoo Fantasy
-# RESEND_API_KEY=re_...          # optional: password reset emails
+# RESEND_API_KEY=re_...          # optional: password reset & feedback emails
+# FEEDBACK_EMAIL=you@example.com # optional: where feedback notifications are sent

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -27,6 +27,12 @@ database_id = "6acfacc9-ccdd-46bd-9cea-8693306ed524"
 #   wrangler secret put YAHOO_CLIENT_SECRET --env production
 #     → Yahoo OAuth from https://developer.yahoo.com/apps/
 #
+#   wrangler secret put RESEND_API_KEY --env production
+#     → Optional: enables password reset & feedback notification emails
+#
+#   wrangler secret put FEEDBACK_EMAIL --env production
+#     → Optional: email address that receives feedback submissions
+#
 # For local dev, these are set in server/.dev.vars (gitignored)
 
 [vars]


### PR DESCRIPTION
Both env vars were required for feedback email notifications but missing from .dev.vars.example and wrangler.toml secret setup instructions, making them easy to overlook during deployment.

https://claude.ai/code/session_01TYdC22u2HDeDSQeDD4Kk2T