### PR TITLE
Regenerate package-lock.json from clean state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,9 +64,9 @@
                   }
             },
             "node_modules/@babel/runtime": {
-                  "version": "7.28.6",
-                  "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-                  "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+                  "version": "7.29.2",
+                  "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+                  "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
                   "license": "MIT",
                   "engines": {
                         "node": ">=6.9.0"
@@ -515,31 +515,31 @@
                   }
             },
             "node_modules/@floating-ui/core": {
-                  "version": "1.7.4",
-                  "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-                  "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+                  "version": "1.7.5",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+                  "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
                   "license": "MIT",
                   "dependencies": {
-                        "@floating-ui/utils": "^0.2.10"
+                        "@floating-ui/utils": "^0.2.11"
                   }
             },
             "node_modules/@floating-ui/dom": {
-                  "version": "1.7.5",
-                  "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-                  "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+                  "version": "1.7.6",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+                  "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
                   "license": "MIT",
                   "dependencies": {
-                        "@floating-ui/core": "^1.7.4",
-                        "@floating-ui/utils": "^0.2.10"
+                        "@floating-ui/core": "^1.7.5",
+                        "@floating-ui/utils": "^0.2.11"
                   }
             },
             "node_modules/@floating-ui/react-dom": {
-                  "version": "2.1.7",
-                  "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
-                  "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+                  "version": "2.1.8",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+                  "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
                   "license": "MIT",
                   "dependencies": {
-                        "@floating-ui/dom": "^1.7.5"
+                        "@floating-ui/dom": "^1.7.6"
                   },
                   "peerDependencies": {
                         "react": ">=16.8.0",
@@ -547,9 +547,9 @@
                   }
             },
             "node_modules/@floating-ui/utils": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-                  "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+                  "version": "0.2.11",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+                  "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
                   "license": "MIT"
             },
             "node_modules/@puppeteer/browsers": {
@@ -2191,9 +2191,9 @@
                   "license": "MIT"
             },
             "node_modules/@rollup/rollup-android-arm-eabi": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.0.tgz",
-                  "integrity": "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+                  "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
                   "cpu": [
                         "arm"
                   ],
@@ -2205,9 +2205,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-android-arm64": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.0.tgz",
-                  "integrity": "sha512-sa4LyseLLXr1onr97StkU1Nb7fWcg6niokTwEVNOO7awaKaoRObQ54+V/hrF/BP1noMEaaAW6Fg2d/CfLiq3Mg==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+                  "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2219,9 +2219,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-darwin-arm64": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.0.tgz",
-                  "integrity": "sha512-/NNIj9A7yLjKdmkx5dC2XQ9DmjIECpGpwHoGmA5E1AhU0fuICSqSWScPhN1yLCkEdkCwJIDu2xIeLPs60MNIVg==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+                  "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2233,9 +2233,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-darwin-x64": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.0.tgz",
-                  "integrity": "sha512-xoh8abqgPrPYPr7pTYipqnUi1V3em56JzE/HgDgitTqZBZ3yKCWI+7KUkceM6tNweyUKYru1UMi7FC060RyKwA==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+                  "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
                   "cpu": [
                         "x64"
                   ],
@@ -2247,9 +2247,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-freebsd-arm64": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.0.tgz",
-                  "integrity": "sha512-PCkMh7fNahWSbA0OTUQ2OpYHpjZZr0hPr8lId8twD7a7SeWrvT3xJVyza+dQwXSSq4yEQTMoXgNOfMCsn8584g==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+                  "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2261,9 +2261,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-freebsd-x64": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.0.tgz",
-                  "integrity": "sha512-1j3stGx+qbhXql4OCDZhnK7b01s6rBKNybfsX+TNrEe9JNq4DLi1yGiR1xW+nL+FNVvI4D02PUnl6gJ/2y6WJA==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+                  "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
                   "cpu": [
                         "x64"
                   ],
