### PR TITLE
Replace trade finder mega-call with per-target fan-out

### DIFF
--- a/server/src/routes/tradeFinder.ts
+++ b/server/src/routes/tradeFinder.ts
@@ -217,6 +217,12 @@ interface RecommendationsBody {
   leagueId: string;
   targetPosition?: string;
   targetTeamId?: string;
+  /** Optional: target a specific player on any opponent team. When
+   *  set, the finder skips broad target selection and runs a single
+   *  focused construction call for that exact player. Must be a
+   *  player that exists on a team in the league other than the
+   *  user's own roster. */
+  targetPlayerId?: string;
   leagueSettings?: Partial<LeagueSettings>;
   /** Optional: restrict the user's send-side candidate pool to these
    *  player ids (must be on their roster). */
@@ -298,7 +304,10 @@ tradeFinderRoutes.post('/recommendations', authMiddleware, async (c) => {
     // that would make previously cached results invalid (e.g. tighter
     // filters, new analyzer inputs). Bump it here when we ship fixes
     // that would make a user say "the old trade is still showing up".
-    const CACHE_VERSION = 'v4';
+    // v5: switched from single mega-call construction to parallel
+    //     per-target fan-out. Prior cached results used the mega-call
+    //     pipeline and would otherwise persist for the rest of the day.
+    const CACHE_VERSION = 'v5';
     const todayKey = new Date().toISOString().slice(0, 10);
     const sortedPlayerIds = [...(body.userPlayerIds ?? [])].sort();
     const sortedPicks = [...(body.userPicks ?? [])]
@@ -308,7 +317,7 @@ tradeFinderRoutes.post('/recommendations', authMiddleware, async (c) => {
       sortedPlayerIds.length === 0 && sortedPicks.length === 0
         ? 'any'
         : `p[${sortedPlayerIds.join(',')}]|pk[${sortedPicks.join(',')}]`;
-    const filterKey = `${body.targetPosition || 'any'}-${body.targetTeamId || 'any'}-${assetKey}`;
+    const filterKey = `${body.targetPosition || 'any'}-${body.targetTeamId || 'any'}-${body.targetPlayerId || 'any'}-${assetKey}`;
     const cacheKey = new Request(
       `https://cache.local/trade-finder/recs/${CACHE_VERSION}/${league.id}/${userTeam.id}/${league.currentWeek}/${filterKey}/${todayKey}`
     );
@@ -351,6 +360,7 @@ tradeFinderRoutes.post('/recommendations', authMiddleware, async (c) => {
       leagueType: (league.leagueType as 'redraft' | 'dynasty' | 'keeper') ?? 'redraft',
       targetPosition: body.targetPosition ?? null,
       targetTeamId: body.targetTeamId ?? null,
+      targetPlayerId: body.targetPlayerId ?? null,
       maxRecommendations: 8,
       userPlayerIds: body.userPlayerIds ?? null,
       userPicks: body.userPicks ?? null,

--- a/server/src/services/teamComposition.ts
+++ b/server/src/services/teamComposition.ts
@@ -298,3 +298,186 @@ export function playersAtPosition(
   if (!summary) return [];
   return summary.players.map((p) => p.playerId);
 }
+
+// ── Acquisition target selection (for trade finder fan-out) ─────────
+//
+// Given the user's composition and every partner's composition, produce
+// a deterministic list of concrete acquisition targets. This feeds the
+// trade finder's per-target fan-out: each target becomes one focused
+// construction call. The goal is to surface ~20-30 high-signal targets
+// across the league before burning any AI budget.
+
+export interface AcquisitionTarget {
+  partnerTeamId: string;
+  targetPlayerId: string;
+  /** Position of the target player (already uppercased). */
+  targetPosition: string;
+  /** Short human-readable label for why this target was picked. Used
+   *  in debug logs and threaded into the per-target prompt. */
+  rationale: string;
+  /** Which heuristic surfaced this target. 'need' = partner's top
+   *  player at a user need position; 'surplus' = partner's surplus
+   *  at a user need position (easiest to pry); 'pick' = mid-tier
+   *  starter that a user-owned pick could help acquire. */
+  category: 'need' | 'surplus' | 'pick';
+  /** Deterministic rank score — higher is better. Used to truncate
+   *  the global pool down to the per-call fan-out budget. */
+  rankScore: number;
+}
+
+export interface SelectAcquisitionTargetsArgs {
+  userComp: TeamComposition;
+  compositionsByTeam: Map<string, TeamComposition>;
+  /** Partner team IDs to consider (already filtered by the caller so
+   *  the user's own team and any out-of-scope partners are excluded). */
+  partnerTeamIds: string[];
+  /** If set, restrict all categories to this position only. */
+  targetPosition: string | null;
+  /** If the user has draft picks in their offer, pick-centric targets
+   *  become relevant. When false, the 'pick' category is skipped. */
+  hasUserPicks: boolean;
+  /** Max targets per partner team after category ranking. Default 3. */
+  perPartnerLimit?: number;
+  /** Global cap across all partners after ranking. Default 30. */
+  totalLimit?: number;
+}
+
+// Weight by need urgency when ranking targets globally.
+const NEED_WEIGHT: Record<NeedLevel, number> = {
+  premium: 3,
+  starter: 2,
+  depth: 1,
+  none: 0.5,
+};
+
+export function selectAcquisitionTargets(
+  args: SelectAcquisitionTargetsArgs
+): AcquisitionTarget[] {
+  const {
+    userComp,
+    compositionsByTeam,
+    partnerTeamIds,
+    targetPosition,
+    hasUserPicks,
+    perPartnerLimit = 3,
+    totalLimit = 30,
+  } = args;
+
+  const wantPos = targetPosition ? targetPosition.toUpperCase() : null;
+
+  // Which positions should drive target selection for this call:
+  //  - If the user set a target-position filter, that's the only one.
+  //  - Otherwise, the user's explicit needs.
+  //  - Fallback: if the user has no explicit needs (a balanced roster),
+  //    treat every skill position as a 'depth' need so we still
+  //    generate targets across the league.
+  const needLevelByPos = new Map<string, NeedLevel>();
+  if (wantPos) {
+    const existing = userComp.needs.find((n) => n.position === wantPos);
+    needLevelByPos.set(wantPos, existing?.level ?? 'starter');
+  } else if (userComp.needs.length > 0) {
+    for (const n of userComp.needs) needLevelByPos.set(n.position, n.level);
+  } else {
+    for (const p of ['QB', 'RB', 'WR', 'TE']) {
+      needLevelByPos.set(p, 'depth');
+    }
+  }
+
+  const allTargets: AcquisitionTarget[] = [];
+
+  for (const partnerId of partnerTeamIds) {
+    const partnerComp = compositionsByTeam.get(partnerId);
+    if (!partnerComp) continue;
+
+    const perPartner: AcquisitionTarget[] = [];
+    const takenIds = new Set<string>();
+
+    // Category 1: need-driven. Partner's top 2 non-stash players at
+    // each user-need position. We deliberately DON'T skip the partner's
+    // #1 player here — the per-target prompt includes a "partner must
+    // plausibly accept" rule, so the construction pass will drop any
+    // target that's too attached to be pried loose. Our job is just
+    // to surface plausible candidates.
+    for (const [pos, level] of needLevelByPos) {
+      const summary = partnerComp.byPosition.get(pos);
+      if (!summary) continue;
+      let picked = 0;
+      for (const slot of summary.players) {
+        if (picked >= 2) break;
+        if (takenIds.has(slot.playerId)) continue;
+        if (slot.tier === 'stash') continue;
+        takenIds.add(slot.playerId);
+        perPartner.push({
+          partnerTeamId: partnerId,
+          targetPlayerId: slot.playerId,
+          targetPosition: pos,
+          rationale: `Addresses user ${pos} ${level} need`,
+          category: 'need',
+          rankScore: NEED_WEIGHT[level] * slot.finalValue,
+        });
+        picked++;
+      }
+    }
+
+    // Category 2: surplus-arbitrage. Positions where the partner has
+    // surplus players AND the user has a need. Surplus players are
+    // the easiest to pry because the owner doesn't depend on them —
+    // we bump their rank score by 20% accordingly.
+    for (const [pos, summary] of partnerComp.byPosition) {
+      if (summary.surplusCount === 0) continue;
+      if (!needLevelByPos.has(pos)) continue;
+      // Best non-stash, non-taken player at this surplus position.
+      for (const slot of summary.players) {
+        if (takenIds.has(slot.playerId)) continue;
+        if (slot.tier === 'stash') continue;
+        takenIds.add(slot.playerId);
+        const level = needLevelByPos.get(pos) ?? 'depth';
+        perPartner.push({
+          partnerTeamId: partnerId,
+          targetPlayerId: slot.playerId,
+          targetPosition: pos,
+          rationale: `Partner has ${pos} surplus; easiest to acquire`,
+          category: 'surplus',
+          rankScore: NEED_WEIGHT[level] * slot.finalValue * 1.2,
+        });
+        break; // at most one surplus target per position per partner
+      }
+    }
+
+    // Category 3: pick-driven. Only relevant when the user is actually
+    // offering picks. Target mid/high-tier STARTERS — these are the
+    // players most likely to move for a pick + throw-in because the
+    // owner values future assets over a present-day mid-tier piece.
+    if (hasUserPicks) {
+      for (const [pos, summary] of partnerComp.byPosition) {
+        if (wantPos && pos !== wantPos) continue;
+        for (const slot of summary.players) {
+          if (takenIds.has(slot.playerId)) continue;
+          if (slot.tier !== 'mid' && slot.tier !== 'high') continue;
+          if (slot.role !== 'starter' && slot.role !== 'flex') continue;
+          takenIds.add(slot.playerId);
+          const level = needLevelByPos.get(pos) ?? 'depth';
+          perPartner.push({
+            partnerTeamId: partnerId,
+            targetPlayerId: slot.playerId,
+            targetPosition: pos,
+            rationale: `Pick-centric: mid-tier starter, a pick + throw-in could close the gap`,
+            category: 'pick',
+            rankScore: NEED_WEIGHT[level] * slot.finalValue * 0.9,
+          });
+          break; // at most one pick target per position per partner
+        }
+      }
+    }
+
+    // Rank this partner's contributions internally and keep the top
+    // `perPartnerLimit`. This prevents any single partner (e.g. a
+    // team with surplus at every position) from dominating the pool.
+    perPartner.sort((a, b) => b.rankScore - a.rankScore);
+    allTargets.push(...perPartner.slice(0, perPartnerLimit));
+  }
+
+  // Global sort + hard cap. Bounds fan-out concurrency and cost.
+  allTargets.sort((a, b) => b.rankScore - a.rankScore);
+  return allTargets.slice(0, totalLimit);
+}

--- a/server/src/services/tradeConstructor.ts
+++ b/server/src/services/tradeConstructor.ts
@@ -490,3 +490,327 @@ export async function constructTrades(
     return null;
   }
 }
+
+// ── Per-target focused construction (fan-out primitive) ─────────────
+//
+// constructTradeForTarget makes ONE focused call to construct the
+// single best realistic package for acquiring a specific player.
+// This is the primitive the trade finder fans out in parallel across
+// ~20-30 deterministic targets, replacing the old whole-league
+// mega-call. Much smaller prompt (one user roster + one partner roster
+// instead of ~12 team rosters), so each call finishes faster and
+// gives the model a much smaller attention budget per decision.
+
+export interface ConstructTargetArgs {
+  anthropicKey: string;
+  snapshot: LeagueContextSnapshot;
+  userTeamId: string;
+  partnerTeamId: string;
+  targetPlayerId: string;
+  /** Optional rationale from the target-selection step. Threaded into
+   *  the prompt so the model understands WHY we're targeting this
+   *  player (e.g. "Addresses user RB starter need"). */
+  rationale?: string | null;
+  /** Optional required user-side asset ids. When set, every valid
+   *  package must include at least one of these on the sent side. */
+  requiredUserPlayerIds?: string[] | null;
+  /** Optional user picks — the model is told they'll be threaded into
+   *  the trade separately and factors their value into the package. */
+  userPicks?: Array<{ year: number; round: number }> | null;
+}
+
+function buildTargetSystemPrompt(): string {
+  return `You are an elite fantasy football trade architect. Your job is to construct the SINGLE BEST realistic trade package the user could offer to acquire one specific target player from one specific partner team.
+
+### TWO HARD RULES
+
+RULE 1: THE TRADE MUST MAKE THE USER'S TEAM BETTER.
+RULE 2: THE PARTNER'S GM MUST ACTUALLY ACCEPT IT IN REAL LIFE.
+
+Both rules bind at the same time. If you cannot satisfy both, return null — no trade. A null answer is the correct answer when the user simply can't afford the target, or when the partner would never trade this player.
+
+### The packaging rule — avoid robberies
+
+When the target is an elite player, a SINGLE player on the user's side almost never matches value. You MUST pad the user's side with additional players or picks until the values on both sides are within ~15% of each other. Packages can be 1-5 players per side — use as many as the math requires.
+
+Example of a BAD package to never propose:
+  user sends: Jaxson Dart (rookie QB, [45/depth/bench])
+  user receives: Lamar Jackson (elite QB, [180/elite/starter])
+  → This is a ~75% value delta. No real GM accepts it. Either PAD or return null.
+
+${PICK_VALUE_REFERENCE}
+
+### Before finalizing, answer these four questions
+
+  A. Is the user clearly upgrading at a position they need, or
+     sidegrading? (If sidegrading, return null.)
+  B. If I were the partner's GM, would I be disgusted to accept
+     this? (If yes, pad the user's side until it feels fair.)
+  C. Is the deterministic value the user SENDS within 15% of what
+     they RECEIVE, using the [val] tags plus pick value?
+  D. Does the partner have a reason to say yes — addressing one of
+     their own needs, clearing a logjam, or getting clear value?
+
+### Core principles
+
+- AI-FIRST. The [val] tags are starting points. You may disagree
+  based on trends, coaching, or injury timeline — explain why in
+  the reasoning.
+- BOTH SIDES MUST WANT IT.
+- HONESTY. If no realistic package exists from this user roster,
+  return null. That's a valid, expected answer.
+
+### Constraints
+
+- Every sent player must be on the USER's roster (marked YOU).
+- Every received player must be on the PARTNER team's roster,
+  AND the target player MUST be included in receivedPlayerIds.
+- Packages can include 1-5 players per side.
+- Use the player IDs exactly as shown (id=... on each roster line).
+  NEVER invent or rename player IDs.
+- Do NOT include picks in sentPlayerIds — picks are threaded
+  separately by the caller.
+
+### Response format
+
+Respond with ONLY valid JSON in one of these two shapes:
+
+Shape A — a valid trade:
+{
+  "partnerTeamId": "team_id",
+  "sentPlayerIds": ["player_id", "player_id"],
+  "receivedPlayerIds": ["player_id"],
+  "userReasoning": "1-2 sentences on HOW THIS UPGRADES THE USER",
+  "partnerReasoning": "1-2 sentences on WHY THE PARTNER ACCEPTS",
+  "confidence": "high" | "medium" | "low"
+}
+
+Shape B — no realistic package exists:
+null
+
+Return the JSON ONLY, no prose.`;
+}
+
+// Compact per-team format for the focused prompt. Like
+// formatLeagueContextForConstructor but rendered for exactly one team,
+// with player IDs inline (id=...) so the model can echo them back
+// exactly in sentPlayerIds / receivedPlayerIds, and with the target
+// marked visually.
+function formatTeamForFocusedPrompt(
+  snap: LeagueContextSnapshot,
+  teamId: string,
+  opts: { label: 'YOU' | 'PARTNER'; markPlayerId?: string | null }
+): string {
+  const team = snap.teams.find((t) => t.id === teamId);
+  if (!team) return `(team ${teamId} not found)`;
+
+  const lines: string[] = [];
+  const labelSuffix = opts.label === 'YOU' ? ' (YOU)' : ' (PARTNER)';
+  const meta: string[] = [];
+  if (team.record) meta.push(team.record);
+  if (team.rank != null) meta.push(`#${team.rank}`);
+  lines.push(
+    `=== ${team.name}${labelSuffix}${meta.length ? ` [${meta.join(', ')}]` : ''} ===`
+  );
+
+  const needs = team.composition.needs.length > 0
+    ? team.composition.needs.map((n) => `${n.position}(${n.level})`).join(', ')
+    : '(none)';
+  lines.push(`Needs: ${needs}`);
+
+  for (const pos of ['QB', 'RB', 'WR', 'TE']) {
+    const summary = team.composition.byPosition.get(pos);
+    if (!summary || summary.players.length === 0) continue;
+    lines.push(`${pos}:`);
+    for (const slot of summary.players) {
+      const facts = snap.factsById.get(slot.playerId);
+      const name = facts?.name ?? slot.playerId;
+      const status = facts?.identity.status;
+      const statusTag =
+        status && status !== 'active' ? ` [${status.toUpperCase()}]` : '';
+      const tag = `[${Math.round(slot.finalValue)}/${slot.tier}/${slot.role}]`;
+      const marker =
+        opts.markPlayerId && slot.playerId === opts.markPlayerId
+          ? ' <<< TARGET'
+          : '';
+      lines.push(`  - ${name} ${tag} id=${slot.playerId}${statusTag}${marker}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function buildTargetUserMessage(args: ConstructTargetArgs): string {
+  const {
+    snapshot,
+    userTeamId,
+    partnerTeamId,
+    targetPlayerId,
+    rationale,
+    requiredUserPlayerIds,
+    userPicks,
+  } = args;
+
+  const targetFacts = snapshot.factsById.get(targetPlayerId);
+  const targetValuation = snapshot.valuations.get(targetPlayerId);
+  const partnerTeam = snapshot.teams.find((t) => t.id === partnerTeamId);
+
+  const lines: string[] = [];
+  lines.push(
+    `Construct the single best realistic trade package the user could offer to acquire this target player. Return JSON (trade or null) ONLY.`
+  );
+  lines.push('');
+  lines.push('=== TARGET ===');
+  if (targetFacts) {
+    const tag = targetValuation
+      ? ` [${Math.round(targetValuation.finalValue)}/${targetValuation.tier}]`
+      : '';
+    lines.push(
+      `${targetFacts.name} (${targetFacts.position}, ${targetFacts.nflTeam})${tag}`
+    );
+    lines.push(`id=${targetPlayerId}`);
+  } else {
+    lines.push(`Player id=${targetPlayerId} (facts unavailable)`);
+  }
+  lines.push(`On team: ${partnerTeam?.name ?? partnerTeamId}`);
+  if (rationale) {
+    lines.push(`Why we're targeting: ${rationale}`);
+  }
+  lines.push('');
+
+  // Filter block
+  const filterLines: string[] = [];
+  if (requiredUserPlayerIds && requiredUserPlayerIds.length > 0) {
+    filterLines.push(
+      `- REQUIRED USER ASSETS: every trade you construct MUST include at least one of these player ids in sentPlayerIds: ${requiredUserPlayerIds.join(', ')}`
+    );
+  }
+  if (userPicks && userPicks.length > 0) {
+    const picksStr = userPicks.map(formatPickAsset).join(', ');
+    filterLines.push(
+      `- BONUS USER ASSETS: the user is offering these draft picks as part of this trade: ${picksStr}.`
+    );
+    filterLines.push(
+      `  * Do NOT include picks in sentPlayerIds — the caller threads them separately.`
+    );
+    filterLines.push(
+      `  * DO factor the pick value into packaging. Because a pick is already on the user's side, the user-side PLAYER total can be LOWER than the partner-side player total — the pick fills the gap.`
+    );
+  }
+  if (filterLines.length > 0) {
+    lines.push('USER FILTERS:');
+    lines.push(...filterLines);
+    lines.push('');
+  }
+
+  lines.push(
+    'NOTE: use the player IDs shown as id=... on each roster line. Echo them exactly in sentPlayerIds / receivedPlayerIds.'
+  );
+  lines.push('');
+  lines.push(
+    formatTeamForFocusedPrompt(snapshot, userTeamId, { label: 'YOU' })
+  );
+  lines.push('');
+  lines.push(
+    formatTeamForFocusedPrompt(snapshot, partnerTeamId, {
+      label: 'PARTNER',
+      markPlayerId: targetPlayerId,
+    })
+  );
+  lines.push('');
+  lines.push(
+    `Now produce JSON: either one balanced trade package that acquires the TARGET, or null if no realistic package exists from this user roster. JSON ONLY.`
+  );
+
+  return lines.join('\n');
+}
+
+// Parse the single-trade response. Unlike constructTrades, this call
+// returns ONE trade or null — not a trades array.
+function coerceSingleTradeResponse(raw: unknown): ConstructedTrade | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object') return null;
+  const item = raw as RawTrade;
+  if (typeof item.partnerTeamId !== 'string') return null;
+  if (!isStringArray(item.sentPlayerIds)) return null;
+  if (!isStringArray(item.receivedPlayerIds)) return null;
+  if (item.sentPlayerIds.length === 0 || item.receivedPlayerIds.length === 0) {
+    return null;
+  }
+  return {
+    partnerTeamId: item.partnerTeamId,
+    sentPlayerIds: item.sentPlayerIds,
+    receivedPlayerIds: item.receivedPlayerIds,
+    userReasoning:
+      typeof item.userReasoning === 'string' ? item.userReasoning : '',
+    partnerReasoning:
+      typeof item.partnerReasoning === 'string' ? item.partnerReasoning : '',
+    confidence: coerceConfidence(item.confidence),
+  };
+}
+
+export async function constructTradeForTarget(
+  args: ConstructTargetArgs
+): Promise<ConstructedTrade | null> {
+  const { anthropicKey } = args;
+
+  const systemPrompt = buildTargetSystemPrompt();
+  const userMessage = buildTargetUserMessage(args);
+
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': anthropicKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        // Single trade + reasoning fits comfortably in 800 tokens.
+        max_tokens: 900,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: userMessage }],
+        temperature: 0.5,
+      }),
+      // Per-target calls are small; 30s is plenty.
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!res.ok) {
+      console.error(
+        '[tradeConstructor.target] AI call failed:',
+        res.status,
+        await res.text().catch(() => '')
+      );
+      return null;
+    }
+
+    const data = (await res.json()) as {
+      content?: { type: string; text?: string }[];
+    };
+    const textBlock = data.content?.find((b) => b.type === 'text');
+    const rawText = textBlock?.text?.trim();
+    if (!rawText) return null;
+
+    // Strip code fences and any "null" literal the model might emit.
+    const jsonStr = rawText.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+    if (jsonStr === 'null' || jsonStr === '') return null;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch (parseErr) {
+      console.error(
+        '[tradeConstructor.target] JSON parse failed:',
+        parseErr,
+        jsonStr.slice(0, 200)
+      );
+      return null;
+    }
+
+    return coerceSingleTradeResponse(parsed);
+  } catch (err) {
+    console.error('[tradeConstructor.target] construct failed:', err);
+    return null;
+  }
+}

--- a/server/src/services/tradeFinder.ts
+++ b/server/src/services/tradeFinder.ts
@@ -1,7 +1,8 @@
 /**
  * Trade Finder (Feature 2).
  *
- * Three-stage pipeline:
+ * Pipeline: deterministic target selection → parallel per-target AI
+ * construction → validation → trusted-analyzer verification → filter.
  *
  *  Stage 1 — deterministic scoping (no AI, ~50ms):
  *   1. Load rosters for every team in the league.
@@ -11,27 +12,32 @@
  *      depth, who is surplus, and which positions are a real need.
  *   5. Format the whole league as a compact snapshot for the AI prompt.
  *
- *  Stage 2 — single AI mega-call (constructTrades):
- *   6. Hand the whole league snapshot to Claude in ONE call. Claude
- *      compares every team holistically and constructs 5-6 mutually
- *      beneficial trades, with reasoning for both sides.
- *   7. Validate the AI output:
- *        a) ownership — every sent player on user roster, every
- *           received player on the named partner team
- *        b) value sanity — deterministic valuation delta within 30%
- *        c) drop hallucinations and robberies
+ *  Stage 2 — parallel per-target construction (fan-out):
+ *   6. selectAcquisitionTargets picks ~20-30 concrete acquisition
+ *      targets across the league (need-driven + surplus-arbitrage +
+ *      pick-driven) using deterministic logic from teamComposition.
+ *      If targetPlayerId is set, Stage 1 emits exactly one target.
+ *   7. Fan out one constructTradeForTarget call per target in
+ *      parallel with a concurrency cap. Each call gets a focused
+ *      prompt (user roster + one partner roster) and returns a
+ *      single trade or null.
+ *   8. Dedupe survivors and run them through validateConstructedTrade
+ *      — roster ownership, value sanity, filter respects.
  *
  *  Stage 3 — verification pass (parallel AI grading):
- *   8. Run each surviving constructed trade through analyzeCandidateWithAI
+ *   9. Run each surviving constructed trade through analyzeCandidateWithAI
  *      — the trusted analyzer prompt — to get an independent fairness
  *      score, winner, and team grades.
- *   9. Filter trades whose fairness diff exceeds MAX_FAIRNESS_DIFF and
+ *  10. Filter trades whose fairness diff exceeds MAX_FAIRNESS_DIFF and
  *      return the survivors sorted most-fair-first.
  *
- * Fallback chain: if the constructor call fails or returns zero valid
- * trades, fall back to the deterministic needs-aware matcher; if that
- * also returns nothing, fall back to the legacy brute-force generator.
- * The user always sees something rather than an empty state.
+ * Empty-state policy: if the fan-out returns zero valid candidates,
+ * we return an empty recommendations array. We do NOT silently fall
+ * back to the old mega-call, the matcher, or brute-force generation
+ * from this path — fan-out already tries 20-30 targeted constructions,
+ * and a zero here is a genuine signal that no realistic deal exists.
+ * The legacy matcher + brute-force modules remain in the file but are
+ * no longer invoked from the finder's primary code path.
  *
  * Team Needs Dashboard is a separate AI-generated narrative — see
  * buildTeamNeeds below. It uses the same Claude client but a different
@@ -63,7 +69,9 @@ import {
 } from './playerValuation';
 import {
   buildTeamComposition,
+  selectAcquisitionTargets,
   type TeamComposition,
+  type AcquisitionTarget,
 } from './teamComposition';
 import {
   matchTrades,
@@ -72,6 +80,7 @@ import {
 } from './tradeMatcher';
 import {
   constructTrades,
+  constructTradeForTarget,
   type ConstructedTrade,
 } from './tradeConstructor';
 import {
@@ -261,6 +270,10 @@ interface FindRecommendationsArgs {
   leagueType?: 'redraft' | 'dynasty' | 'keeper';
   targetPosition?: string | null;
   targetTeamId?: string | null;
+  /** If set, the finder skips target-selection and goes straight to
+   *  a single focused construction call for this exact player. The
+   *  player must exist on a team other than the user's. */
+  targetPlayerId?: string | null;
   maxRecommendations?: number;
   /** Optional: if set, the user's candidate pool is restricted to
    *  these player IDs (all must be on their roster). Picks are not
@@ -284,6 +297,7 @@ export async function findTradeRecommendations(
     leagueType = 'redraft',
     targetPosition,
     targetTeamId,
+    targetPlayerId,
     maxRecommendations = 5,
     userPlayerIds,
     userPicks,
@@ -412,16 +426,22 @@ export async function findTradeRecommendations(
     settings: leagueSettings,
   };
 
-  // 6. Stage 2 — call the constructor mega-call. ONE AI request that
-  //    sees the whole league and returns candidate trades.
+  // 6. Stage 2 — parallel per-target fan-out.
   //
-  //    If the standard pass returns too few valid candidates (which
-  //    happens most often when the user specified a draft pick, or
-  //    when roster shape is unusual), we fire a CREATIVE retry that
-  //    runs hotter and is explicitly prompted to explore less-obvious
-  //    angles — positional arbitrage, bench-for-starter swaps,
-  //    pick-centric deals, weaker partners, etc. Results are merged,
-  //    deduped, and flow into the same validation pipeline.
+  //    Instead of one mega-call that sees the whole league and has
+  //    to pick 8 trades, we:
+  //      (a) deterministically select ~20-30 concrete acquisition
+  //          targets using teamComposition (needs + surplus + picks),
+  //      (b) fan out one focused constructTradeForTarget call per
+  //          target in parallel (concurrency-capped),
+  //      (c) dedupe survivors and feed them into the existing
+  //          validation + verification + filter pipeline.
+  //
+  //    Targeted construction gives each decision its own attention
+  //    budget, so the AI stops going lazy and converging on a single
+  //    "safe" idea. If the user specified targetPlayerId (new UI
+  //    input), Stage 1 is skipped and we fan out a single call for
+  //    that exact target.
   type ValidatedTrade = {
     targetTeamId: string;
     sendPlayerIds: string[];
@@ -435,153 +455,161 @@ export async function findTradeRecommendations(
     : null;
   const hasUserPicks = normalizedPicks.length > 0;
 
-  const runAndValidate = async (
-    mode: 'standard' | 'creative',
-    desiredCount: number
-  ): Promise<ValidatedTrade[]> => {
-    const result = await constructTrades({
-      anthropicKey,
-      snapshot,
-      filters: {
-        targetPosition: targetPosition ?? null,
-        requiredUserPlayerIds: restrictUserAssets,
-        userPicks: hasUserPicks ? normalizedPicks : null,
-        desiredCount,
-        mode,
-      },
-    });
-    const validated: ValidatedTrade[] = [];
-    if (!result || result.trades.length === 0) {
+  // 6a. Build the target list.
+  let targets: AcquisitionTarget[];
+  if (targetPlayerId) {
+    // User asked for one specific player — find them on whichever
+    // partner team owns them and emit exactly one target. Defensive
+    // checks here so a bad client payload can't crash the call.
+    let targetOwnerId: string | null = null;
+    for (const partnerId of partnerTeamIds) {
+      const roster = rosterByTeam.get(partnerId);
+      if (roster && roster.some((r) => r.playerId === targetPlayerId)) {
+        targetOwnerId = partnerId;
+        break;
+      }
+    }
+    if (!targetOwnerId) {
       console.log(
-        `[tradeFinder] constructor ${mode} returned 0 trades` +
-          (result?.notes ? ` — notes: ${result.notes.slice(0, 120)}` : '')
+        `[tradeFinder] targetPlayerId=${targetPlayerId} not on any allowed partner team — returning empty`
       );
-      return validated;
+      return [];
     }
-    for (const trade of result.trades) {
-      const reason = validateConstructedTrade(
-        trade,
-        userTeamId,
-        userRosterPlayerIds,
-        rosterByTeam,
-        allowedPartnerIds,
-        targetPosition ?? null,
-        requiredAssetSet,
-        valuations,
-        factsById,
-        hasUserPicks
-      );
-      if (reason !== null) {
-        console.log(
-          `[tradeFinder] dropped ${mode} constructed trade: ${reason}`,
-          trade.sentPlayerIds,
-          '→',
-          trade.receivedPlayerIds
-        );
-        continue;
-      }
-      validated.push({
-        targetTeamId: trade.partnerTeamId,
-        sendPlayerIds: trade.sentPlayerIds,
-        receivePlayerIds: trade.receivedPlayerIds,
-        fit: {
-          forYou: trade.userReasoning ? [trade.userReasoning] : [],
-          forThem: trade.partnerReasoning ? [trade.partnerReasoning] : [],
-          userNeedsMet: [],
-          partnerNeedsMet: [],
-        },
-      });
-    }
-    return validated;
-  };
-
-  // Standard pass first. Always runs.
-  let validatedFromConstructor = await runAndValidate(
-    'standard',
-    Math.max(maxRecommendations + 2, 8)
-  );
-  console.log(
-    `[tradeFinder] standard pass produced ${validatedFromConstructor.length} valid candidates`
-  );
-
-  // Creative retry if the standard pass is thin. Threshold: fewer than
-  // half of what the user asked for. The retry almost always fires
-  // when picks are involved because the standard pass is more
-  // conservative about pick-for-player packaging.
-  const MIN_CANDIDATES_BEFORE_RETRY = Math.max(
-    Math.ceil(maxRecommendations / 2),
-    2
-  );
-  if (validatedFromConstructor.length < MIN_CANDIDATES_BEFORE_RETRY) {
+    const facts = factsById.get(targetPlayerId);
+    const pos = (facts?.position ?? '').toUpperCase();
+    targets = [
+      {
+        partnerTeamId: targetOwnerId,
+        targetPlayerId,
+        targetPosition: pos,
+        rationale: 'User-specified target player',
+        category: 'need',
+        rankScore: 1,
+      },
+    ];
     console.log(
-      `[tradeFinder] only ${validatedFromConstructor.length} < ${MIN_CANDIDATES_BEFORE_RETRY} candidates — running creative retry`
-    );
-    const creativeResults = await runAndValidate(
-      'creative',
-      Math.max(maxRecommendations + 2, 8)
-    );
-    console.log(
-      `[tradeFinder] creative pass added ${creativeResults.length} candidates`
-    );
-
-    // Dedupe by (send set, receive set, partner)
-    const seenKeys = new Set<string>();
-    const makeKey = (v: ValidatedTrade) =>
-      `${v.targetTeamId}|${[...v.sendPlayerIds].sort().join(',')}|${[...v.receivePlayerIds].sort().join(',')}`;
-    for (const v of validatedFromConstructor) seenKeys.add(makeKey(v));
-    for (const v of creativeResults) {
-      const k = makeKey(v);
-      if (!seenKeys.has(k)) {
-        seenKeys.add(k);
-        validatedFromConstructor.push(v);
-      }
-    }
-  }
-
-  // 8. Decide which set of survivors moves to the verification pass.
-  //    Primary: validated constructor output.
-  //    Fallback 1: deterministic needs-aware matcher.
-  //    Fallback 2: legacy brute-force generator.
-  let topGlobal: ValidatedTrade[];
-
-  if (validatedFromConstructor.length > 0) {
-    topGlobal = validatedFromConstructor.slice(
-      0,
-      Math.max(maxRecommendations, 5)
+      `[tradeFinder] fan-out: single user-specified target ${facts?.name ?? targetPlayerId} on team ${targetOwnerId}`
     );
   } else {
-    console.log(
-      '[tradeFinder] constructor returned 0 valid trades, falling back to matcher'
-    );
-    topGlobal = runMatcherFallback({
-      partnerTeamIds,
-      compositionsByTeam,
+    targets = selectAcquisitionTargets({
       userComp,
-      valuations,
-      factsById,
-      leagueSettings,
+      compositionsByTeam,
+      partnerTeamIds,
       targetPosition: targetPosition ?? null,
-      restrictUserAssets,
-      maxRecommendations,
+      hasUserPicks,
     });
-
-    if (topGlobal.length === 0) {
-      console.log(
-        '[tradeFinder] matcher fallback empty, using brute-force generator'
-      );
-      topGlobal = runBruteForceFallback({
-        partnerTeamIds,
-        rosterByTeam,
-        userRoster,
-        restrictUserAssets,
-        targetPosition: targetPosition ?? null,
-        factsById,
-        maxRecommendations,
-      });
+    console.log(
+      `[tradeFinder] fan-out: ${targets.length} targets selected across ${new Set(targets.map((t) => t.partnerTeamId)).size} partners`
+    );
+    if (targets.length === 0) {
+      return [];
     }
   }
 
-  if (topGlobal.length === 0) return [];
+  // 6b. Fan out focused construction calls with a concurrency cap so
+  //     we don't hammer the Anthropic API with 30 simultaneous requests.
+  const FAN_OUT_CONCURRENCY = 8;
+  const constructed: Array<ConstructedTrade & { target: AcquisitionTarget }> = [];
+
+  // Simple worker-pool: each worker pulls the next index until the
+  // queue is empty. Preserves parallelism while capping concurrency.
+  let nextIdx = 0;
+  const worker = async () => {
+    while (true) {
+      const idx = nextIdx++;
+      if (idx >= targets.length) return;
+      const target = targets[idx];
+      const trade = await constructTradeForTarget({
+        anthropicKey,
+        snapshot,
+        userTeamId,
+        partnerTeamId: target.partnerTeamId,
+        targetPlayerId: target.targetPlayerId,
+        rationale: target.rationale,
+        requiredUserPlayerIds: restrictUserAssets,
+        userPicks: hasUserPicks ? normalizedPicks : null,
+      });
+      if (trade) constructed.push({ ...trade, target });
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(FAN_OUT_CONCURRENCY, targets.length) }, () =>
+      worker()
+    )
+  );
+  console.log(
+    `[tradeFinder] fan-out: ${constructed.length}/${targets.length} targets returned a candidate`
+  );
+
+  // 6c. Dedupe by (partner, sortedSendIds, sortedReceiveIds). Targets
+  //     often converge on the same package (e.g. two targets on the
+  //     same team where only one is realistically obtainable).
+  const seenKeys = new Set<string>();
+  const dedupedConstructed: typeof constructed = [];
+  for (const c of constructed) {
+    const key = `${c.partnerTeamId}|${[...c.sentPlayerIds].sort().join(',')}|${[...c.receivedPlayerIds].sort().join(',')}`;
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    dedupedConstructed.push(c);
+  }
+
+  // 6d. Run survivors through the existing validation gauntlet —
+  //     ownership, filter respects, and value sanity.
+  const validated: ValidatedTrade[] = [];
+  for (const trade of dedupedConstructed) {
+    const reason = validateConstructedTrade(
+      trade,
+      userTeamId,
+      userRosterPlayerIds,
+      rosterByTeam,
+      allowedPartnerIds,
+      // When the user picked a specific target, targetPosition is
+      // implicit (the target's position); skip the position filter
+      // so we don't double-enforce and drop the single-target trade.
+      targetPlayerId ? null : (targetPosition ?? null),
+      requiredAssetSet,
+      valuations,
+      factsById,
+      hasUserPicks
+    );
+    if (reason !== null) {
+      console.log(
+        `[tradeFinder] dropped fan-out trade: ${reason}`,
+        trade.sentPlayerIds,
+        '→',
+        trade.receivedPlayerIds
+      );
+      continue;
+    }
+    validated.push({
+      targetTeamId: trade.partnerTeamId,
+      sendPlayerIds: trade.sentPlayerIds,
+      receivePlayerIds: trade.receivedPlayerIds,
+      fit: {
+        forYou: trade.userReasoning ? [trade.userReasoning] : [],
+        forThem: trade.partnerReasoning ? [trade.partnerReasoning] : [],
+        userNeedsMet: [],
+        partnerNeedsMet: [],
+      },
+    });
+  }
+  console.log(
+    `[tradeFinder] fan-out: ${validated.length} candidates passed validation`
+  );
+
+  // Honest empty state: if fan-out + validation found nothing, return
+  // empty. No silent fallback to the matcher or brute-force — if 20+
+  // targeted constructions couldn't find a realistic deal, a blind
+  // generator won't either, and a "fallback" result would confuse the
+  // user by hiding a real signal ("there's genuinely nothing here").
+  if (validated.length === 0) {
+    return [];
+  }
+
+  const topGlobal: ValidatedTrade[] = validated.slice(
+    0,
+    Math.max(maxRecommendations, 5)
+  );
 
   // 7. Pre-fetch enrichment (season stats, trend, news) for every
   //    player that appears in any surviving candidate. This matches

--- a/src/components/TradeFinderView.tsx
+++ b/src/components/TradeFinderView.tsx
@@ -10,6 +10,7 @@ import {
   ArrowRight,
   Plus,
   X,
+  Target,
 } from 'lucide-react';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
@@ -134,6 +135,15 @@ export function TradeFinderView({
   // The user's own roster — needed to populate the asset picker
   const [myRoster, setMyRoster] = useState<MyRosterBrief | null>(null);
 
+  // Every other team's roster in the league — powers the
+  // "Target a specific player" picker. Excludes the user's own roster.
+  const [otherRosters, setOtherRosters] = useState<MyRosterBrief[]>([]);
+  // Selected target player id (optional). When set, the finder runs
+  // a single focused construction call for this exact player instead
+  // of scanning the whole league.
+  const [targetPlayerId, setTargetPlayerId] = useState<string>('');
+  const [showTargetPicker, setShowTargetPicker] = useState(false);
+
   const tierAllowed =
     !!user && (user.subscriptionTier === 'pro' || user.subscriptionTier === 'elite');
 
@@ -183,7 +193,32 @@ export function TradeFinderView({
   useEffect(() => {
     setAssetPlayerIds([]);
     setAssetPicks([]);
+    setTargetPlayerId('');
   }, [selectedLeagueId]);
+
+  // Load every team's roster in the league so the "Target a specific
+  // player" picker has something to show. Excludes the user's own team.
+  useEffect(() => {
+    if (!selectedLeagueId || !myRoster) {
+      setOtherRosters([]);
+      return;
+    }
+    let cancelled = false;
+    api
+      .get<{ teams: MyRosterBrief[] }>(`/rosters/${selectedLeagueId}/all`)
+      .then((data) => {
+        if (cancelled) return;
+        setOtherRosters(
+          (data.teams ?? []).filter((t) => t.teamId !== myRoster.teamId)
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setOtherRosters([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedLeagueId, myRoster]);
 
   const addAssetPlayer = (playerId: string) => {
     setAssetPlayerIds((prev) =>
@@ -218,6 +253,7 @@ export function TradeFinderView({
           leagueId: selectedLeagueId,
           targetPosition: filterPosition || undefined,
           targetTeamId: filterTeam || undefined,
+          targetPlayerId: targetPlayerId || undefined,
           userPlayerIds: assetPlayerIds.length > 0 ? assetPlayerIds : undefined,
           userPicks: assetPicks.length > 0 ? assetPicks : undefined,
         }
@@ -235,7 +271,7 @@ export function TradeFinderView({
   useEffect(() => {
     setHasSearched(false);
     setRecommendations([]);
-  }, [selectedLeagueId, filterPosition, assetPlayerIds, assetPicks]);
+  }, [selectedLeagueId, filterPosition, assetPlayerIds, assetPicks, targetPlayerId]);
 
   if (!tierAllowed) {
     return (
@@ -728,6 +764,142 @@ export function TradeFinderView({
                       Add Pick
                     </button>
                   </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Target a specific player (optional) — when set, the
+              finder runs a single focused construction call for this
+              exact player instead of scanning the whole league. */}
+          <div
+            className={`border-t pt-3 ${
+              isDarkMode ? 'border-slate-800' : 'border-slate-200'
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => setShowTargetPicker((v) => !v)}
+              className={`flex items-center gap-2 text-xs font-semibold uppercase tracking-wide ${
+                isDarkMode
+                  ? 'text-slate-400 hover:text-slate-300'
+                  : 'text-slate-500 hover:text-slate-600'
+              }`}
+            >
+              {showTargetPicker ? (
+                <ChevronDown className="w-3.5 h-3.5" />
+              ) : (
+                <ChevronRight className="w-3.5 h-3.5" />
+              )}
+              Target a specific player (optional)
+              {targetPlayerId && (
+                <span
+                  className={`ml-1 text-[10px] font-bold px-1.5 py-0.5 rounded ${
+                    isDarkMode
+                      ? 'bg-purple-500/20 text-purple-300'
+                      : 'bg-purple-50 text-purple-700'
+                  }`}
+                >
+                  1
+                </span>
+              )}
+            </button>
+            {showTargetPicker && (
+              <div className="mt-3 space-y-3">
+                <p
+                  className={`text-xs ${
+                    isDarkMode ? 'text-slate-400' : 'text-slate-500'
+                  }`}
+                >
+                  Pick any player in the league. The finder will try to
+                  build one realistic package to acquire them instead of
+                  scanning for general fits. Leave empty to let the finder
+                  search across the whole league.
+                </p>
+
+                {/* Current selection pill */}
+                {targetPlayerId && (() => {
+                  const found = otherRosters
+                    .flatMap((t) =>
+                      [
+                        ...(t.roster.starters || []),
+                        ...(t.roster.bench || []),
+                        ...(t.roster.ir || []),
+                      ].map((p) => ({ team: t.teamName, ...p }))
+                    )
+                    .find((p) => p.playerId === targetPlayerId);
+                  if (!found) return null;
+                  return (
+                    <div className="flex flex-wrap gap-1.5">
+                      <span
+                        className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-full ${
+                          isDarkMode
+                            ? 'bg-purple-500/20 text-purple-200'
+                            : 'bg-purple-50 text-purple-800'
+                        }`}
+                      >
+                        <Target className="w-3 h-3" />
+                        <span className="text-[9px] opacity-70">
+                          {found.position}
+                        </span>
+                        {found.name}
+                        <span className="text-[9px] opacity-70">
+                          ({found.team})
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => setTargetPlayerId('')}
+                          className="hover:opacity-70"
+                        >
+                          <X className="w-3 h-3" />
+                        </button>
+                      </span>
+                    </div>
+                  );
+                })()}
+
+                <div>
+                  <label
+                    className={`block text-[10px] font-bold uppercase mb-1 ${
+                      isDarkMode ? 'text-slate-400' : 'text-slate-500'
+                    }`}
+                  >
+                    Pick a player from any opponent
+                  </label>
+                  <select
+                    value={targetPlayerId}
+                    onChange={(e) => setTargetPlayerId(e.target.value)}
+                    disabled={otherRosters.length === 0}
+                    className={`w-full px-3 py-2 text-sm rounded-lg border ${
+                      isDarkMode
+                        ? 'bg-slate-800 border-slate-600 text-white'
+                        : 'bg-white border-slate-300 text-slate-900'
+                    } outline-none disabled:opacity-50`}
+                  >
+                    <option value="">
+                      {otherRosters.length === 0
+                        ? 'Loading league rosters...'
+                        : 'Any player — let the finder decide'}
+                    </option>
+                    {otherRosters.map((team) => {
+                      const players = [
+                        ...(team.roster.starters || []),
+                        ...(team.roster.bench || []),
+                      ].filter(
+                        (p) => p.position !== 'K' && p.position !== 'DEF'
+                      );
+                      if (players.length === 0) return null;
+                      return (
+                        <optgroup key={team.teamId} label={team.teamName}>
+                          {players.map((p) => (
+                            <option key={p.playerId} value={p.playerId}>
+                              {p.position} • {p.name}
+                            </option>
+                          ))}
+                        </optgroup>
+                      );
+                    })}
+                  </select>
                 </div>
               </div>
             )}


