### PR TITLE
Switch prerender to puppeteer-core, update lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
                         "@types/react": "^19.2.14",
                         "@types/react-dom": "^19.2.3",
                         "@vitejs/plugin-react-swc": "^3.10.2",
+                        "puppeteer-core": "^24.0.0",
                         "typescript": "^5.9.3",
                         "vite": "6.3.5"
                   }
@@ -550,6 +551,28 @@
                   "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
                   "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
                   "license": "MIT"
+            },
+            "node_modules/@puppeteer/browsers": {
+                  "version": "2.13.0",
+                  "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+                  "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "debug": "^4.4.3",
+                        "extract-zip": "^2.0.1",
+                        "progress": "^2.0.3",
+                        "proxy-agent": "^6.5.0",
+                        "semver": "^7.7.4",
+                        "tar-fs": "^3.1.1",
+                        "yargs": "^17.7.2"
+                  },
+                  "bin": {
+                        "browsers": "lib/cjs/main-cli.js"
+                  },
+                  "engines": {
+                        "node": ">=18"
+                  }
             },
             "node_modules/@radix-ui/number": {
                   "version": "1.1.1",
@@ -2741,6 +2764,13 @@
                         "@swc/counter": "^0.1.3"
                   }
             },
+            "node_modules/@tootallnate/quickjs-emscripten": {
+                  "version": "0.23.0",
+                  "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+                  "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+                  "dev": true,
+                  "license": "MIT"
+            },
             "node_modules/@types/d3-array": {
                   "version": "3.2.2",
                   "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -2841,6 +2871,17 @@
                         "@types/react": "^19.2.0"
                   }
             },
+            "node_modules/@types/yauzl": {
+                  "version": "2.10.3",
+                  "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+                  "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "dependencies": {
+                        "@types/node": "*"
+                  }
+            },
             "node_modules/@vitejs/plugin-react-swc": {
                   "version": "3.11.0",
                   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.11.0.tgz",
@@ -2855,6 +2896,42 @@
                         "vite": "^4 || ^5 || ^6 || ^7"
                   }
             },
+            "node_modules/agent-base": {
+                  "version": "7.1.4",
+                  "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+                  "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 14"
+                  }
+            },
+            "node_modules/ansi-regex": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                  "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/ansi-styles": {
+                  "version": "4.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                  "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "color-convert": "^2.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  },
+                  "funding": {
+                        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+                  }
+            },
             "node_modules/aria-hidden": {
                   "version": "1.2.6",
                   "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -2867,6 +2944,150 @@
                         "node": ">=10"
                   }
             },
+            "node_modules/ast-types": {
+                  "version": "0.13.4",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+                  "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "tslib": "^2.0.1"
+                  },
+                  "engines": {
+                        "node": ">=4"
+                  }
+            },
+            "node_modules/bare-events": {
+                  "version": "2.8.2",
+                  "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+                  "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "peerDependencies": {
+                        "bare-abort-controller": "*"
+                  },
+                  "peerDependenciesMeta": {
+                        "bare-abort-controller": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/bare-fs": {
+                  "version": "4.5.6",
+                  "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
+                  "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "bare-events": "^2.5.4",
+                        "bare-path": "^3.0.0",
+                        "bare-stream": "^2.6.4",
+                        "bare-url": "^2.2.2",
+                        "fast-fifo": "^1.3.2"
+                  },
+                  "engines": {
+                        "bare": ">=1.16.0"
+                  },
+                  "peerDependencies": {
+                        "bare-buffer": "*"
+                  },
+                  "peerDependenciesMeta": {
+                        "bare-buffer": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/bare-os": {
+                  "version": "3.8.0",
+                  "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.0.tgz",
+                  "integrity": "sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "engines": {
+                        "bare": ">=1.14.0"
+                  }
+            },
+            "node_modules/bare-path": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+                  "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "bare-os": "^3.0.1"
+                  }
+            },
+            "node_modules/bare-stream": {
+                  "version": "2.11.0",
+                  "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.11.0.tgz",
+                  "integrity": "sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "streamx": "^2.25.0",
+                        "teex": "^1.0.1"
+                  },
+                  "peerDependencies": {
+                        "bare-abort-controller": "*",
+                        "bare-buffer": "*",
+                        "bare-events": "*"
+                  },
+                  "peerDependenciesMeta": {
+                        "bare-abort-controller": {
+                              "optional": true
+                        },
+                        "bare-buffer": {
+                              "optional": true
+                        },
+                        "bare-events": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/bare-url": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+                  "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "bare-path": "^3.0.0"
+                  }
+            },
+            "node_modules/basic-ftp": {
+                  "version": "5.2.0",
+                  "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+                  "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=10.0.0"
+                  }
+            },
+            "node_modules/buffer-crc32": {
+                  "version": "0.2.13",
+                  "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+                  "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": "*"
+                  }
+            },
+            "node_modules/chromium-bidi": {
+                  "version": "14.0.0",
+                  "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+                  "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "mitt": "^3.0.1",
+                        "zod": "^3.24.1"
+                  },
+                  "peerDependencies": {
+                        "devtools-protocol": "*"
+                  }
+            },
             "node_modules/class-variance-authority": {
                   "version": "0.7.1",
                   "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -2877,6 +3098,21 @@
                   },
                   "funding": {
                         "url": "https://polar.sh/cva"
+                  }
+            },
+            "node_modules/cliui": {
+                  "version": "8.0.1",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+                  "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.1",
+                        "wrap-ansi": "^7.0.0"
+                  },
+                  "engines": {
+                        "node": ">=12"
                   }
             },
             "node_modules/clsx": {
@@ -2903,6 +3139,26 @@
                         "react": "^18 || ^19 || ^19.0.0-rc",
                         "react-dom": "^18 || ^19 || ^19.0.0-rc"
                   }