@@ -2275,9 +2275,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.0.tgz",
-                  "integrity": "sha512-eyrr5W08Ms9uM0mLcKfM/Uzx7hjhz2bcjv8P2uynfj0yU8GGPdz8iYrBPhiLOZqahoAMB8ZiolRZPbbU2MAi6Q==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+                  "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
                   "cpu": [
                         "arm"
                   ],
@@ -2289,9 +2289,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.0.tgz",
-                  "integrity": "sha512-Xds90ITXJCNyX9pDhqf85MKWUI4lqjiPAipJ8OLp8xqI2Ehk+TCVhF9rvOoN8xTbcafow3QOThkNnrM33uCFQA==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+                  "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
                   "cpu": [
                         "arm"
                   ],
@@ -2303,9 +2303,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-arm64-gnu": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.0.tgz",
-                  "integrity": "sha512-Xws2KA4CLvZmXjy46SQaXSejuKPhwVdaNinldoYfqruZBaJHqVo6hnRa8SDo9z7PBW5x84SH64+izmldCgbezw==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+                  "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2317,9 +2317,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-arm64-musl": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.0.tgz",
-                  "integrity": "sha512-hrKXKbX5FdaRJj7lTMusmvKbhMJSGWJ+w++4KmjiDhpTgNlhYobMvKfDoIWecy4O60K6yA4SnztGuNTQF+Lplw==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+                  "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2331,9 +2331,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-loong64-gnu": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.0.tgz",
-                  "integrity": "sha512-6A+nccfSDGKsPm00d3xKcrsBcbqzCTAukjwWK6rbuAnB2bHaL3r9720HBVZ/no7+FhZLz/U3GwwZZEh6tOSI8Q==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+                  "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
                   "cpu": [
                         "loong64"
                   ],
@@ -2345,9 +2345,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-loong64-musl": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.0.tgz",
-                  "integrity": "sha512-4P1VyYUe6XAJtQH1Hh99THxr0GKMMwIXsRNOceLrJnaHTDgk1FTcTimDgneRJPvB3LqDQxUmroBclQ1S0cIJwQ==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+                  "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
                   "cpu": [
                         "loong64"
                   ],
@@ -2359,9 +2359,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.0.tgz",
-                  "integrity": "sha512-8Vv6pLuIZCMcgXre6c3nOPhE0gjz1+nZP6T+hwWjr7sVH8k0jRkH+XnfjjOTglyMBdSKBPPz54/y1gToSKwrSQ==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+                  "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
                   "cpu": [
                         "ppc64"
                   ],
@@ -2373,9 +2373,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-ppc64-musl": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.0.tgz",
-                  "integrity": "sha512-r1te1M0Sm2TBVD/RxBPC6RZVwNqUTwJTA7w+C/IW5v9Ssu6xmxWEi+iJQlpBhtUiT1raJ5b48pI8tBvEjEFnFA==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+                  "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
                   "cpu": [
                         "ppc64"
                   ],
@@ -2387,9 +2387,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.0.tgz",
-                  "integrity": "sha512-say0uMU/RaPm3CDQLxUUTF2oNWL8ysvHkAjcCzV2znxBr23kFfaxocS9qJm+NdkRhF8wtdEEAJuYcLPhSPbjuQ==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+                  "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
                   "cpu": [
                         "riscv64"
                   ],
@@ -2401,9 +2401,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-riscv64-musl": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.0.tgz",
-                  "integrity": "sha512-/MU7/HizQGsnBREtRpcSbSV1zfkoxSTR7wLsRmBPQ8FwUj5sykrP1MyJTvsxP5KBq9SyE6kH8UQQQwa0ASeoQQ==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+                  "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
                   "cpu": [
                         "riscv64"
                   ],