### PR DESCRIPTION
The single whole-league constructor call was converging on lazy "safe" ideas and regularly returning zero valid candidates. Replace it with ~20-30 deterministic target picks (need-driven + surplus arbitrage + pick-centric) each getting their own focused construction call in parallel. Also wire up a "Target a specific player" UI input that runs a single focused call for an exact opponent player.

- server/src/services/teamComposition.ts: add selectAcquisitionTargets (3 per opponent, globally capped at 30, ranked by need weight × value).
- server/src/services/tradeConstructor.ts: add constructTradeForTarget, a focused single-target primitive with player IDs inline in the prompt so the model echoes them exactly instead of hallucinating.
- server/src/services/tradeFinder.ts: replace the mega-call + matcher/brute-force fallback chain with a worker-pool fan-out (concurrency 8), dedupe, reuse the existing validate → analyze → filter pipeline. Return honest empty state on zero results — no silent fallback to the old generator.
- server/src/routes/tradeFinder.ts: accept targetPlayerId, thread it through, bump CACHE_VERSION to v5 to invalidate stale results.
- src/components/TradeFinderView.tsx: add "Target a specific player" collapsible with an optgroup-by-team combobox sourced from /rosters/:leagueId/all.

https://claude.ai/code/session_01PaHiRFLZ8hUiFAzEC93XWT