+            },
+            "node_modules/color-convert": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                  "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "color-name": "~1.1.4"
+                  },
+                  "engines": {
+                        "node": ">=7.0.0"
+                  }
+            },
+            "node_modules/color-name": {
+                  "version": "1.1.4",
+                  "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                  "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                  "dev": true,
+                  "license": "MIT"
             },
             "node_modules/csstype": {
                   "version": "3.2.3",
@@ -3031,6 +3287,16 @@
                         "node": ">=12"
                   }
             },
+            "node_modules/data-uri-to-buffer": {
+                  "version": "6.0.2",
+                  "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+                  "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 14"
+                  }
+            },
             "node_modules/date-fns": {
                   "version": "3.6.0",
                   "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
@@ -3042,17 +3308,57 @@
                         "url": "https://github.com/sponsors/kossnocorp"
                   }
             },
+            "node_modules/debug": {
+                  "version": "4.4.3",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+                  "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ms": "^2.1.3"
+                  },
+                  "engines": {
+                        "node": ">=6.0"
+                  },
+                  "peerDependenciesMeta": {
+                        "supports-color": {
+                              "optional": true
+                        }
+                  }
+            },
             "node_modules/decimal.js-light": {
                   "version": "2.5.1",
                   "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
                   "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
                   "license": "MIT"
             },
+            "node_modules/degenerator": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+                  "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ast-types": "^0.13.4",
+                        "escodegen": "^2.1.0",
+                        "esprima": "^4.0.1"
+                  },
+                  "engines": {
+                        "node": ">= 14"
+                  }
+            },
             "node_modules/detect-node-es": {
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
                   "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
                   "license": "MIT"
+            },
+            "node_modules/devtools-protocol": {
+                  "version": "0.0.1581282",
+                  "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+                  "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
+                  "dev": true,
+                  "license": "BSD-3-Clause"
             },
             "node_modules/dom-helpers": {
                   "version": "5.2.1",
@@ -3090,6 +3396,23 @@
                   "license": "MIT",
                   "peerDependencies": {
                         "embla-carousel": "8.6.0"
+                  }
+            },
+            "node_modules/emoji-regex": {
+                  "version": "8.0.0",
+                  "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                  "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/end-of-stream": {
+                  "version": "1.4.5",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+                  "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "once": "^1.4.0"
                   }
             },
             "node_modules/esbuild": {
@@ -3134,11 +3457,108 @@
                         "@esbuild/win32-x64": "0.25.12"
                   }
             },