@@ -2415,9 +2415,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-s390x-gnu": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.0.tgz",
-                  "integrity": "sha512-Q9eh+gUGILIHEaJf66aF6a414jQbDnn29zeu0eX3dHMuysnhTvsUvZTCAyZ6tJhUjnvzBKE4FtuaYxutxRZpOg==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+                  "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
                   "cpu": [
                         "s390x"
                   ],
@@ -2429,9 +2429,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-x64-gnu": {
-                  "version": "4.59.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-                  "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+                  "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
                   "cpu": [
                         "x64"
                   ],
@@ -2441,9 +2441,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-linux-x64-musl": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.0.tgz",
-                  "integrity": "sha512-XeatKzo4lHDsVEbm1XDHZlhYZZSQYym6dg2X/Ko0kSFgio+KXLsxwJQprnR48GvdIKDOpqWqssC3iBCjoMcMpw==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+                  "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
                   "cpu": [
                         "x64"
                   ],
@@ -2455,9 +2455,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-openbsd-x64": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.0.tgz",
-                  "integrity": "sha512-Lu71y78F5qOfYmubYLHPcJm74GZLU6UJ4THkf/a1K7Tz2ycwC2VUbsqbJAXaR6Bx70SRdlVrt2+n5l7F0agTUw==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+                  "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
                   "cpu": [
                         "x64"
                   ],
@@ -2469,9 +2469,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-openharmony-arm64": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.0.tgz",
-                  "integrity": "sha512-v5xwKDWcu7qhAEcsUubiav7r+48Uk/ENWdr82MBZZRIm7zThSxCIVDfb3ZeRRq9yqk+oIzMdDo6fCcA5DHfMyA==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+                  "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2483,9 +2483,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-win32-arm64-msvc": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.0.tgz",
-                  "integrity": "sha512-XnaaaSMGSI6Wk8F4KK3QP7GfuuhjGchElsVerCplUuxRIzdvZ7hRBpLR0omCmw+kI2RFJB80nenhOoGXlJ5TfQ==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+                  "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2497,9 +2497,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-win32-ia32-msvc": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.0.tgz",
-                  "integrity": "sha512-3K1lP+3BXY4t4VihLw5MEg6IZD3ojSYzqzBG571W3kNQe4G4CcFpSUQVgurYgib5d+YaCjeFow8QivWp8vuSvA==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+                  "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
                   "cpu": [
                         "ia32"
                   ],
@@ -2511,9 +2511,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-win32-x64-gnu": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.0.tgz",
-                  "integrity": "sha512-MDk610P/vJGc5L5ImE4k5s+GZT3en0KoK1MKPXCRgzmksAMk79j4h3k1IerxTNqwDLxsGxStEZVBqG0gIqZqoA==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+                  "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
                   "cpu": [
                         "x64"
                   ],
@@ -2525,9 +2525,9 @@
                   ]
             },
             "node_modules/@rollup/rollup-win32-x64-msvc": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.0.tgz",
-                  "integrity": "sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+                  "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
                   "cpu": [
                         "x64"
                   ],
@@ -2539,9 +2539,9 @@
                   ]
             },
             "node_modules/@swc/core": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
-                  "integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.21.tgz",
+                  "integrity": "sha512-fkk7NJcBscrR3/F8jiqlMptRHP650NxqDnspBMrRe5d8xOoCy9MLL5kOBLFXjFLfMo3KQQHhk+/jUULOMlR1uQ==",
                   "dev": true,
                   "hasInstallScript": true,
                   "license": "Apache-2.0",
