### PR TITLE
Add MyFantasyLeague (MFL) sync integration

### DIFF
--- a/server/src/routes/leagues.ts
+++ b/server/src/routes/leagues.ts
@@ -14,6 +14,16 @@ import { authMiddleware } from '../middleware/auth';
 import { rateLimit } from '../middleware/rateLimit';
 import { generateId } from '../utils/id';
 import { generateProjectionsFromProps } from '../services/projections';
+import {
+  fetchLeague as fetchMflLeague,
+  fetchRosters as fetchMflRosters,
+  fetchSchedule as fetchMflSchedule,
+  fetchPlayerScores as fetchMflPlayerScores,
+  parseMflName,
+  mapMflPosition,
+  mapMflTeam,
+  ensureArray,
+} from '../services/mfl';
 import type { Env, Variables } from '../index';
 
 // Rate limit for league routes: 60 req/min per IP (all auth-gated)
@@ -432,9 +442,9 @@ leagueRoutes.post('/connect', authMiddleware, async (c) => {
       return c.json({ error: 'Platform, external ID, and name are required' }, 400);
     }
 
-    const validPlatforms = ['sleeper', 'espn', 'yahoo'];
+    const validPlatforms = ['sleeper', 'espn', 'yahoo', 'mfl'];
     if (!validPlatforms.includes(platform)) {
-      return c.json({ error: 'Invalid platform. Must be sleeper, espn, or yahoo' }, 400);
+      return c.json({ error: 'Invalid platform. Must be sleeper, espn, yahoo, or mfl' }, 400);
     }
 
     if (typeof externalId !== 'string' || externalId.trim().length === 0 || externalId.length > 200) {
@@ -1526,6 +1536,345 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
       const err = error instanceof Error ? error : new Error(String(error));
       console.error('Yahoo sync error:', err);
       return c.json({ error: err.message || 'Failed to sync league from Yahoo' }, 500);
+    }
+  }
+
+  // Handle MFL sync
+  if (league.platform === 'mfl' && league.externalId) {
+    try {
+      const year = league.seasonYear || new Date().getFullYear();
+
+      // 1. Fetch league settings from MFL
+      const mflLeagueData = await fetchMflLeague(league.externalId, year);
+      const mflLeague = mflLeagueData?.league;
+      if (!mflLeague) {
+        return c.json({ error: 'Failed to fetch league data from MFL. Check your league ID.' }, 500);
+      }
+
+      const franchises = ensureArray(mflLeague.franchises?.franchise);
+      if (franchises.length === 0) {
+        return c.json({ error: 'No franchises found in MFL league' }, 500);
+      }
+
+      // Update league metadata
+      await db.update(schema.leagues)
+        .set({
+          name: mflLeague.name || league.name,
+          teamCount: franchises.length,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.leagues.id, league.id));
+
+      // 2. Fetch rosters from MFL
+      const mflRostersData = await fetchMflRosters(league.externalId, year);
+      const mflRosters = ensureArray(mflRostersData?.rosters?.franchise);
+
+      // Build franchise ID → franchise info map
+      const franchiseMap = new Map<string, typeof franchises[0]>();
+      for (const f of franchises) {
+        franchiseMap.set(f.id, f);
+      }
+
+      let teamsImported = 0;
+      let playersImported = 0;
+
+      // Collect all MFL player IDs across all rosters for batch lookup
+      const allMflPlayerIds = new Set<string>();
+      for (const roster of mflRosters) {
+        const players = ensureArray(roster.player);
+        for (const p of players) {
+          if (p.id) allMflPlayerIds.add(p.id);
+        }
+      }
+
+      // Pre-fetch MFL player details for name matching
+      let mflPlayerMap = new Map<string, { firstName: string; lastName: string; fullName: string; position: string; team: string }>();
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 25000);
+        const mflPlayersUrl = `https://api.myfantasyleague.com/${year}/export?TYPE=players&DETAILS=1&JSON=1`;
+        const playersResponse = await fetch(mflPlayersUrl, {
+          signal: controller.signal,
+          headers: { 'User-Agent': 'FilmRoomFantasy/1.0' },
+        });
+        clearTimeout(timeoutId);
+        if (playersResponse.ok) {
+          const playersData = await playersResponse.json() as any;
+          const mflPlayers = ensureArray(playersData?.players?.player);
+          for (const mp of mflPlayers) {
+            if (!mp.id) continue;
+            const parsed = parseMflName(mp.name || '');
+            const pos = mapMflPosition(mp.position || '');
+            if (pos) {
+              mflPlayerMap.set(mp.id, {
+                firstName: parsed.firstName,
+                lastName: parsed.lastName,
+                fullName: parsed.fullName,
+                position: pos,
+                team: mapMflTeam(mp.team || 'FA'),
+              });
+            }
+          }
+        }
+      } catch (e) {
+        console.error('Failed to fetch MFL players (sync continues with name matching):', e);
+      }
+
+      // Process each franchise/roster
+      for (const roster of mflRosters) {
+        const franchise = franchiseMap.get(roster.id);
+        const teamName = franchise?.name || `Team ${roster.id}`;
+        const ownerName = franchise?.owner_name || teamName;
+
+        // Upsert team
+        const existingTeam = league.teams.find(t => t.externalOwnerId === roster.id);
+        let teamId: string;
+
+        if (existingTeam) {
+          teamId = existingTeam.id;
+          await db.update(schema.teams).set({
+            name: teamName,
+            ownerDisplayName: ownerName,
+            faabBudget: franchise?.bbidAvailableBalance ? parseInt(franchise.bbidAvailableBalance, 10) : undefined,
+            updatedAt: new Date(),
+          }).where(eq(schema.teams.id, existingTeam.id));
+        } else {
+          teamId = generateId();
+          await db.insert(schema.teams).values({
+            id: teamId,
+            name: teamName,
+            leagueId: league.id,
+            ownerId: user.id,
+            externalOwnerId: roster.id,
+            ownerDisplayName: ownerName,
+            faabBudget: franchise?.bbidAvailableBalance ? parseInt(franchise.bbidAvailableBalance, 10) : 100,
+          });
+        }
+        teamsImported++;
+
+        // Sync roster players
+        const rosterPlayers = ensureArray(roster.player);
+        if (rosterPlayers.length > 0) {
+          // Clear existing roster spots for this team
+          await db.delete(schema.rosterSpots)
+            .where(eq(schema.rosterSpots.teamId, teamId));
+
+          let starterCount = 0;
+          let benchCount = 0;
+
+          for (const rosterPlayer of rosterPlayers) {
+            if (!rosterPlayer.id) continue;
+
+            const mflPlayerInfo = mflPlayerMap.get(rosterPlayer.id);
+            if (!mflPlayerInfo) continue; // Skip non-fantasy positions
+
+            // Try to find the player in our DB by name + position
+            let dbPlayer = null;
+            if (mflPlayerInfo.firstName && mflPlayerInfo.lastName) {
+              dbPlayer = await db.query.nflPlayers.findFirst({
+                where: and(
+                  eq(schema.nflPlayers.firstName, mflPlayerInfo.firstName),
+                  eq(schema.nflPlayers.lastName, mflPlayerInfo.lastName),
+                  eq(schema.nflPlayers.position, mflPlayerInfo.position),
+                ),
+              });
+            }
+
+            // Fallback: try full name match
+            if (!dbPlayer && mflPlayerInfo.fullName) {
+              dbPlayer = await db.query.nflPlayers.findFirst({
+                where: and(
+                  eq(schema.nflPlayers.name, mflPlayerInfo.fullName),
+                  eq(schema.nflPlayers.position, mflPlayerInfo.position),
+                ),
+              });
+            }
+
+            // For DEF, match by team
+            if (!dbPlayer && mflPlayerInfo.position === 'DEF') {
+              dbPlayer = await db.query.nflPlayers.findFirst({
+                where: and(
+                  eq(schema.nflPlayers.team, mflPlayerInfo.team),
+                  eq(schema.nflPlayers.position, 'DEF'),
+                ),
+              });
+            }
+
+            if (dbPlayer) {
+              const isIR = rosterPlayer.status === 'INJURED_RESERVE' || rosterPlayer.status === 'TAXI_SQUAD';
+              const isStarter = !isIR && rosterPlayer.status === 'ROSTER' && starterCount < 9;
+              const slot = isIR ? 'IR' : isStarter ? mflPlayerInfo.position : `BN${benchCount + 1}`;
+
+              if (isStarter) starterCount++;
+              if (!isStarter && !isIR) benchCount++;
+
+              await db.insert(schema.rosterSpots).values({
+                id: generateId(),
+                teamId,
+                playerId: dbPlayer.id,
+                slot,
+                isStarter,
+                acquiredType: 'sync',
+              });
+              playersImported++;
+            }
+          }
+        }
+      }
+
+      // 3. Sync matchups from MFL schedule
+      let matchupsImported = 0;
+      try {
+        const mflScheduleData = await fetchMflSchedule(league.externalId, year);
+        const weeklySchedules = ensureArray(mflScheduleData?.schedule?.weeklySchedule);
+
+        // Re-fetch teams after upserts
+        const updatedTeams = await db.query.teams.findMany({
+          where: eq(schema.teams.leagueId, league.id),
+        });
+        const franchiseIdToTeamId = new Map<string, string>();
+        for (const t of updatedTeams) {
+          if (t.externalOwnerId) {
+            franchiseIdToTeamId.set(t.externalOwnerId, t.id);
+          }
+        }
+
+        for (const weekSchedule of weeklySchedules) {
+          const week = parseInt(weekSchedule.week, 10);
+          if (isNaN(week) || week < 1) continue;
+
+          const matchups = ensureArray(weekSchedule.matchup);
+          for (const matchup of matchups) {
+            const teams = ensureArray(matchup.franchise);
+            if (teams.length !== 2) continue;
+
+            const homeTeamId = franchiseIdToTeamId.get(teams[0].id);
+            const awayTeamId = franchiseIdToTeamId.get(teams[1].id);
+            if (!homeTeamId || !awayTeamId) continue;
+
+            const homeScore = parseFloat(teams[0].score || '0') || 0;
+            const awayScore = parseFloat(teams[1].score || '0') || 0;
+            const isComplete = (teams[0].result === 'W' || teams[0].result === 'L' || teams[0].result === 'T');
+
+            // Check for existing matchup
+            const existingMatchup = await db.query.matchups.findFirst({
+              where: and(
+                eq(schema.matchups.leagueId, league.id),
+                eq(schema.matchups.week, week),
+                eq(schema.matchups.homeTeamId, homeTeamId),
+              ),
+            });
+
+            if (!existingMatchup) {
+              await db.insert(schema.matchups).values({
+                id: generateId(),
+                leagueId: league.id,
+                week,
+                homeTeamId,
+                awayTeamId,
+                homeScore,
+                awayScore,
+                isComplete,
+              });
+              matchupsImported++;
+            } else {
+              await db.update(schema.matchups)
+                .set({ homeScore, awayScore, isComplete })
+                .where(eq(schema.matchups.id, existingMatchup.id));
+            }
+          }
+        }
+      } catch (scheduleErr) {
+        console.error('MFL schedule sync error (non-fatal):', scheduleErr);
+      }
+
+      // 4. Sync player scores for completed weeks
+      let statsImported = 0;
+      try {
+        const currentWeek = league.currentWeek || 1;
+        for (let week = 1; week <= currentWeek; week++) {
+          if (week > 1) await sleep(150);
+          try {
+            const scoresData = await fetchMflPlayerScores(league.externalId, year, week);
+            const playerScores = ensureArray(
+              scoresData?.playerScores?.playerScore as any
+            );
+
+            for (const ps of playerScores) {
+              if (!ps.id || !ps.score) continue;
+              const mflInfo = mflPlayerMap.get(ps.id);
+              if (!mflInfo) continue;
+
+              // Find player in DB
+              let dbPlayer = null;
+              if (mflInfo.firstName && mflInfo.lastName) {
+                dbPlayer = await db.query.nflPlayers.findFirst({
+                  where: and(
+                    eq(schema.nflPlayers.firstName, mflInfo.firstName),
+                    eq(schema.nflPlayers.lastName, mflInfo.lastName),
+                    eq(schema.nflPlayers.position, mflInfo.position),
+                  ),
+                });
+              }
+              if (!dbPlayer && mflInfo.position === 'DEF') {
+                dbPlayer = await db.query.nflPlayers.findFirst({
+                  where: and(
+                    eq(schema.nflPlayers.team, mflInfo.team),
+                    eq(schema.nflPlayers.position, 'DEF'),
+                  ),
+                });
+              }
+              if (!dbPlayer) continue;
+
+              const score = parseFloat(ps.score) || 0;
+
+              // Check if stats exist
+              const existingStats = await db.query.playerWeeklyStats.findFirst({
+                where: and(
+                  eq(schema.playerWeeklyStats.playerId, dbPlayer.id),
+                  eq(schema.playerWeeklyStats.week, week),
+                  eq(schema.playerWeeklyStats.seasonYear, year),
+                ),
+              });
+
+              // MFL only provides total score, not breakdowns - store as PPR points
+              if (existingStats) {
+                await db.update(schema.playerWeeklyStats)
+                  .set({ fantasyPointsPPR: score, fantasyPointsHalf: score, fantasyPointsStd: score })
+                  .where(eq(schema.playerWeeklyStats.id, existingStats.id));
+              } else if (score > 0) {
+                await db.insert(schema.playerWeeklyStats).values({
+                  id: generateId(),
+                  playerId: dbPlayer.id,
+                  week,
+                  seasonYear: year,
+                  fantasyPointsPPR: score,
+                  fantasyPointsHalf: score,
+                  fantasyPointsStd: score,
+                });
+                statsImported++;
+              }
+            }
+          } catch (weekErr) {
+            console.error(`MFL stats sync error for week ${week} (non-fatal):`, weekErr);
+          }
+        }
+      } catch (statsErr) {
+        console.error('MFL stats sync error (non-fatal):', statsErr);
+      }
+
+      return c.json({
+        success: true,
+        message: `Synced from MFL: ${teamsImported} teams, ${playersImported} players, ${matchupsImported} matchups, ${statsImported} stats`,
+        teamsImported,
+        playersImported,
+        matchupsImported,
+        statsImported,
+      });
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      console.error('MFL sync error:', err);
+      return c.json({ error: err.message || 'Failed to sync league from MFL' }, 500);
     }
   }
 