+            "node_modules/escalade": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+                  "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6"
+                  }
+            },
+            "node_modules/escodegen": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+                  "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+                  "dev": true,
+                  "license": "BSD-2-Clause",
+                  "dependencies": {
+                        "esprima": "^4.0.1",
+                        "estraverse": "^5.2.0",
+                        "esutils": "^2.0.2"
+                  },
+                  "bin": {
+                        "escodegen": "bin/escodegen.js",
+                        "esgenerate": "bin/esgenerate.js"
+                  },
+                  "engines": {
+                        "node": ">=6.0"
+                  },
+                  "optionalDependencies": {
+                        "source-map": "~0.6.1"
+                  }
+            },
+            "node_modules/esprima": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                  "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+                  "dev": true,
+                  "license": "BSD-2-Clause",
+                  "bin": {
+                        "esparse": "bin/esparse.js",
+                        "esvalidate": "bin/esvalidate.js"
+                  },
+                  "engines": {
+                        "node": ">=4"
+                  }
+            },
+            "node_modules/estraverse": {
+                  "version": "5.3.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+                  "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+                  "dev": true,
+                  "license": "BSD-2-Clause",
+                  "engines": {
+                        "node": ">=4.0"
+                  }
+            },
+            "node_modules/esutils": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+                  "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+                  "dev": true,
+                  "license": "BSD-2-Clause",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
             "node_modules/eventemitter3": {
                   "version": "4.0.7",
                   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
                   "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
                   "license": "MIT"
+            },
+            "node_modules/events-universal": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+                  "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "bare-events": "^2.7.0"
+                  }
+            },
+            "node_modules/extract-zip": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+                  "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+                  "dev": true,
+                  "license": "BSD-2-Clause",
+                  "dependencies": {
+                        "debug": "^4.1.1",
+                        "get-stream": "^5.1.0",
+                        "yauzl": "^2.10.0"
+                  },
+                  "bin": {
+                        "extract-zip": "cli.js"
+                  },
+                  "engines": {
+                        "node": ">= 10.17.0"
+                  },
+                  "optionalDependencies": {
+                        "@types/yauzl": "^2.9.1"
+                  }
             },
             "node_modules/fast-equals": {
                   "version": "5.4.0",
@@ -3147,6 +3567,23 @@
                   "license": "MIT",
                   "engines": {
                         "node": ">=6.0.0"
+                  }
+            },
+            "node_modules/fast-fifo": {
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+                  "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/fd-slicer": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+                  "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "pend": "~1.2.0"
                   }
             },
             "node_modules/fdir": {
@@ -3182,6 +3619,16 @@
                         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
                   }
             },
+            "node_modules/get-caller-file": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                  "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+                  "dev": true,
+                  "license": "ISC",
+                  "engines": {
+                        "node": "6.* || 8.* || >= 10.*"
+                  }
+            },
             "node_modules/get-nonce": {
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -3189,6 +3636,65 @@
                   "license": "MIT",
                   "engines": {
                         "node": ">=6"
+                  }
+            },
+            "node_modules/get-stream": {
+                  "version": "5.2.0",
+                  "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                  "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "pump": "^3.0.0"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/sindresorhus"
+                  }
+            },
+            "node_modules/get-uri": {
+                  "version": "6.0.5",
+                  "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+                  "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "basic-ftp": "^5.0.2",
+                        "data-uri-to-buffer": "^6.0.2",
+                        "debug": "^4.3.4"
+                  },
+                  "engines": {
+                        "node": ">= 14"
+                  }
+            },
+            "node_modules/http-proxy-agent": {
+                  "version": "7.0.2",
+                  "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+                  "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "agent-base": "^7.1.0",
+                        "debug": "^4.3.4"
+                  },
+                  "engines": {
+                        "node": ">= 14"
+                  }
+            },
+            "node_modules/https-proxy-agent": {
+                  "version": "7.0.6",
+                  "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+                  "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "agent-base": "^7.1.2",
+                        "debug": "4"
+                  },
+                  "engines": {
+                        "node": ">= 14"
                   }
             },
             "node_modules/input-otp": {
@@ -3219,6 +3725,26 @@
                         "loose-envify": "^1.0.0"
                   }
             },
+            "node_modules/ip-address": {
+                  "version": "10.1.0",
+                  "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+                  "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 12"
+                  }
+            },
+            "node_modules/is-fullwidth-code-point": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                  "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
             "node_modules/js-tokens": {
                   "version": "4.0.0",
                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3243,6 +3769,16 @@
                         "loose-envify": "cli.js"
                   }
             },
