### PR TITLE
Redesign articles pages with richer visual styling

### DIFF
--- a/src/components/ArticleDetailView.tsx
+++ b/src/components/ArticleDetailView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { ArrowLeft, Loader2 } from 'lucide-react';
+import { ArrowLeft, Loader2, Clock, User, ChevronRight, BookOpen, TrendingUp, Zap, Award, HelpCircle } from 'lucide-react';
 import { api } from '../services/api';
 import { ARTICLE_CATEGORIES } from '../data/articles';
 import { SEO } from './SEO';
@@ -25,6 +25,14 @@ interface ArticleData {
   publishedAt: string | null;
   updatedAt: number;
 }
+
+const CATEGORY_ICONS: Record<string, typeof BookOpen> = {
+  strategy: Zap,
+  rankings: TrendingUp,
+  news: BookOpen,
+  tools: Award,
+  beginners: HelpCircle,
+};
 
 export function ArticleDetailView({ slug, isDarkMode, onBack, onArticleSelect, onNavigate }: ArticleDetailViewProps) {
   const [article, setArticle] = useState<ArticleData | null>(null);
@@ -70,9 +78,10 @@ export function ArticleDetailView({ slug, isDarkMode, onBack, onArticleSelect, o
   if (error || !article) {
     return (
       <div className="max-w-3xl mx-auto text-center py-16">
+        <BookOpen className={`w-16 h-16 mx-auto mb-4 ${isDarkMode ? 'text-slate-700' : 'text-slate-300'}`} />
         <h1 className={`text-2xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Article Not Found</h1>
-        <p className={`mb-4 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>The article you're looking for doesn't exist.</p>
-        <button onClick={onBack} className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+        <p className={`mb-4 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>The article you're looking for doesn't exist or has been removed.</p>
+        <button onClick={onBack} className="px-5 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-semibold">
           Back to Articles
         </button>
       </div>
@@ -80,6 +89,7 @@ export function ArticleDetailView({ slug, isDarkMode, onBack, onArticleSelect, o
   }
 
   const category = ARTICLE_CATEGORIES[article.category as keyof typeof ARTICLE_CATEGORIES];
+  const CategoryIcon = CATEGORY_ICONS[article.category] || BookOpen;
   const date = article.publishedAt
     ? new Date(article.publishedAt).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
     : '';
@@ -127,67 +137,109 @@ export function ArticleDetailView({ slug, isDarkMode, onBack, onArticleSelect, o
         <ArrowLeft className="w-4 h-4" /> Back to Articles
       </button>
 
-      {/* Article header */}
-      <header className="mb-8">
-        <div className="flex items-center gap-3 mb-3">
-          {category && (
-            <span
-              className="text-xs font-bold uppercase tracking-wide px-2 py-0.5 rounded"
-              style={{ color: category.color, background: `${category.color}18` }}
-            >
-              {category.label}
+      {/* Article header with gradient accent */}
+      <header className={`relative overflow-hidden rounded-2xl mb-8 ${isDarkMode ? 'bg-slate-900 border border-slate-700' : 'bg-white border border-slate-200'}`}>
+        {/* Gradient top bar */}
+        {category && (
+          <div
+            className="h-2 w-full"
+            style={{ background: `linear-gradient(to right, ${category.color}, ${category.color}66)` }}
+          />
+        )}
+
+        <div className="p-6 sm:p-8">
+          {/* Category + meta row */}
+          <div className="flex flex-wrap items-center gap-3 mb-4">
+            {category && (
+              <span
+                className="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider px-3 py-1.5 rounded-lg"
+                style={{ color: category.color, background: `${category.color}15` }}
+              >
+                <CategoryIcon className="w-3.5 h-3.5" />
+                {category.label}
+              </span>
+            )}
+            <span className={`text-sm flex items-center gap-1.5 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+              <Clock className="w-3.5 h-3.5" />
+              {article.readingTime} min read
             </span>
-          )}
-          <span className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
-            {date}{date && ' \u00b7 '}{article.readingTime} min read
-          </span>
+          </div>
+
+          {/* Title */}
+          <h1 className={`text-2xl sm:text-3xl lg:text-4xl font-bold leading-tight mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+            {article.title}
+          </h1>
+
+          {/* Description */}
+          <p className={`text-base sm:text-lg leading-relaxed mb-5 ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
+            {article.description}
+          </p>
+
+          {/* Author + date */}
+          <div className={`flex items-center gap-4 pt-4 border-t ${isDarkMode ? 'border-slate-800' : 'border-slate-100'}`}>
+            <div className={`w-9 h-9 rounded-full flex items-center justify-center ${isDarkMode ? 'bg-slate-800' : 'bg-slate-100'}`}>
+              <User className={`w-4 h-4 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`} />
+            </div>
+            <div>
+              <p className={`text-sm font-semibold ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}>{article.author}</p>
+              {date && <p className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{date}</p>}
+            </div>
+          </div>
         </div>
-        <h1 className={`text-2xl sm:text-3xl font-bold leading-tight mb-3 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
-          {article.title}
-        </h1>
-        <p className={`text-base leading-relaxed ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
-          {article.description}
-        </p>
       </header>
 
       {/* Article body */}
       <div
-        className={`prose max-w-none ${isDarkMode ? 'prose-invert' : ''}`}
+        className={`prose prose-lg max-w-none ${isDarkMode ? 'prose-invert' : ''}`}
         style={{
           ['--tw-prose-body' as string]: isDarkMode ? '#cbd5e1' : '#475569',
           ['--tw-prose-headings' as string]: isDarkMode ? '#f1f5f9' : '#0f172a',
           ['--tw-prose-links' as string]: '#3b82f6',
           ['--tw-prose-bold' as string]: isDarkMode ? '#f1f5f9' : '#0f172a',
           ['--tw-prose-bullets' as string]: isDarkMode ? '#64748b' : '#94a3b8',
+          ['--tw-prose-counters' as string]: isDarkMode ? '#64748b' : '#94a3b8',
+          ['--tw-prose-hr' as string]: isDarkMode ? '#334155' : '#e2e8f0',
         }}
         dangerouslySetInnerHTML={{ __html: article.content }}
       />
 
       {/* Tags */}
-      <div className={`flex flex-wrap gap-2 mt-8 pt-6 border-t ${isDarkMode ? 'border-slate-800' : 'border-slate-200'}`}>
-        {article.tags.map((tag) => (
-          <span
-            key={tag}
-            className={`text-xs px-3 py-1 rounded-full ${isDarkMode ? 'bg-slate-800 text-slate-400' : 'bg-slate-100 text-slate-500'}`}
-          >
-            {tag}
+      {article.tags.length > 0 && (
+        <div className={`flex flex-wrap gap-2 mt-10 pt-6 border-t ${isDarkMode ? 'border-slate-800' : 'border-slate-200'}`}>
+          <span className={`text-xs font-semibold uppercase tracking-wider mr-1 self-center ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+            Tags
           </span>
-        ))}
-      </div>
+          {article.tags.map((tag) => (
+            <span
+              key={tag}
+              className={`text-xs px-3 py-1.5 rounded-lg font-medium transition-colors ${
+                isDarkMode ? 'bg-slate-800 text-slate-400 hover:bg-slate-700' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+              }`}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
 
       {/* CTA */}
-      <div className={`mt-8 p-6 rounded-xl border text-center ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-slate-50 border-slate-200'}`}>
+      <div className={`mt-8 p-6 sm:p-8 rounded-2xl border text-center ${
+        isDarkMode ? 'bg-gradient-to-br from-slate-900 to-slate-800 border-slate-700' : 'bg-gradient-to-br from-blue-50 to-indigo-50 border-blue-100'
+      }`}>
+        <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center mx-auto mb-4">
+          <Zap className="w-6 h-6 text-white" />
+        </div>
         <h2 className={`text-lg font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
           Put this into practice
         </h2>
-        <p className={`text-sm mb-4 ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
+        <p className={`text-sm mb-5 max-w-md mx-auto ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
           Check the latest player rankings, evaluate trades, and find waiver wire gems — all powered by Vegas lines.
         </p>
         <div className="flex flex-wrap justify-center gap-3">
-          <button onClick={() => onNavigate('Board')} className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors">
+          <button onClick={() => onNavigate('Board')} className="px-5 py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors shadow-md shadow-blue-500/25">
             View Rankings
           </button>
-          <button onClick={() => onNavigate('TradeAnalyzer')} className={`px-4 py-2 text-sm font-semibold rounded-lg border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-800' : 'border-slate-300 text-slate-700 hover:bg-slate-100'}`}>
+          <button onClick={() => onNavigate('TradeAnalyzer')} className={`px-5 py-2.5 text-sm font-semibold rounded-lg border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-slate-300 text-slate-700 hover:bg-white'}`}>
             Trade Analyzer
           </button>
         </div>
@@ -199,27 +251,39 @@ export function ArticleDetailView({ slug, isDarkMode, onBack, onArticleSelect, o
           <h2 className={`text-lg font-bold mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
             Related Articles
           </h2>
-          <div className="space-y-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             {relatedArticles.map((ra) => {
               const raCat = ARTICLE_CATEGORIES[ra.category as keyof typeof ARTICLE_CATEGORIES];
+              const RaIcon = CATEGORY_ICONS[ra.category] || BookOpen;
               return (
                 <button
                   key={ra.slug}
                   onClick={() => onArticleSelect(ra.slug)}
-                  className={`w-full text-left p-4 rounded-lg border transition-all ${
+                  className={`group text-left p-4 rounded-xl border transition-all ${
                     isDarkMode
-                      ? 'bg-slate-900 border-slate-700 hover:border-slate-600'
-                      : 'bg-white border-slate-200 hover:border-slate-300'
+                      ? 'bg-slate-900 border-slate-700 hover:border-slate-500'
+                      : 'bg-white border-slate-200 hover:shadow-md hover:shadow-slate-200/50'
                   }`}
                 >
                   {raCat && (
-                    <span className="text-xs font-bold uppercase tracking-wide" style={{ color: raCat.color }}>
-                      {raCat.label}
-                    </span>
+                    <div className="flex items-center gap-2 mb-2">
+                      <div
+                        className="w-6 h-6 rounded-md flex items-center justify-center"
+                        style={{ background: `${raCat.color}15` }}
+                      >
+                        <RaIcon className="w-3 h-3" style={{ color: raCat.color }} />
+                      </div>
+                      <span className="text-[11px] font-bold uppercase tracking-wider" style={{ color: raCat.color }}>
+                        {raCat.label}
+                      </span>
+                    </div>
                   )}
-                  <h3 className={`text-sm font-bold mt-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+                  <h3 className={`text-sm font-bold leading-snug group-hover:text-blue-500 transition-colors line-clamp-2 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
                     {ra.title}
                   </h3>
+                  <span className={`text-xs mt-2 flex items-center gap-0.5 font-semibold ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}>
+                    Read <ChevronRight className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />
+                  </span>
                 </button>
               );
             })}

--- a/src/components/ArticlesView.tsx
+++ b/src/components/ArticlesView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Clock, ChevronRight, BookOpen, TrendingUp, Zap, Award, HelpCircle } from 'lucide-react';
 import { api } from '../services/api';
 import { ARTICLE_CATEGORIES } from '../data/articles';
 import { SEO } from './SEO';
@@ -20,6 +20,14 @@ interface ArticleData {
   readingTime: number;
   publishedAt: string | null;
 }
+
+const CATEGORY_ICONS: Record<string, typeof BookOpen> = {
+  strategy: Zap,
+  rankings: TrendingUp,
+  news: BookOpen,
+  tools: Award,
+  beginners: HelpCircle,
+};
 
 export function ArticlesView({ isDarkMode, onNavigate, onArticleSelect }: ArticlesViewProps) {
   const [articles, setArticles] = useState<ArticleData[]>([]);
@@ -49,8 +57,11 @@ export function ArticlesView({ isDarkMode, onNavigate, onArticleSelect }: Articl
     return articles.filter(a => a.category === selectedCategory);
   }, [selectedCategory, articles]);
 
+  const featuredArticle = filteredArticles[0];
+  const restArticles = filteredArticles.slice(1);
+
   return (
-    <div className="max-w-4xl mx-auto">
+    <div className="max-w-5xl mx-auto">
       <SEO
         title="Fantasy Football Articles & Guides | FilmRoom"
         description="Expert fantasy football strategy guides, rankings analysis, waiver wire tips, and beginner resources. Learn how to win your fantasy league with data-driven insights."
@@ -74,36 +85,45 @@ export function ArticlesView({ isDarkMode, onNavigate, onArticleSelect }: Articl
         ]}
       />
 
+      {/* Header */}
       <div className="mb-8">
-        <h1 className={`text-3xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
-          Fantasy Football Articles & Guides
-        </h1>
+        <div className="flex items-center gap-3 mb-3">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center">
+            <BookOpen className="w-5 h-5 text-white" />
+          </div>
+          <div>
+            <h1 className={`text-2xl sm:text-3xl font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+              Articles & Guides
+            </h1>
+          </div>
+        </div>
         <p className={`text-base ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
           Strategy guides, rankings breakdowns, and tips to help you win your fantasy league.
         </p>
       </div>
 
-      {/* Category filter */}
+      {/* Category filter pills */}
       <div className="flex flex-wrap gap-2 mb-8">
         <button
           onClick={() => setSelectedCategory('all')}
-          className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+          className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
             selectedCategory === 'all'
-              ? 'bg-blue-600 text-white'
-              : isDarkMode ? 'bg-slate-800 text-slate-300 hover:bg-slate-700' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+              ? 'bg-blue-600 text-white shadow-md shadow-blue-500/25'
+              : isDarkMode ? 'bg-slate-800/80 text-slate-300 hover:bg-slate-700 border border-slate-700' : 'bg-white text-slate-600 hover:bg-slate-50 border border-slate-200'
           }`}
         >
-          All
+          All Articles
         </button>
-        {Object.entries(ARTICLE_CATEGORIES).map(([key, { label }]) => (
+        {Object.entries(ARTICLE_CATEGORIES).map(([key, { label, color }]) => (
           <button
             key={key}
             onClick={() => setSelectedCategory(key)}
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+            className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
               selectedCategory === key
-                ? 'bg-blue-600 text-white'
-                : isDarkMode ? 'bg-slate-800 text-slate-300 hover:bg-slate-700' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                ? 'text-white shadow-md'
+                : isDarkMode ? 'bg-slate-800/80 text-slate-300 hover:bg-slate-700 border border-slate-700' : 'bg-white text-slate-600 hover:bg-slate-50 border border-slate-200'
             }`}
+            style={selectedCategory === key ? { background: color, boxShadow: `0 4px 14px ${color}40` } : undefined}
           >
             {label}
           </button>
@@ -125,22 +145,40 @@ export function ArticlesView({ isDarkMode, onNavigate, onArticleSelect }: Articl
 
       {/* Article list */}
       {!loading && !error && (
-        <div className="space-y-4">
+        <>
           {filteredArticles.length === 0 ? (
             <div className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-              <p>No articles yet. Check back soon!</p>
+              <BookOpen className="w-12 h-12 mx-auto mb-4 opacity-30" />
+              <p className="text-lg font-medium">No articles yet</p>
+              <p className="text-sm mt-1">Check back soon for new content!</p>
             </div>
           ) : (
-            filteredArticles.map((article) => (
-              <ArticleCard
-                key={article.slug}
-                article={article}
-                isDarkMode={isDarkMode}
-                onClick={() => onArticleSelect(article.slug)}
-              />
-            ))
+            <div className="space-y-6">
+              {/* Featured article (first one, large card) */}
+              {featuredArticle && (
+                <FeaturedCard
+                  article={featuredArticle}
+                  isDarkMode={isDarkMode}
+                  onClick={() => onArticleSelect(featuredArticle.slug)}
+                />
+              )}
+
+              {/* Rest of articles in grid */}
+              {restArticles.length > 0 && (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {restArticles.map((article) => (
+                    <ArticleCard
+                      key={article.slug}
+                      article={article}
+                      isDarkMode={isDarkMode}
+                      onClick={() => onArticleSelect(article.slug)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
           )}
-        </div>
+        </>
       )}
 
       {/* Internal links section */}
@@ -171,8 +209,9 @@ export function ArticlesView({ isDarkMode, onNavigate, onArticleSelect }: Articl
   );
 }
 
-function ArticleCard({ article, isDarkMode, onClick }: { article: ArticleData; isDarkMode: boolean; onClick: () => void }) {
+function FeaturedCard({ article, isDarkMode, onClick }: { article: ArticleData; isDarkMode: boolean; onClick: () => void }) {
   const category = ARTICLE_CATEGORIES[article.category as keyof typeof ARTICLE_CATEGORIES];
+  const CategoryIcon = CATEGORY_ICONS[article.category] || BookOpen;
   const date = article.publishedAt
     ? new Date(article.publishedAt).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
     : '';
@@ -182,38 +221,136 @@ function ArticleCard({ article, isDarkMode, onClick }: { article: ArticleData; i
   return (
     <article
       onClick={onClick}
-      className={`p-5 rounded-xl border cursor-pointer transition-all ${
+      className={`group relative overflow-hidden rounded-2xl cursor-pointer transition-all duration-300 ${
         isDarkMode
-          ? 'bg-slate-900 border-slate-700 hover:border-slate-600 hover:bg-slate-800'
-          : 'bg-white border-slate-200 hover:border-slate-300 hover:shadow-sm'
+          ? 'bg-slate-900 border border-slate-700 hover:border-slate-500'
+          : 'bg-white border border-slate-200 hover:shadow-lg hover:shadow-slate-200/50'
       }`}
     >
-      <div className="flex items-center gap-3 mb-2">
-        <span
-          className="text-xs font-bold uppercase tracking-wide px-2 py-0.5 rounded"
-          style={{ color: category.color, background: `${category.color}18` }}
-        >
-          {category.label}
-        </span>
-        <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
-          {date}{date && ' \u00b7 '}{article.readingTime} min read
-        </span>
-      </div>
-      <h2 className={`text-lg font-bold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
-        {article.title}
-      </h2>
-      <p className={`text-sm leading-relaxed ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
-        {article.description}
-      </p>
-      <div className="flex flex-wrap gap-1.5 mt-3">
-        {article.tags.slice(0, 4).map((tag) => (
-          <span
-            key={tag}
-            className={`text-xs px-2 py-0.5 rounded ${isDarkMode ? 'bg-slate-800 text-slate-400' : 'bg-slate-100 text-slate-500'}`}
+      {/* Gradient accent bar */}
+      <div
+        className="h-1.5 w-full"
+        style={{ background: `linear-gradient(to right, ${category.color}, ${category.color}88)` }}
+      />
+      <div className="p-6 sm:p-8">
+        <div className="flex items-start gap-5">
+          {/* Category icon */}
+          <div
+            className="hidden sm:flex w-14 h-14 rounded-xl items-center justify-center flex-shrink-0"
+            style={{ background: `${category.color}15` }}
           >
-            {tag}
+            <CategoryIcon className="w-7 h-7" style={{ color: category.color }} />
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-3 mb-3">
+              <span
+                className="text-xs font-bold uppercase tracking-wider px-2.5 py-1 rounded-md"
+                style={{ color: category.color, background: `${category.color}15` }}
+              >
+                {category.label}
+              </span>
+              <span className={`text-xs flex items-center gap-1 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+                <Clock className="w-3 h-3" />
+                {article.readingTime} min read
+              </span>
+            </div>
+
+            <h2 className={`text-xl sm:text-2xl font-bold mb-2 leading-snug group-hover:text-blue-500 transition-colors ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+              {article.title}
+            </h2>
+
+            <p className={`text-sm sm:text-base leading-relaxed mb-4 ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
+              {article.description}
+            </p>
+
+            <div className="flex items-center justify-between">
+              <div className="flex flex-wrap gap-2">
+                {article.tags.slice(0, 3).map((tag) => (
+                  <span
+                    key={tag}
+                    className={`text-xs px-2.5 py-1 rounded-md font-medium ${isDarkMode ? 'bg-slate-800 text-slate-400' : 'bg-slate-100 text-slate-500'}`}
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              <div className={`flex items-center gap-1 text-sm font-semibold transition-colors ${isDarkMode ? 'text-blue-400 group-hover:text-blue-300' : 'text-blue-600 group-hover:text-blue-700'}`}>
+                Read <ChevronRight className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />
+              </div>
+            </div>
+
+            {date && (
+              <p className={`text-xs mt-3 ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>
+                {article.author} &middot; {date}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function ArticleCard({ article, isDarkMode, onClick }: { article: ArticleData; isDarkMode: boolean; onClick: () => void }) {
+  const category = ARTICLE_CATEGORIES[article.category as keyof typeof ARTICLE_CATEGORIES];
+  const CategoryIcon = CATEGORY_ICONS[article.category] || BookOpen;
+  const date = article.publishedAt
+    ? new Date(article.publishedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    : '';
+
+  if (!category) return null;
+
+  return (
+    <article
+      onClick={onClick}
+      className={`group relative overflow-hidden rounded-xl cursor-pointer transition-all duration-300 ${
+        isDarkMode
+          ? 'bg-slate-900 border border-slate-700 hover:border-slate-500'
+          : 'bg-white border border-slate-200 hover:shadow-md hover:shadow-slate-200/50'
+      }`}
+    >
+      {/* Gradient accent */}
+      <div
+        className="h-1 w-full"
+        style={{ background: `linear-gradient(to right, ${category.color}, ${category.color}66)` }}
+      />
+      <div className="p-5">
+        <div className="flex items-center gap-2.5 mb-3">
+          <div
+            className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+            style={{ background: `${category.color}15` }}
+          >
+            <CategoryIcon className="w-4 h-4" style={{ color: category.color }} />
+          </div>
+          <span
+            className="text-[11px] font-bold uppercase tracking-wider"
+            style={{ color: category.color }}
+          >
+            {category.label}
           </span>
-        ))}
+          <span className={`text-[11px] ml-auto ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>
+            {date}
+          </span>
+        </div>
+
+        <h2 className={`text-base font-bold mb-1.5 leading-snug group-hover:text-blue-500 transition-colors line-clamp-2 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+          {article.title}
+        </h2>
+
+        <p className={`text-sm leading-relaxed line-clamp-2 mb-3 ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
+          {article.description}
+        </p>
+
+        <div className="flex items-center justify-between">
+          <span className={`text-xs flex items-center gap-1 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+            <Clock className="w-3 h-3" />
+            {article.readingTime} min
+          </span>
+          <span className={`text-xs font-semibold flex items-center gap-0.5 transition-colors ${isDarkMode ? 'text-blue-400 group-hover:text-blue-300' : 'text-blue-600 group-hover:text-blue-700'}`}>
+            Read <ChevronRight className="w-3.5 h-3.5 group-hover:translate-x-0.5 transition-transform" />
+          </span>
+        </div>
       </div>
     </article>
   );


### PR DESCRIPTION
Articles list:
- Featured hero card for the first article with large layout and category icon
- Remaining articles in a responsive 2-column grid
- Gradient accent bars on each card colored by category
- Category icons (Zap for strategy, TrendingUp for rankings, etc.)
- Pill-style category filters with colored active states
- Hover animations: title color shift, "Read" arrow nudge, shadow lift
- Clock icon with reading time, better empty state

Article detail:
- Header wrapped in a card with gradient top bar and category badge
- Author section with avatar placeholder, date, and divider
- Larger prose body (prose-lg) with additional style variables
- Tags section with label prefix
- CTA card with gradient background, centered icon, and shadow buttons
- Related articles in a 3-column grid with icons and hover effects

https://claude.ai/code/session_019X8SkRzjXV7HM4BbTLta4g