--- a/server/src/services/mfl.ts
+++ b/server/src/services/mfl.ts
@@ -1,0 +1,285 @@
+/**
+ * MyFantasyLeague (MFL) API integration.
+ * API docs: https://api.myfantasyleague.com/
+ *
+ * MFL's export API is publicly accessible for most league data.
+ * No OAuth required - just the league ID and season year.
+ * Responses are JSON when &JSON=1 is appended.
+ */
+
+const MFL_BASE = 'https://api.myfantasyleague.com';
+
+// ========================================
+// Response types
+// ========================================
+
+export interface MflLeagueResponse {
+  league: {
+    id: string;
+    name: string;
+    rosterSize?: string;
+    injuredReserve?: string;
+    startCount?: string;
+    nflPoolType?: string;
+    rostersPerPlayer?: string;
+    starters?: {
+      position: { name: string; limit: string }[];
+    };
+    franchises?: {
+      franchise: MflFranchise[];
+    };
+    history?: {
+      league?: { year: string; url: string }[];
+    };
+  };
+}
+
+export interface MflFranchise {
+  id: string;
+  name: string;
+  owner_name?: string;
+  abbrev?: string;
+  waiverSortOrder?: string;
+  bbidAvailableBalance?: string;
+}
+
+export interface MflRostersResponse {
+  rosters: {
+    franchise: {
+      id: string;
+      player?: MflRosterPlayer[];
+    }[];
+  };
+}
+
+export interface MflRosterPlayer {
+  id: string;
+  status: string; // 'ROSTER', 'INJURED_RESERVE', 'TAXI_SQUAD', etc.
+}
+
+export interface MflPlayersResponse {
+  players: {
+    player: MflPlayer[];
+  };
+}
+
+export interface MflPlayer {
+  id: string;
+  name: string; // "LastName, FirstName"
+  position: string;
+  team: string;
+  status?: string;
+  jersey?: string;
+  weight?: string;
+  height?: string;
+  college?: string;
+  age?: string;
+  draft_year?: string;
+  birthdate?: string;
+}
+
+export interface MflScheduleResponse {
+  schedule: {
+    weeklySchedule: MflWeekSchedule[] | MflWeekSchedule;
+  };
+}
+
+export interface MflWeekSchedule {
+  week: string;
+  matchup: MflMatchup[] | MflMatchup;
+}
+
+export interface MflMatchup {
+  franchise: { id: string; score?: string; result?: string; isHome?: string }[];
+}
+
+export interface MflPlayerScoresResponse {
+  playerScores: {
+    week: string;
+    playerScore?: MflPlayerScore[] | MflPlayerScore;
+  };
+}
+
+export interface MflPlayerScore {
+  id: string;
+  score: string;
+  isAvailable?: string;
+}
+
+export interface MflLiveScoringResponse {
+  liveScoring: {
+    week: string;
+    matchup: MflLiveMatchup[] | MflLiveMatchup;
+  };
+}
+
+export interface MflLiveMatchup {
+  franchise: {
+    id: string;
+    score: string;
+    gameSecondsRemaining?: string;
+    playersCurrentlyPlaying?: string;
+    playersYetToPlay?: string;
+    isHome?: string;
+    player?: MflLivePlayer[] | MflLivePlayer;
+  }[];
+}
+
+export interface MflLivePlayer {
+  id: string;
+  score: string;
+  gameSecondsRemaining?: string;
+  status?: string;
+}
+
+// ========================================
+// API fetch helpers
+// ========================================
+
+function buildUrl(year: number, type: string, params: Record<string, string> = {}): string {
+  const url = new URL(`${MFL_BASE}/${year}/export`);
+  url.searchParams.set('TYPE', type);
+  url.searchParams.set('JSON', '1');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+async function mflFetch<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'FilmRoomFantasy/1.0',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`MFL API error: ${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+// ========================================
+// Public API functions
+// ========================================
+
+/** Fetch league settings and franchise list. */
+export async function fetchLeague(leagueId: string, year: number): Promise<MflLeagueResponse> {
+  return mflFetch<MflLeagueResponse>(buildUrl(year, 'league', { L: leagueId }));
+}
+
+/** Fetch all rosters for a league. */
+export async function fetchRosters(leagueId: string, year: number): Promise<MflRostersResponse> {
+  return mflFetch<MflRostersResponse>(buildUrl(year, 'rosters', { L: leagueId }));
+}
+
+/** Fetch the full schedule (all weeks). */
+export async function fetchSchedule(leagueId: string, year: number): Promise<MflScheduleResponse> {
+  return mflFetch<MflScheduleResponse>(buildUrl(year, 'schedule', { L: leagueId }));
+}
+
+/** Fetch player scores for a specific week. */
+export async function fetchPlayerScores(leagueId: string, year: number, week: number): Promise<MflPlayerScoresResponse> {
+  return mflFetch<MflPlayerScoresResponse>(buildUrl(year, 'playerScores', { L: leagueId, W: String(week) }));
+}
+
+/** Fetch live scoring for the current week. */
+export async function fetchLiveScoring(leagueId: string, year: number): Promise<MflLiveScoringResponse> {
+  return mflFetch<MflLiveScoringResponse>(buildUrl(year, 'liveScoring', { L: leagueId }));
+}
+
+/** Fetch all MFL players (large dataset). */
+export async function fetchPlayers(year: number): Promise<MflPlayersResponse> {
+  return mflFetch<MflPlayersResponse>(buildUrl(year, 'players', { DETAILS: '1' }));
+}
+
+// ========================================
+// Data mapping utilities
+// ========================================
+
+/** MFL returns names as "LastName, FirstName" - parse into parts. */
+export function parseMflName(mflName: string): { firstName: string; lastName: string; fullName: string } {
+  const parts = mflName.split(', ');
+  if (parts.length === 2) {
+    return {
+      firstName: parts[1].trim(),
+      lastName: parts[0].trim(),
+      fullName: `${parts[1].trim()} ${parts[0].trim()}`,
+    };
+  }
+  // Team defenses or other formats (e.g., "Bears, Chicago" or "Chiefs D/ST")
+  return { firstName: '', lastName: mflName, fullName: mflName };
+}
+
+/** Map MFL position codes to canonical positions. */
+export function mapMflPosition(mflPosition: string): string | null {
+  const posMap: Record<string, string> = {
+    QB: 'QB',
+    RB: 'RB',
+    WR: 'WR',
+    TE: 'TE',
+    PK: 'K',
+    K: 'K',
+    Def: 'DEF',
+    DEF: 'DEF',
+    DT: null as unknown as string,
+    DE: null as unknown as string,
+    LB: null as unknown as string,
+    CB: null as unknown as string,
+    S: null as unknown as string,
+  };
+  return posMap[mflPosition] ?? null;
+}
+
+/** Map MFL team abbreviations to standard NFL team codes. */
+export function mapMflTeam(mflTeam: string): string {
+  const teamMap: Record<string, string> = {
+    ARI: 'ARI',
+    ATL: 'ATL',
+    BAL: 'BAL',
+    BUF: 'BUF',
+    CAR: 'CAR',
+    CHI: 'CHI',
+    CIN: 'CIN',
+    CLE: 'CLE',
+    DAL: 'DAL',
+    DEN: 'DEN',
+    DET: 'DET',
+    GBP: 'GB',
+    GB: 'GB',
+    HOU: 'HOU',
+    IND: 'IND',
+    JAC: 'JAX',
+    JAX: 'JAX',
+    KCC: 'KC',
+    KC: 'KC',
+    LAC: 'LAC',
+    LAR: 'LAR',
+    LVR: 'LV',
+    LV: 'LV',
+    MIA: 'MIA',
+    MIN: 'MIN',
+    NEP: 'NE',
+    NE: 'NE',
+    NOS: 'NO',
+    NO: 'NO',
+    NYG: 'NYG',
+    NYJ: 'NYJ',
+    PHI: 'PHI',
+    PIT: 'PIT',
+    SEA: 'SEA',
+    SFO: 'SF',
+    SF: 'SF',
+    TBB: 'TB',
+    TB: 'TB',
+    TEN: 'TEN',
+    WAS: 'WAS',
+    FA: 'FA',
+  };
+  return teamMap[mflTeam] || mflTeam;
+}
+
+/** Normalize an array from MFL - MFL returns a single object instead of array when there's only one item. */
+export function ensureArray<T>(val: T | T[] | undefined): T[] {
+  if (val === undefined || val === null) return [];
+  return Array.isArray(val) ? val : [val];
+}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -125,6 +125,7 @@ export function SettingsView({ isDarkMode = true, onToggleDarkMode, onLeagueSync
     { id: 'sleeper' as Platform, name: 'Sleeper', color: 'bg-blue-500', textColor: 'text-blue-400', description: 'Connect via username' },
     { id: 'espn' as Platform, name: 'ESPN', color: 'bg-red-600', textColor: 'text-red-400', description: 'Public leagues only' },
     { id: 'yahoo' as Platform, name: 'Yahoo', color: 'bg-purple-600', textColor: 'text-purple-400', description: 'Connect via OAuth' },
+    { id: 'mfl' as Platform, name: 'MFL', color: 'bg-green-600', textColor: 'text-green-400', description: 'Enter league ID' },
   ];
 
   // Reset modal state
@@ -353,6 +354,7 @@ export function SettingsView({ isDarkMode = true, onToggleDarkMode, onLeagueSync
       case 'sleeper': return 'bg-blue-500/20 text-blue-500';
       case 'espn': return 'bg-red-500/20 text-red-500';
       case 'yahoo': return 'bg-purple-500/20 text-purple-500';
+      case 'mfl': return 'bg-green-500/20 text-green-500';
       default: return isDarkMode ? 'bg-slate-800 text-slate-300' : 'bg-slate-200 text-slate-600';
     }
   };
@@ -428,7 +430,7 @@ export function SettingsView({ isDarkMode = true, onToggleDarkMode, onLeagueSync
                     <div>
                       <div className={`font-semibold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{league.name}</div>
                       <div className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-                        {league.platform ? league.platform.charAt(0).toUpperCase() + league.platform.slice(1) : 'FilmRoom'} • {league.seasonYear} • {league.teamCount} Teams • {league.scoringFormat.toUpperCase()}
+                        {league.platform ? (league.platform === 'mfl' ? 'MFL' : league.platform === 'espn' ? 'ESPN' : league.platform.charAt(0).toUpperCase() + league.platform.slice(1)) : 'FilmRoom'} • {league.seasonYear} • {league.teamCount} Teams • {league.scoringFormat.toUpperCase()}
                       </div>
                       {league.updatedAt && (
                         <div className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
@@ -687,7 +689,7 @@ export function SettingsView({ isDarkMode = true, onToggleDarkMode, onLeagueSync
               {/* Step 1: Select Platform */}
               {connectionStep === 'select-platform' && (
                 <div className="space-y-4">
-                  <div className="grid grid-cols-3 gap-4">
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                     {platforms.map((platform) => (
                       <button
                         key={platform.id}
@@ -842,6 +844,7 @@ export function SettingsView({ isDarkMode = true, onToggleDarkMode, onLeagueSync
                       {selectedPlatform === 'sleeper' && 'Find your league ID in the Sleeper app under League Settings'}
                       {selectedPlatform === 'espn' && 'Find your league ID in the URL: fantasy.espn.com/football/league?leagueId=XXXXXX'}
                       {selectedPlatform === 'yahoo' && 'Find your league ID in the URL: football.fantasysports.yahoo.com/f1/XXXXXX'}
+                      {selectedPlatform === 'mfl' && 'Find your league ID in the URL: myfantasyleague.com/YYYY/home/XXXXX (the 5-digit number)'}
                     </p>
                   </div>
 
@@ -957,7 +960,7 @@ export function SettingsView({ isDarkMode = true, onToggleDarkMode, onLeagueSync
                       {fetchedLeague.name}
                     </div>
                     <div className={`text-sm space-y-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-                      <p>Platform: {fetchedLeague.platform.charAt(0).toUpperCase() + fetchedLeague.platform.slice(1)}</p>
+                      <p>Platform: {fetchedLeague.platform === 'mfl' ? 'MFL' : fetchedLeague.platform === 'espn' ? 'ESPN' : fetchedLeague.platform.charAt(0).toUpperCase() + fetchedLeague.platform.slice(1)}</p>
                       <p>Season: {fetchedLeague.seasonYear}</p>
                       <p>Teams: {fetchedLeague.teamCount}</p>
                       <p>Scoring: {fetchedLeague.scoringFormat.toUpperCase()}</p>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -11,6 +11,7 @@ export {
   sleeperApi,
   espnApi,
   yahooApi,
+  mflApi,
 } from './leagueConnect';
 
 // Export types

--- a/src/services/leagueConnect.ts
+++ b/src/services/leagueConnect.ts
@@ -1,7 +1,7 @@
 // League Connection Service - Connects to external fantasy platforms
 import api from './api';
 
-export type Platform = 'sleeper' | 'espn' | 'yahoo';
+export type Platform = 'sleeper' | 'espn' | 'yahoo' | 'mfl';
 
 export interface ExternalLeague {
   externalId: string;
@@ -191,6 +191,38 @@ export const espnApi = {
   },
 };
 
+// MFL API - Public API, no auth needed (league ID + year)
+export const mflApi = {
+  // Get league by ID and year
+  getLeague: async (leagueId: string, season: number = new Date().getFullYear()): Promise<ExternalLeague | null> => {
+    try {
+      const response = await fetch(
+        `https://api.myfantasyleague.com/${season}/export?TYPE=league&L=${encodeURIComponent(leagueId)}&JSON=1`
+      );
+      if (!response.ok) return null;
+      const data = await response.json();
+
+      const league = data?.league;
+      if (!league) return null;
+
+      const franchises = Array.isArray(league.franchises?.franchise)
+        ? league.franchises.franchise
+        : league.franchises?.franchise ? [league.franchises.franchise] : [];
+
+      return {
+        externalId: leagueId,
+        platform: 'mfl',
+        name: league.name || `MFL League ${leagueId}`,
+        seasonYear: season,
+        teamCount: franchises.length || 12,
+        scoringFormat: 'ppr', // MFL scoring varies; default to PPR, user can adjust
+      };
+    } catch {
+      return null;
+    }
+  },
+};
+
 // Yahoo API - Requires OAuth (handled by backend)
 export const yahooApi = {
   // Get Yahoo OAuth authorization URL from backend
@@ -264,6 +296,8 @@ export const leagueConnectService = {
         return sleeperApi.getLeague(leagueId);
       case 'espn':
         return espnApi.getLeague(leagueId);
+      case 'mfl':
+        return mflApi.getLeague(leagueId);
       case 'yahoo':
         return null; // Yahoo leagues are fetched through OAuth flow, not by ID
       default:


### PR DESCRIPTION
Adds full MFL platform support including:
- MFL API service with league, roster, schedule, and player score fetching
- Sync handler that imports teams, rosters, matchups, and player stats from MFL
- Player matching by name/position to existing NFL player database
- Frontend league connection flow with MFL platform option
- MFL league ID validation and help text in Settings UI

https://claude.ai/code/session_01FvsgskFbhaEqCnmEKKpfiG