+            "node_modules/lru-cache": {
+                  "version": "7.18.3",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+                  "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+                  "dev": true,
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
             "node_modules/lucide-react": {
                   "version": "0.487.0",
                   "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.487.0.tgz",
@@ -3251,6 +3787,20 @@
                   "peerDependencies": {
                         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
                   }
+            },
+            "node_modules/mitt": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+                  "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/ms": {
+                  "version": "2.1.3",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                  "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+                  "dev": true,
+                  "license": "MIT"
             },
             "node_modules/nanoid": {
                   "version": "3.3.11",
@@ -3271,6 +3821,16 @@
                         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
                   }
             },
+            "node_modules/netmask": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+                  "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 0.4.0"
+                  }
+            },
             "node_modules/next-themes": {
                   "version": "0.4.6",
                   "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -3289,6 +3849,57 @@
                   "engines": {
                         "node": ">=0.10.0"
                   }
+            },
+            "node_modules/once": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "wrappy": "1"
+                  }
+            },
+            "node_modules/pac-proxy-agent": {
+                  "version": "7.2.0",
+                  "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+                  "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@tootallnate/quickjs-emscripten": "^0.23.0",
+                        "agent-base": "^7.1.2",
+                        "debug": "^4.3.4",
+                        "get-uri": "^6.0.1",
+                        "http-proxy-agent": "^7.0.0",
+                        "https-proxy-agent": "^7.0.6",
+                        "pac-resolver": "^7.0.1",
+                        "socks-proxy-agent": "^8.0.5"
+                  },
+                  "engines": {
+                        "node": ">= 14"
+                  }
+            },
+            "node_modules/pac-resolver": {
+                  "version": "7.0.1",
+                  "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+                  "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "degenerator": "^5.0.0",
+                        "netmask": "^2.0.2"
+                  },
+                  "engines": {
+                        "node": ">= 14"
+                  }
+            },
+            "node_modules/pend": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+                  "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+                  "dev": true,
+                  "license": "MIT"
             },
             "node_modules/picocolors": {
                   "version": "1.1.1",
@@ -3339,6 +3950,16 @@
                         "node": "^10 || ^12 || >=14"
                   }
             },
+            "node_modules/progress": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+                  "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=0.4.0"
+                  }
+            },
             "node_modules/prop-types": {
                   "version": "15.8.1",
                   "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3355,6 +3976,63 @@
                   "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
                   "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
                   "license": "MIT"
+            },
+            "node_modules/proxy-agent": {
+                  "version": "6.5.0",
+                  "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+                  "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "agent-base": "^7.1.2",
+                        "debug": "^4.3.4",
+                        "http-proxy-agent": "^7.0.1",
+                        "https-proxy-agent": "^7.0.6",
+                        "lru-cache": "^7.14.1",
+                        "pac-proxy-agent": "^7.1.0",
+                        "proxy-from-env": "^1.1.0",
+                        "socks-proxy-agent": "^8.0.5"
+                  },
+                  "engines": {
+                        "node": ">= 14"
+                  }
+            },
+            "node_modules/proxy-from-env": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+                  "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/pump": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+                  "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                  }
+            },
+            "node_modules/puppeteer-core": {
+                  "version": "24.40.0",
+                  "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
+                  "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "@puppeteer/browsers": "2.13.0",
+                        "chromium-bidi": "14.0.0",
+                        "debug": "^4.4.3",
+                        "devtools-protocol": "0.0.1581282",
+                        "typed-query-selector": "^2.12.1",
+                        "webdriver-bidi-protocol": "0.4.1",
+                        "ws": "^8.19.0"
+                  },
+                  "engines": {
+                        "node": ">=18"
+                  }
             },
             "node_modules/react": {
                   "version": "18.3.1",
@@ -3579,6 +4257,16 @@
                         "decimal.js-light": "^2.4.1"
                   }
             },
+            "node_modules/require-directory": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                  "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
             "node_modules/rollup": {
                   "version": "4.57.0",
                   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.0.tgz",
@@ -3647,11 +4335,65 @@
                         "loose-envify": "^1.1.0"
                   }
             },