@@ -2557,16 +2557,18 @@
                         "url": "https://opencollective.com/swc"
                   },
                   "optionalDependencies": {
-                        "@swc/core-darwin-arm64": "1.15.11",
-                        "@swc/core-darwin-x64": "1.15.11",
-                        "@swc/core-linux-arm-gnueabihf": "1.15.11",
-                        "@swc/core-linux-arm64-gnu": "1.15.11",
-                        "@swc/core-linux-arm64-musl": "1.15.11",
-                        "@swc/core-linux-x64-gnu": "1.15.11",
-                        "@swc/core-linux-x64-musl": "1.15.11",
-                        "@swc/core-win32-arm64-msvc": "1.15.11",
-                        "@swc/core-win32-ia32-msvc": "1.15.11",
-                        "@swc/core-win32-x64-msvc": "1.15.11"
+                        "@swc/core-darwin-arm64": "1.15.21",
+                        "@swc/core-darwin-x64": "1.15.21",
+                        "@swc/core-linux-arm-gnueabihf": "1.15.21",
+                        "@swc/core-linux-arm64-gnu": "1.15.21",
+                        "@swc/core-linux-arm64-musl": "1.15.21",
+                        "@swc/core-linux-ppc64-gnu": "1.15.21",
+                        "@swc/core-linux-s390x-gnu": "1.15.21",
+                        "@swc/core-linux-x64-gnu": "1.15.21",
+                        "@swc/core-linux-x64-musl": "1.15.21",
+                        "@swc/core-win32-arm64-msvc": "1.15.21",
+                        "@swc/core-win32-ia32-msvc": "1.15.21",
+                        "@swc/core-win32-x64-msvc": "1.15.21"
                   },
                   "peerDependencies": {
                         "@swc/helpers": ">=0.5.17"
@@ -2578,9 +2580,9 @@
                   }
             },
             "node_modules/@swc/core-darwin-arm64": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.11.tgz",
-                  "integrity": "sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.21.tgz",
+                  "integrity": "sha512-SA8SFg9dp0qKRH8goWsax6bptFE2EdmPf2YRAQW9WoHGf3XKM1bX0nd5UdwxmC5hXsBUZAYf7xSciCler6/oyA==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2595,9 +2597,9 @@
                   }
             },
             "node_modules/@swc/core-darwin-x64": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.11.tgz",
-                  "integrity": "sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.21.tgz",
+                  "integrity": "sha512-//fOVntgowz9+V90lVsNCtyyrtbHp3jWH6Rch7MXHXbcvbLmbCTmssl5DeedUWLLGiAAW1wksBdqdGYOTjaNLw==",
                   "cpu": [
                         "x64"
                   ],
@@ -2612,9 +2614,9 @@
                   }
             },
             "node_modules/@swc/core-linux-arm-gnueabihf": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.11.tgz",
-                  "integrity": "sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.21.tgz",
+                  "integrity": "sha512-meNI4Sh6h9h8DvIfEc0l5URabYMSuNvyisLmG6vnoYAS43s8ON3NJR8sDHvdP7NJTrLe0q/x2XCn6yL/BeHcZg==",
                   "cpu": [
                         "arm"
                   ],
@@ -2629,9 +2631,9 @@
                   }
             },
             "node_modules/@swc/core-linux-arm64-gnu": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.11.tgz",
-                  "integrity": "sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.21.tgz",
+                  "integrity": "sha512-QrXlNQnHeXqU2EzLlnsPoWEh8/GtNJLvfMiPsDhk+ht6Xv8+vhvZ5YZ/BokNWSIZiWPKLAqR0M7T92YF5tmD3g==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2646,9 +2648,9 @@
                   }
             },
             "node_modules/@swc/core-linux-arm64-musl": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.11.tgz",
-                  "integrity": "sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.21.tgz",
+                  "integrity": "sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2662,10 +2664,44 @@
                         "node": ">=10"
                   }
             },
