### PR TITLE
Matcher: scan all positions and relax mutual-benefit in opt-in mode

### DIFF
--- a/server/src/routes/tradeFinder.ts
+++ b/server/src/routes/tradeFinder.ts
@@ -379,12 +379,12 @@ tradeFinderRoutes.post('/recommendations', authMiddleware, async (c) => {
     // that would make previously cached results invalid (e.g. tighter
     // filters, new analyzer inputs). Bump it here when we ship fixes
     // that would make a user say "the old trade is still showing up".
-    // v6: switched the finder from generate → verify to enumerate →
-    //     rank → verify. Matcher is now pick-aware and required-asset
-    //     seeded; Claude ranks a deterministic pool instead of
-    //     freely constructing trades. Cached v5 results were built
-    //     against the old pipeline and should be invalidated.
-    const CACHE_VERSION = 'v6';
+    // v7: matcher now scans all skill positions and relaxes mutual
+    //     benefit when the user has opted in with filters (required
+    //     assets or picks). Fixes "Tank Dell + 1st for a better WR"
+    //     returning empty because WR wasn't in the user's computed
+    //     needs.
+    const CACHE_VERSION = 'v7';
     const todayKey = new Date().toISOString().slice(0, 10);
     const sortedPlayerIds = [...(body.userPlayerIds ?? [])].sort();
     const sortedPicks = [...(body.userPicks ?? [])]

--- a/server/src/services/tradeMatcher.ts
+++ b/server/src/services/tradeMatcher.ts
@@ -30,7 +30,6 @@ import { sumValue } from './playerValuation';
 import type {
   TeamComposition,
   NeedLevel,
-  PositionSummary,
 } from './teamComposition';
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -529,23 +528,41 @@ export function matchTrades(args: MatchTradesArgs): MatchedCandidate[] {
   const candidates: MatchedCandidate[] = [];
   const seenKeys = new Set<string>(); // dedupe identical packages
 
-  const userNeedsList =
-    userComp.needs.length > 0
-      ? userComp.needs
-      : [
-          // No explicit needs → still try to upgrade via tier jumps at
-          // any skill position. Treated as 'depth' needs so the matcher
-          // will still generate candidates.
-          ...Array.from(userComp.byPosition.values())
-            .filter((s): s is PositionSummary => !!s)
-            .map((s) => ({ position: s.position, level: 'depth' as NeedLevel })),
-        ];
+  // Which partner positions should the matcher scan?
+  //
+  // Rule:
+  //  - targetPosition set         → only that position
+  //  - user has filters (restrict assets or picks) → ALL skill
+  //    positions, because the user has explicitly opted in and
+  //    wants to see what's possible, not just what their computed
+  //    needs say. Without this, "I want to trade my WR + a pick
+  //    for a better WR" dies silently when WR isn't in the
+  //    computed needs list.
+  //  - otherwise                  → computed needs list (or all
+  //    skill positions if the user has no computed needs)
+  const userHasFilters =
+    (restrictUserAssets != null && restrictUserAssets.length > 0) ||
+    pickValueSum > 0;
+
+  const ALL_SKILL_POSITIONS = ['QB', 'RB', 'WR', 'TE'] as const;
+  let userNeedsList: Array<{ position: string; level: NeedLevel }>;
+
+  if (targetPosition) {
+    const pos = targetPosition.toUpperCase();
+    const existing = userComp.needs.find((n) => n.position === pos);
+    userNeedsList = [{ position: pos, level: existing?.level ?? 'depth' }];
+  } else if (userHasFilters || userComp.needs.length === 0) {
+    // Opt-in mode OR no computed needs — scan every skill position.
+    userNeedsList = ALL_SKILL_POSITIONS.map((pos) => {
+      const existing = userComp.needs.find((n) => n.position === pos);
+      return { position: pos, level: existing?.level ?? ('depth' as NeedLevel) };
+    });
+  } else {
+    userNeedsList = userComp.needs;
+  }
 
   for (const seed of seeds) {
     for (const need of userNeedsList) {
-      // If the user filtered by targetPosition, only consider that position
-      if (targetPosition && need.position !== targetPosition.toUpperCase()) continue;
-
       const partnerSummary = partnerComp.byPosition.get(need.position);
       if (!partnerSummary) continue;
 
@@ -586,12 +603,29 @@ export function matchTrades(args: MatchTradesArgs): MatchedCandidate[] {
           const userNeedsMet = needsMetBy(userComp, pair.receive, valuations);
           const partnerNeedsMet = needsMetBy(partnerComp, pair.send, valuations);
 
-          // Mutual benefit guard — both sides must address at least one
-          // need. Exception: partner has zero needs (juggernaut team) —
-          // one-sided deals allowed because the partner might move depth
-          // for a marginal upgrade + user-offered picks.
-          if (userNeedsMet.length === 0) continue;
-          if (partnerComp.needs.length > 0 && partnerNeedsMet.length === 0) continue;
+          // Mutual benefit guard — relaxed in opt-in mode.
+          //
+          // Default mode: both sides must address at least one need.
+          //   Otherwise every search would return "value-matched
+          //   but nobody wants it" trades.
+          //
+          // Opt-in (user has filters): skip the user-side check —
+          //   the user already said "I want to move these assets."
+          //   Requiring their received player to meet a computed
+          //   need blocks "upgrade at a position you already have
+          //   coverage at" trades.
+          //
+          // Opt-in (user offers picks): also skip the partner-side
+          //   check — the pick is the sweetener. Many partners
+          //   accept a pick + filler for their spare starter without
+          //   the filler itself addressing a partner need.
+          const userCheckOk = userHasFilters || userNeedsMet.length > 0;
+          const partnerCheckOk =
+            partnerComp.needs.length === 0 ||
+            partnerNeedsMet.length > 0 ||
+            pickValueSum > 0;
+          if (!userCheckOk) continue;
+          if (!partnerCheckOk) continue;
 
           // Pick-aware value totals: pickValueSum is added to the user
           // side because that's what the partner actually receives


### PR DESCRIPTION
Three bugs were combining to kill "Tank Dell + 1st for a better WR":

1. The matcher's main loop iterated userComp.needs to decide which partner positions to scan. If WR wasn't in the user's computed needs (e.g. WR is rated "depth" or "none"), the matcher NEVER looked at any partner's WRs — so a WR upgrade was structurally impossible regardless of how valuable the partner's WR was.

2. needsMetBy returned empty for positions where needLevel='none'. The mutual-benefit guard then dropped any trade where the received player was a "tier upgrade" at a position the user already had coverage at, even though upgrading a position the user already owns is a perfectly valid reason to trade.

3. The partner-side needsMet check required Tank Dell (or whatever the user sends) to address one of the partner's computed needs. But when the user throws in a 1st-round pick, the pick itself is the enticement — partners accept depth + a pick without the depth piece needing to plug a hole.

Fix: introduce userHasFilters = restrictUserAssets || pickValueSum > 0. When true:
  - Scan ALL skill positions (QB/RB/WR/TE) on the partner side, not just user's computed needs.
  - Skip the user-side mutual-benefit check. The user has already said "I want to move these assets."
  - When pickValueSum > 0, also skip the partner-side check. The pick is the sweetener.

Default mode (no user filters) stays strict — the matcher still requires mutual need fit to prevent "value-matched but nobody wants it" junk trades when the user is browsing without intent.

CACHE_VERSION bumped v6 → v7.

https://claude.ai/code/session_01PaHiRFLZ8hUiFAzEC93XWT