+            "node_modules/semver": {
+                  "version": "7.7.4",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+                  "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+                  "dev": true,
+                  "license": "ISC",
+                  "bin": {
+                        "semver": "bin/semver.js"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
             "node_modules/shallowequal": {
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
                   "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
                   "license": "MIT"
+            },
+            "node_modules/smart-buffer": {
+                  "version": "4.2.0",
+                  "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+                  "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 6.0.0",
+                        "npm": ">= 3.0.0"
+                  }
+            },
+            "node_modules/socks": {
+                  "version": "2.8.7",
+                  "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+                  "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ip-address": "^10.0.1",
+                        "smart-buffer": "^4.2.0"
+                  },
+                  "engines": {
+                        "node": ">= 10.0.0",
+                        "npm": ">= 3.0.0"
+                  }
+            },
+            "node_modules/socks-proxy-agent": {
+                  "version": "8.0.5",
+                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+                  "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "agent-base": "^7.1.2",
+                        "debug": "^4.3.4",
+                        "socks": "^2.8.3"
+                  },
+                  "engines": {
+                        "node": ">= 14"
+                  }
             },
             "node_modules/sonner": {
                   "version": "2.0.7",
@@ -3661,6 +4403,17 @@
                   "peerDependencies": {
                         "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
                         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/source-map": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                  "dev": true,
+                  "license": "BSD-3-Clause",
+                  "optional": true,
+                  "engines": {
+                        "node": ">=0.10.0"
                   }
             },
             "node_modules/source-map-js": {
@@ -3673,6 +4426,46 @@
                         "node": ">=0.10.0"
                   }
             },
+            "node_modules/streamx": {
+                  "version": "2.25.0",
+                  "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+                  "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "events-universal": "^1.0.0",
+                        "fast-fifo": "^1.3.2",
+                        "text-decoder": "^1.1.0"
+                  }
+            },
+            "node_modules/string-width": {
+                  "version": "4.2.3",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                  "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/strip-ansi": {
+                  "version": "6.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                  "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ansi-regex": "^5.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
             "node_modules/tailwind-merge": {
                   "version": "3.4.0",
                   "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -3681,6 +4474,84 @@
                   "funding": {
                         "type": "github",
                         "url": "https://github.com/sponsors/dcastil"
+                  }
+            },
+            "node_modules/tar-fs": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+                  "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "pump": "^3.0.0",
+                        "tar-stream": "^3.1.5"
+                  },
+                  "optionalDependencies": {
+                        "bare-fs": "^4.0.1",
+                        "bare-path": "^3.0.0"
+                  }
+            },
+            "node_modules/tar-stream": {
+                  "version": "3.1.8",
+                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+                  "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "b4a": "^1.6.4",
+                        "bare-fs": "^4.5.5",
+                        "fast-fifo": "^1.2.0",
+                        "streamx": "^2.15.0"
+                  }
+            },
+            "node_modules/tar-stream/node_modules/b4a": {
+                  "version": "1.8.0",
+                  "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+                  "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "peerDependencies": {
+                        "react-native-b4a": "*"
+                  },
+                  "peerDependenciesMeta": {
+                        "react-native-b4a": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/teex": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+                  "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "streamx": "^2.12.5"
+                  }
+            },
+            "node_modules/text-decoder": {
+                  "version": "1.2.7",
+                  "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+                  "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "b4a": "^1.6.4"
+                  }
+            },
+            "node_modules/text-decoder/node_modules/b4a": {
+                  "version": "1.8.0",
+                  "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+                  "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "peerDependencies": {
+                        "react-native-b4a": "*"
+                  },
+                  "peerDependenciesMeta": {
+                        "react-native-b4a": {
+                              "optional": true
+                        }
                   }
             },
             "node_modules/tiny-invariant": {
@@ -3711,6 +4582,13 @@
                   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
                   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
                   "license": "0BSD"
+            },
+            "node_modules/typed-query-selector": {
+                  "version": "2.12.1",
+                  "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+                  "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+                  "dev": true,
+                  "license": "MIT"
             },
             "node_modules/typescript": {
                   "version": "5.9.3",
@@ -3893,6 +4771,120 @@
                         "yaml": {
                               "optional": true
                         }
+                  }
+            },
+            "node_modules/webdriver-bidi-protocol": {
+                  "version": "0.4.1",
+                  "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+                  "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+                  "dev": true,
+                  "license": "Apache-2.0"
+            },
+            "node_modules/wrap-ansi": {
+                  "version": "7.0.0",
+                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                  "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "funding": {
+                        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+                  }
+            },
+            "node_modules/wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+                  "dev": true,
+                  "license": "ISC"
+            },
+            "node_modules/ws": {
+                  "version": "8.20.0",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+                  "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=10.0.0"
+                  },
+                  "peerDependencies": {
+                        "bufferutil": "^4.0.1",
+                        "utf-8-validate": ">=5.0.2"
+                  },
+                  "peerDependenciesMeta": {
+                        "bufferutil": {
+                              "optional": true
+                        },
+                        "utf-8-validate": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/y18n": {
+                  "version": "5.0.8",
+                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+                  "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+                  "dev": true,
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/yargs": {
+                  "version": "17.7.2",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+                  "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "cliui": "^8.0.1",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.3",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^21.1.1"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/yargs-parser": {
+                  "version": "21.1.1",
+                  "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+                  "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+                  "dev": true,
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/yauzl": {
+                  "version": "2.10.0",
+                  "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+                  "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "buffer-crc32": "~0.2.3",
+                        "fd-slicer": "~1.1.0"
+                  }
+            },
+            "node_modules/zod": {
+                  "version": "3.25.76",
+                  "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+                  "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "funding": {
+                        "url": "https://github.com/sponsors/colinhacks"
                   }
             }
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
             "@types/react": "^19.2.14",
             "@types/react-dom": "^19.2.3",
             "@vitejs/plugin-react-swc": "^3.10.2",