+            "node_modules/@swc/core-linux-ppc64-gnu": {
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.21.tgz",
+                  "integrity": "sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==",
+                  "cpu": [
+                        "ppc64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-s390x-gnu": {
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.21.tgz",
+                  "integrity": "sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==",
+                  "cpu": [
+                        "s390x"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
             "node_modules/@swc/core-linux-x64-gnu": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.11.tgz",
-                  "integrity": "sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.21.tgz",
+                  "integrity": "sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==",
                   "cpu": [
                         "x64"
                   ],
@@ -2680,9 +2716,9 @@
                   }
             },
             "node_modules/@swc/core-linux-x64-musl": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.11.tgz",
-                  "integrity": "sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.21.tgz",
+                  "integrity": "sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==",
                   "cpu": [
                         "x64"
                   ],
@@ -2697,9 +2733,9 @@
                   }
             },
             "node_modules/@swc/core-win32-arm64-msvc": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.11.tgz",
-                  "integrity": "sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.21.tgz",
+                  "integrity": "sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==",
                   "cpu": [
                         "arm64"
                   ],
@@ -2714,9 +2750,9 @@
                   }
             },
             "node_modules/@swc/core-win32-ia32-msvc": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.11.tgz",
-                  "integrity": "sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.21.tgz",
+                  "integrity": "sha512-IkSZj8PX/N4HcaFhMQtzmkV8YSnuNoJ0E6OvMwFiOfejPhiKXvl7CdDsn1f4/emYEIDO3fpgZW9DTaCRMDxaDA==",
                   "cpu": [
                         "ia32"
                   ],
@@ -2731,9 +2767,9 @@
                   }
             },
             "node_modules/@swc/core-win32-x64-msvc": {
-                  "version": "1.15.11",
-                  "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.11.tgz",
-                  "integrity": "sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==",
+                  "version": "1.15.21",
+                  "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.21.tgz",
+                  "integrity": "sha512-zUyWso7OOENB6e1N1hNuNn8vbvLsTdKQ5WKLgt/JcBNfJhKy/6jmBmqI3GXk/MyvQKd5SLvP7A0F36p7TeDqvw==",
                   "cpu": [
                         "x64"
                   ],
@@ -2755,9 +2791,9 @@
                   "license": "Apache-2.0"
             },
             "node_modules/@swc/types": {
-                  "version": "0.1.25",
-                  "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
-                  "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+                  "version": "0.1.26",
+                  "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+                  "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
                   "dev": true,
                   "license": "Apache-2.0",
                   "dependencies": {
@@ -2842,9 +2878,9 @@
                   "license": "MIT"
             },
             "node_modules/@types/node": {
-                  "version": "20.19.30",
-                  "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-                  "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+                  "version": "20.19.37",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+                  "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
                   "dev": true,
                   "license": "MIT",
                   "dependencies": {
@@ -3909,9 +3945,9 @@
                   "license": "ISC"
             },
             "node_modules/picomatch": {
-                  "version": "4.0.3",
-                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-                  "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+                  "version": "4.0.4",
+                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+                  "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
                   "dev": true,
                   "license": "MIT",
                   "engines": {
@@ -3922,9 +3958,9 @@
                   }
             },
             "node_modules/postcss": {
-                  "version": "8.5.6",
-                  "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-                  "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+                  "version": "8.5.8",
+                  "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+                  "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
                   "dev": true,
                   "funding": [
                         {
@@ -4094,9 +4130,9 @@
                   }
             },
             "node_modules/react-hook-form": {
-                  "version": "7.71.1",
-                  "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
-                  "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
+                  "version": "7.72.0",
+                  "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
+                  "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
                   "license": "MIT",
                   "engines": {
                         "node": ">=18.0.0"
@@ -4268,9 +4304,9 @@
                   }
             },
             "node_modules/rollup": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.0.tgz",
-                  "integrity": "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==",
+                  "version": "4.60.0",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+                  "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
                   "dev": true,
                   "license": "MIT",
                   "dependencies": {
@@ -4284,47 +4320,33 @@
                         "npm": ">=8.0.0"
                   },
                   "optionalDependencies": {
-                        "@rollup/rollup-android-arm-eabi": "4.57.0",
-                        "@rollup/rollup-android-arm64": "4.57.0",
-                        "@rollup/rollup-darwin-arm64": "4.57.0",
-                        "@rollup/rollup-darwin-x64": "4.57.0",
-                        "@rollup/rollup-freebsd-arm64": "4.57.0",
-                        "@rollup/rollup-freebsd-x64": "4.57.0",
-                        "@rollup/rollup-linux-arm-gnueabihf": "4.57.0",
-                        "@rollup/rollup-linux-arm-musleabihf": "4.57.0",
-                        "@rollup/rollup-linux-arm64-gnu": "4.57.0",
-                        "@rollup/rollup-linux-arm64-musl": "4.57.0",
-                        "@rollup/rollup-linux-loong64-gnu": "4.57.0",
-                        "@rollup/rollup-linux-loong64-musl": "4.57.0",
-                        "@rollup/rollup-linux-ppc64-gnu": "4.57.0",
-                        "@rollup/rollup-linux-ppc64-musl": "4.57.0",
-                        "@rollup/rollup-linux-riscv64-gnu": "4.57.0",
-                        "@rollup/rollup-linux-riscv64-musl": "4.57.0",
-                        "@rollup/rollup-linux-s390x-gnu": "4.57.0",
-                        "@rollup/rollup-linux-x64-gnu": "4.57.0",
-                        "@rollup/rollup-linux-x64-musl": "4.57.0",
-                        "@rollup/rollup-openbsd-x64": "4.57.0",
-                        "@rollup/rollup-openharmony-arm64": "4.57.0",
-                        "@rollup/rollup-win32-arm64-msvc": "4.57.0",
-                        "@rollup/rollup-win32-ia32-msvc": "4.57.0",
-                        "@rollup/rollup-win32-x64-gnu": "4.57.0",
-                        "@rollup/rollup-win32-x64-msvc": "4.57.0",
+                        "@rollup/rollup-android-arm-eabi": "4.60.0",
+                        "@rollup/rollup-android-arm64": "4.60.0",
+                        "@rollup/rollup-darwin-arm64": "4.60.0",
+                        "@rollup/rollup-darwin-x64": "4.60.0",
+                        "@rollup/rollup-freebsd-arm64": "4.60.0",
+                        "@rollup/rollup-freebsd-x64": "4.60.0",
+                        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+                        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+                        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+                        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+                        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+                        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+                        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+                        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+                        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+                        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+                        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+                        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+                        "@rollup/rollup-linux-x64-musl": "4.60.0",
+                        "@rollup/rollup-openbsd-x64": "4.60.0",
+                        "@rollup/rollup-openharmony-arm64": "4.60.0",
+                        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+                        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+                        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+                        "@rollup/rollup-win32-x64-msvc": "4.60.0",
                         "fsevents": "~2.3.2"
                   }
-            },
-            "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
-                  "version": "4.57.0",
-                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.0.tgz",
-                  "integrity": "sha512-OR5p5yG5OKSxHReWmwvM0P+VTPMwoBS45PXTMYaskKQqybkS3Kmugq1W+YbNWArF8/s7jQScgzXUhArzEQ7x0A==",
-                  "cpu": [
-                        "x64"
-                  ],
-                  "dev": true,
-                  "license": "MIT",
-                  "optional": true,
-                  "os": [
-                        "linux"
-                  ]
             },
             "node_modules/scheduler": {
                   "version": "0.23.2",
@@ -4467,9 +4489,9 @@
                   }
             },
             "node_modules/tailwind-merge": {
-                  "version": "3.4.0",
-                  "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
-                  "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+                  "version": "3.5.0",
+                  "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+                  "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
                   "license": "MIT",
                   "funding": {
                         "type": "github",


### PR DESCRIPTION
Fixes CI npm ci failure caused by corrupted/incomplete lockfile. Deleted node_modules and lockfile, then ran fresh npm install to regenerate a valid package-lock.json.

https://claude.ai/code/session_019AHMuHDRzbnDuruaWUwzFW