-            "puppeteer": "^24.0.0",
+            "puppeteer-core": "^24.0.0",
             "typescript": "^5.9.3",
             "vite": "6.3.5"
       },

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -12,16 +12,51 @@
  * Requires: puppeteer (devDependency)
  */
 
-import { writeFileSync, mkdirSync } from 'fs';
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { spawn } from 'child_process';
-import puppeteer from 'puppeteer';
+import { spawn, execSync } from 'child_process';
+import puppeteer from 'puppeteer-core';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUILD_DIR = join(__dirname, '..', 'build');
 const PORT = 4173; // Vite preview default port
 const ORIGIN = `http://localhost:${PORT}`;
+
+/**
+ * Find a Chrome/Chromium executable on the system.
+ * Checks common locations and environment variables.
+ */
+function findChrome() {
+  // Allow explicit override via env var
+  if (process.env.CHROME_PATH && existsSync(process.env.CHROME_PATH)) {
+    return process.env.CHROME_PATH;
+  }
+
+  const candidates = [
+    // Linux
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+    // macOS
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    // Common CI paths
+    '/usr/bin/google-chrome-stable',
+    process.env.PUPPETEER_EXECUTABLE_PATH,
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  // Try `which` as a fallback
+  try {
+    return execSync('which google-chrome || which chromium-browser || which chromium', { encoding: 'utf-8' }).trim();
+  } catch {
+    return null;
+  }
+}
 
 // Public routes that crawlers should see with full content.
 // Authenticated routes (home, team, matchup, settings, etc.) are excluded
@@ -144,9 +179,20 @@ async function main() {
   console.log(`Preview server running on port ${PORT}`);
 
   // 2. Launch Puppeteer
+  const chromePath = findChrome();
+  if (!chromePath) {
+    console.error('Could not find Chrome/Chromium. Install it or set CHROME_PATH env var.');
+    console.error('On Ubuntu/CI: sudo apt-get install -y google-chrome-stable');
+    console.error('Or: npx @puppeteer/browsers install chrome@stable');
+    server.kill();
+    process.exit(1);
+  }
+  console.log(`Using Chrome at: ${chromePath}`);
+
   const browser = await puppeteer.launch({
+    executablePath: chromePath,
     headless: 'new',
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'],
   });
 
   const page = await browser.newPage();


### PR DESCRIPTION
Use puppeteer-core instead of puppeteer to avoid bundling a Chrome download. The script auto-detects Chrome/Chromium on the system or accepts a CHROME_PATH env var. Most CI environments (GitHub Actions, Cloudflare, etc.) have Chrome pre-installed.

https://claude.ai/code/session_019AHMuHDRzbnDuruaWUwzFW