### PR TITLE
Trade Finder: add Suggested Targets browse step (Ideas A+B)

### DIFF
--- a/server/src/routes/tradeFinder.ts
+++ b/server/src/routes/tradeFinder.ts
@@ -7,8 +7,10 @@ import type { Env, Variables } from '../index';
 import {
   buildTeamNeeds,
   findTradeRecommendations,
+  findSuggestedTargets,
   type TeamNeeds,
   type TradeRecommendation,
+  type SuggestedTargetsResult,
 } from '../services/tradeFinder';
 import type { LeagueSettings } from '../services/tradeContext';
 
@@ -465,6 +467,137 @@ tradeFinderRoutes.post('/recommendations', authMiddleware, async (c) => {
     return c.json(
       {
         error: 'Failed to build trade recommendations.',
+        requestId,
+        detail: c.env.ENVIRONMENT === 'development' ? msg : undefined,
+      },
+      502
+    );
+  }
+});
+
+// ── POST /targets ────────────────────────────────────────────────────
+// Deterministic "players you should pursue" list. Zero AI calls —
+// powers the browse step of the Trade Finder. Users see this list
+// first, pick a target, and the /recommendations endpoint then
+// builds offer packages for that specific player.
+
+interface TargetsBody {
+  leagueId: string;
+}
+
+tradeFinderRoutes.post('/targets', authMiddleware, async (c) => {
+  const user = c.get('user');
+  const db = c.get('db');
+  if (!user) return c.json({ error: 'Unauthorized' }, 401);
+
+  const tier = user.subscriptionTier || 'free';
+  if (!requiresProOrElite(tier)) {
+    return c.json(
+      { error: 'Trade Finder requires a Pro or Elite subscription.', code: 'TIER_REQUIRED' },
+      403
+    );
+  }
+
+  let body: TargetsBody;
+  try {
+    body = await c.req.json<TargetsBody>();
+  } catch {
+    return c.json({ error: 'Invalid request body' }, 400);
+  }
+  if (!body.leagueId) return c.json({ error: 'leagueId required' }, 400);
+
+  try {
+    const membership = await db.query.leagueMembers.findFirst({
+      where: and(
+        eq(schema.leagueMembers.userId, user.id),
+        eq(schema.leagueMembers.leagueId, body.leagueId)
+      ),
+    });
+    if (!membership) return c.json({ error: 'Not a member of this league' }, 403);
+
+    const allTeams = await db.query.teams.findMany({
+      where: eq(schema.teams.leagueId, body.leagueId),
+    });
+    let userTeam = null;
+    if (membership.externalUsername) {
+      userTeam = allTeams.find(
+        (t) => t.externalOwnerId === membership.externalUsername
+      );
+    }
+    if (!userTeam) userTeam = allTeams.find((t) => t.ownerId === user.id);
+    if (!userTeam) return c.json({ error: 'No team found for user' }, 404);
+
+    const league = await db.query.leagues.findFirst({
+      where: eq(schema.leagues.id, body.leagueId),
+      columns: {
+        id: true,
+        seasonYear: true,
+        currentWeek: true,
+        scoringFormat: true,
+        teamCount: true,
+        hasSuperflex: true,
+        hasTePremium: true,
+        leagueType: true,
+      },
+    });
+    if (!league) return c.json({ error: 'League not found' }, 404);
+
+    // Cache key — targets are pure functions of roster state so we
+    // can reuse the scouting-report fingerprint pattern: roster +
+    // week. Cheap to rebuild though, so a day-key is fine for now.
+    const CACHE_VERSION = 'v1';
+    const todayKey = new Date().toISOString().slice(0, 10);
+    const cacheKey = new Request(
+      `https://cache.local/trade-finder/targets/${CACHE_VERSION}/${league.id}/${userTeam.id}/${league.currentWeek}/${todayKey}`
+    );
+    const cache = getSafeCache();
+
+    const cached = await safeCacheMatch(cache, cacheKey);
+    if (cached) {
+      try {
+        const data = (await cached.json()) as SuggestedTargetsResult;
+        return c.json(data);
+      } catch {
+        // malformed — rebuild
+      }
+    }
+
+    const leagueSettings: LeagueSettings = {
+      scoringFormat:
+        (league.scoringFormat as LeagueSettings['scoringFormat']) || 'ppr',
+      superflex: league.hasSuperflex ?? false,
+      tePremium: league.hasTePremium ?? false,
+      teamCount: league.teamCount,
+    };
+
+    const result = await findSuggestedTargets({
+      db,
+      leagueId: league.id,
+      userTeamId: userTeam.id,
+      leagueSettings,
+      seasonYear: league.seasonYear,
+      currentWeek: league.currentWeek,
+      leagueType: (league.leagueType as 'redraft' | 'dynasty' | 'keeper') ?? 'redraft',
+      maxTargets: 10,
+    });
+
+    const response = new Response(JSON.stringify(result), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'max-age=600',
+      },
+    });
+    safeCachePut(cache, cacheKey, response.clone(), c.executionCtx);
+
+    return c.json(result);
+  } catch (err) {
+    const requestId = c.get('requestId') || 'unknown';
+    const msg = err instanceof Error ? err.message : String(err);
+    const stack = err instanceof Error ? err.stack : undefined;
+    console.error(`[${requestId}] /trade-finder/targets failed:`, msg, stack);
+    return c.json(
+      {
+        error: 'Failed to build trade targets.',
         requestId,
         detail: c.env.ENVIRONMENT === 'development' ? msg : undefined,
       },

--- a/server/src/services/tradeFinder.ts
+++ b/server/src/services/tradeFinder.ts
@@ -40,10 +40,12 @@ import {
   buildValuationMap,
   sumPickValues,
   type PlayerValuation,
+  type PlayerTier,
 } from './playerValuation';
 import {
   buildTeamComposition,
   type TeamComposition,
+  type NeedLevel,
 } from './teamComposition';
 import {
   constructOffersForTarget,
@@ -633,6 +635,403 @@ export async function findTradeRecommendations(
   return filtered.sort(
     (a, b) => a.analysis.fairnessScore.diff - b.analysis.fairnessScore.diff
   );
+}
+
+// ── Suggested Targets ───────────────────────────────────────────────
+//
+// "Here are 10 players on other rosters you should pursue." Pure
+// deterministic scoring + filtering — no AI call. Powers the browse
+// step of the Trade Finder: users open the finder, see suggested
+// targets grouped by which need each one addresses, and click one
+// to drop into the existing per-target offer flow.
+//
+// Scoring (higher = better):
+//   score = urgency × value × availability × recordMult
+//
+//     urgency       — from the user's need level at this position
+//                     (premium 3.0 / starter 2.0 / depth 1.0) or 1.0
+//                     when the target is just a tier upgrade at a
+//                     balanced position.
+//     value         — target's finalValue (ROS projection × factors)
+//     availability  — how moveable the target is from their current
+//                     team: starter w/ no backup = 0.3, starter w/
+//                     backup = 0.8, bench/flex = 1.0, surplus = 1.3
+//     recordMult    — partner's record vs league average. Rebuilding
+//                     teams get 1.3, middle 1.0, contenders 0.85.
+//
+// Filters:
+//   - No K/DEF
+//   - Skip players on the user's own roster
+//   - Skip injured/IR players
+//   - Skip tiny-value players (<20)
+//   - Skip a partner's ONLY elite starter at a position (untouchable)
+//   - Must address a user need OR be a real tier upgrade (>20% above
+//     the user's worst starter at that position)
+//
+// Diversity caps:
+//   - Max 2 targets per opponent team
+//   - Max 3 targets per position
+
+export interface SuggestedTarget {
+  playerId: string;
+  playerName: string;
+  position: string;
+  nflTeam: string;
+  tier: PlayerTier;
+  finalValue: number;
+  partnerTeamId: string;
+  partnerTeamName: string;
+  partnerRecord: string;
+  /** Short "why you should pursue" summary for the UI. */
+  rationale: string;
+  /** Which user need this target addresses — also the bucket key
+   *  for the UI grouping. "upgrade" level means "no computed need
+   *  but this is a clear tier upgrade." */
+  addresses: {
+    position: string;
+    level: NeedLevel | 'upgrade';
+    label: string;
+  };
+  /** Deterministic fit score, higher = better. UI sorts by this. */
+  score: number;
+}
+
+export interface SuggestedTargetsResult {
+  /** Top N targets across all needs, sorted by score. */
+  targets: SuggestedTarget[];
+  /** The distinct need buckets represented in the list. The UI uses
+   *  these to render grouped sections and collects targets by
+   *  matching the `addresses` field. */
+  needs: Array<{
+    position: string;
+    level: NeedLevel | 'upgrade';
+    label: string;
+  }>;
+}
+
+interface FindSuggestedTargetsArgs {
+  db: DB;
+  leagueId: string;
+  userTeamId: string;
+  leagueSettings: LeagueSettings;
+  seasonYear: number;
+  currentWeek: number;
+  leagueType?: 'redraft' | 'dynasty' | 'keeper';
+  maxTargets?: number;
+}
+
+// Human-readable bucket label for a deterministic need.
+function bucketLabel(position: string, level: NeedLevel | 'upgrade'): string {
+  switch (level) {
+    case 'premium':
+      return `Premium ${position} need`;
+    case 'starter':
+      return `Starting ${position}`;
+    case 'depth':
+      return `${position} depth`;
+    case 'none':
+      return `${position}`;
+    case 'upgrade':
+      return `Tier upgrade at ${position}`;
+  }
+}
+
+const NEED_URGENCY: Record<NeedLevel, number> = {
+  premium: 3.0,
+  starter: 2.0,
+  depth: 1.0,
+  none: 0.5,
+};
+
+export async function findSuggestedTargets(
+  args: FindSuggestedTargetsArgs
+): Promise<SuggestedTargetsResult> {
+  const {
+    db,
+    leagueId,
+    userTeamId,
+    leagueSettings,
+    seasonYear,
+    currentWeek,
+    maxTargets = 10,
+  } = args;
+
+  // unused suppressors
+  void seasonYear;
+
+  // 1. Load teams + rosters
+  const allTeams = await db.query.teams.findMany({
+    where: eq(schema.teams.leagueId, leagueId),
+  });
+  const userTeam = allTeams.find((t) => t.id === userTeamId);
+  if (!userTeam) return { targets: [], needs: [] };
+
+  const allRosterSpots = await db.query.rosterSpots.findMany({
+    where: inArray(
+      schema.rosterSpots.teamId,
+      allTeams.map((t) => t.id)
+    ),
+    with: { player: true },
+  });
+
+  const rosterByTeam = new Map<
+    string,
+    Array<{ playerId: string; player: (typeof allRosterSpots)[number]['player'] }>
+  >();
+  for (const r of allRosterSpots) {
+    const list = rosterByTeam.get(r.teamId) || [];
+    list.push({ playerId: r.playerId, player: r.player });
+    rosterByTeam.set(r.teamId, list);
+  }
+
+  // 2. Build trade context + valuations (same pipeline as finder)
+  const allPlayerIds = Array.from(
+    new Set(allRosterSpots.map((r) => r.playerId))
+  );
+  const megaContext = await buildTradeContext({
+    db,
+    playerIds: allPlayerIds,
+    leagueSettings,
+    seasonYear: args.seasonYear,
+    currentWeek,
+    leagueId,
+    userTeamId,
+  });
+  const factsById = new Map<string, PlayerFacts>();
+  for (const p of megaContext.players) factsById.set(p.id, p);
+
+  const valuations = buildValuationMap(
+    megaContext.players,
+    leagueSettings,
+    currentWeek
+  );
+
+  // 3. Build compositions
+  const compositionsByTeam = new Map<string, TeamComposition>();
+  for (const team of allTeams) {
+    const roster = rosterByTeam.get(team.id) || [];
+    compositionsByTeam.set(
+      team.id,
+      buildTeamComposition({
+        teamId: team.id,
+        rosteredPlayerIds: roster.map((r) => r.playerId),
+        valuations,
+        settings: leagueSettings,
+      })
+    );
+  }
+  const userComp = compositionsByTeam.get(userTeamId);
+  if (!userComp) return { targets: [], needs: [] };
+
+  const userRosterPlayerIds = new Set(
+    (rosterByTeam.get(userTeamId) ?? []).map((r) => r.playerId)
+  );
+
+  // 4. Compute league average record (wins / total games) for the
+  //    partner-record multiplier.
+  const avgWinPct = (() => {
+    let totalWins = 0;
+    let totalGames = 0;
+    for (const t of allTeams) {
+      const games = (t.wins ?? 0) + (t.losses ?? 0) + (t.ties ?? 0);
+      if (games === 0) continue;
+      totalWins += t.wins ?? 0;
+      totalGames += games;
+    }
+    return totalGames > 0 ? totalWins / totalGames : 0.5;
+  })();
+
+  // 5. For each user position, compute the worst-starter value so we
+  //    can check tier-upgrade eligibility.
+  const userWorstStarterByPos = new Map<string, number>();
+  for (const [pos, summary] of userComp.byPosition) {
+    const starters = summary.players.filter((p) => p.role === 'starter');
+    if (starters.length === 0) {
+      userWorstStarterByPos.set(pos, 0);
+      continue;
+    }
+    const worst = starters[starters.length - 1];
+    userWorstStarterByPos.set(pos, worst.finalValue);
+  }
+
+  // 6. Score every opponent player.
+  interface Scored {
+    target: SuggestedTarget;
+  }
+  const scored: Scored[] = [];
+
+  for (const team of allTeams) {
+    if (team.id === userTeamId) continue;
+    const partnerComp = compositionsByTeam.get(team.id);
+    if (!partnerComp) continue;
+
+    // Partner's record multiplier. Weaker teams = more willing to trade.
+    const partnerGames =
+      (team.wins ?? 0) + (team.losses ?? 0) + (team.ties ?? 0);
+    const partnerWinPct =
+      partnerGames > 0 ? (team.wins ?? 0) / partnerGames : avgWinPct;
+    const relWin = partnerWinPct - avgWinPct;
+    const recordMult =
+      relWin < -0.1 ? 1.3 : relWin > 0.1 ? 0.85 : 1.0;
+    const partnerRecord = `${team.wins ?? 0}-${team.losses ?? 0}${(team.ties ?? 0) > 0 ? `-${team.ties}` : ''}`;
+
+    for (const [pos, summary] of partnerComp.byPosition) {
+      // How many elite starters does the partner have at this position?
+      // A sole elite starter is usually untouchable.
+      const elitePlayersAtPos = summary.players.filter(
+        (p) => p.role === 'starter' && p.tier === 'elite'
+      );
+      const isSoleElite = (slotId: string) =>
+        elitePlayersAtPos.length === 1 &&
+        elitePlayersAtPos[0].playerId === slotId &&
+        summary.players.length < 3;
+
+      for (const slot of summary.players) {
+        // Skip untouchables + bad data
+        if (userRosterPlayerIds.has(slot.playerId)) continue;
+        if (slot.finalValue < 20) continue;
+        const facts = factsById.get(slot.playerId);
+        if (!facts) continue;
+        const status = facts.identity.status;
+        if (status === 'out' || status === 'injured_reserve') continue;
+        if (isSoleElite(slot.playerId)) continue;
+
+        // Does this address a user need or is it a tier upgrade?
+        const userNeed = userComp.needs.find((n) => n.position === pos);
+        const userStarterValue = userWorstStarterByPos.get(pos) ?? 0;
+        const isTierUpgrade =
+          userStarterValue > 0 && slot.finalValue >= userStarterValue * 1.2;
+
+        let addresses: SuggestedTarget['addresses'] | null = null;
+        let urgency = 0;
+        if (userNeed) {
+          addresses = {
+            position: pos,
+            level: userNeed.level,
+            label: bucketLabel(pos, userNeed.level),
+          };
+          urgency = NEED_URGENCY[userNeed.level];
+        } else if (isTierUpgrade) {
+          addresses = {
+            position: pos,
+            level: 'upgrade',
+            label: bucketLabel(pos, 'upgrade'),
+          };
+          urgency = 1.0;
+        } else {
+          continue; // neither a need nor an upgrade — skip
+        }
+
+        // Availability multiplier from the slot's role on partner team
+        let availability = 1.0;
+        const sameStarterCount = summary.players.filter(
+          (p) => p.role === 'starter'
+        ).length;
+        if (slot.role === 'starter') {
+          availability = sameStarterCount >= 2 ? 0.8 : 0.3;
+        } else if (slot.role === 'flex' || slot.role === 'bench') {
+          availability = 1.0;
+        } else if (slot.role === 'depth') {
+          availability = 1.1;
+        } else if (slot.role === 'surplus') {
+          availability = 1.3;
+        }
+
+        const score = urgency * slot.finalValue * availability * recordMult;
+
+        // Build a rationale string from the available signals.
+        const rationaleParts: string[] = [];
+        if (addresses.level === 'upgrade') {
+          const jump = Math.round(
+            ((slot.finalValue - userStarterValue) / userStarterValue) * 100
+          );
+          rationaleParts.push(`${jump}% upgrade over your current ${pos}`);
+        } else {
+          rationaleParts.push(
+            `Addresses your ${addresses.label.toLowerCase()} need`
+          );
+        }
+        if (slot.role === 'surplus') {
+          rationaleParts.push(`partner has ${pos} surplus`);
+        } else if (slot.role === 'flex' || slot.role === 'bench') {
+          rationaleParts.push(`partner depth piece`);
+        } else if (slot.role === 'starter' && sameStarterCount >= 2) {
+          rationaleParts.push(`partner has 2+ starters at ${pos}`);
+        }
+        if (recordMult > 1.0) {
+          rationaleParts.push(`rebuilding team (${partnerRecord})`);
+        }
+        const rationale = rationaleParts.join(' · ');
+
+        scored.push({
+          target: {
+            playerId: slot.playerId,
+            playerName: facts.name,
+            position: pos,
+            nflTeam: facts.nflTeam,
+            tier: slot.tier,
+            finalValue: Math.round(slot.finalValue),
+            partnerTeamId: team.id,
+            partnerTeamName: team.name,
+            partnerRecord,
+            rationale,
+            addresses,
+            score: Math.round(score * 10) / 10,
+          },
+        });
+      }
+    }
+  }
+
+  // 7. Sort by score descending, apply diversity caps.
+  scored.sort((a, b) => b.target.score - a.target.score);
+
+  const perTeam = new Map<string, number>();
+  const perPosition = new Map<string, number>();
+  const PER_TEAM_CAP = 2;
+  const PER_POSITION_CAP = 3;
+  const diverseTargets: SuggestedTarget[] = [];
+
+  for (const s of scored) {
+    if (diverseTargets.length >= maxTargets) break;
+    const t = s.target;
+    const teamCount = perTeam.get(t.partnerTeamId) ?? 0;
+    const posCount = perPosition.get(t.position) ?? 0;
+    if (teamCount >= PER_TEAM_CAP) continue;
+    if (posCount >= PER_POSITION_CAP) continue;
+    perTeam.set(t.partnerTeamId, teamCount + 1);
+    perPosition.set(t.position, posCount + 1);
+    diverseTargets.push(t);
+  }
+
+  // 8. Build the distinct needs list for the UI buckets.
+  const needsMap = new Map<string, SuggestedTargetsResult['needs'][number]>();
+  for (const t of diverseTargets) {
+    const key = `${t.addresses.position}|${t.addresses.level}`;
+    if (!needsMap.has(key)) {
+      needsMap.set(key, t.addresses);
+    }
+  }
+  // Sort needs by urgency (premium > starter > depth > upgrade > none)
+  const NEED_ORDER: Record<NeedLevel | 'upgrade', number> = {
+    premium: 0,
+    starter: 1,
+    depth: 2,
+    upgrade: 3,
+    none: 4,
+  };
+  const needs = Array.from(needsMap.values()).sort(
+    (a, b) => NEED_ORDER[a.level] - NEED_ORDER[b.level]
+  );
+
+  console.log(
+    `[tradeFinder.suggestTargets] scored ${scored.length}, returned ${diverseTargets.length} targets across ${needs.length} need buckets`
+  );
+
+  return {
+    targets: diverseTargets,
+    needs,
+  };
 }
 
 // ── Validation ──────────────────────────────────────────────────────

--- a/src/components/TradeFinderView.tsx
+++ b/src/components/TradeFinderView.tsx
@@ -79,6 +79,36 @@ interface MyRosterBrief {
   };
 }
 
+type NeedLevelUI = 'premium' | 'starter' | 'depth' | 'none' | 'upgrade';
+
+interface SuggestedTarget {
+  playerId: string;
+  playerName: string;
+  position: string;
+  nflTeam: string;
+  tier: string;
+  finalValue: number;
+  partnerTeamId: string;
+  partnerTeamName: string;
+  partnerRecord: string;
+  rationale: string;
+  addresses: {
+    position: string;
+    level: NeedLevelUI;
+    label: string;
+  };
+  score: number;
+}
+
+interface SuggestedTargetsResult {
+  targets: SuggestedTarget[];
+  needs: Array<{
+    position: string;
+    level: NeedLevelUI;
+    label: string;
+  }>;
+}
+
 const LEAGUE_SELECTION_KEY = 'filmroom.tradeAnalyzer.selectedLeagueId';
 
 function formatPickLabel(pick: DraftPickAsset): string {
@@ -143,6 +173,12 @@ export function TradeFinderView({
   // Every other team's roster in the league — powers the target
   // player picker. Excludes the user's own roster.
   const [otherRosters, setOtherRosters] = useState<MyRosterBrief[]>([]);
+
+  // Suggested targets: the deterministic "players you should pursue"
+  // list grouped by user-need buckets. Loaded when the league is
+  // selected so users see options immediately on open.
+  const [suggestedTargets, setSuggestedTargets] = useState<SuggestedTargetsResult | null>(null);
+  const [isLoadingTargets, setIsLoadingTargets] = useState(false);
 
   const tierAllowed =
     !!user && (user.subscriptionTier === 'pro' || user.subscriptionTier === 'elite');
@@ -220,6 +256,34 @@ export function TradeFinderView({
     };
   }, [selectedLeagueId, myRoster]);
 
+  // Load suggested targets — the deterministic "players you should
+  // pursue" list that the Trade Finder's browse step displays.
+  // Loads when the league is picked so users see options immediately.
+  useEffect(() => {
+    if (!selectedLeagueId || !tierAllowed) {
+      setSuggestedTargets(null);
+      return;
+    }
+    let cancelled = false;
+    setIsLoadingTargets(true);
+    api
+      .post<SuggestedTargetsResult>('/trade-finder/targets', {
+        leagueId: selectedLeagueId,
+      })
+      .then((data) => {
+        if (!cancelled) setSuggestedTargets(data);
+      })
+      .catch(() => {
+        if (!cancelled) setSuggestedTargets(null);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingTargets(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedLeagueId, tierAllowed]);
+
   const addAssetPlayer = (playerId: string) => {
     setAssetPlayerIds((prev) =>
       prev.includes(playerId) ? prev : [...prev, playerId]
@@ -241,9 +305,10 @@ export function TradeFinderView({
     setAssetPicks((prev) => prev.filter((_, i) => i !== idx));
   };
 
-  const fetchRecommendations = async () => {
+  const fetchRecommendations = async (explicitTargetId?: string) => {
+    const effectiveTarget = explicitTargetId ?? targetPlayerId;
     if (!selectedLeagueId || !tierAllowed) return;
-    if (!targetPlayerId) {
+    if (!effectiveTarget) {
       setError('Pick a target player first.');
       return;
     }
@@ -255,7 +320,7 @@ export function TradeFinderView({
         '/trade-finder/recommendations',
         {
           leagueId: selectedLeagueId,
-          targetPlayerId,
+          targetPlayerId: effectiveTarget,
           userPlayerIds: assetPlayerIds.length > 0 ? assetPlayerIds : undefined,
           userPicks: assetPicks.length > 0 ? assetPicks : undefined,
         }
@@ -267,6 +332,22 @@ export function TradeFinderView({
       setIsLoadingRecs(false);
     }
   };
+
+  // Helper for the suggested-target cards: set the target and
+  // immediately kick off an offer fetch. Scrolls the results into
+  // view so the user can see what comes back.
+  const pickSuggestedTarget = useCallback(
+    (target: SuggestedTarget) => {
+      setTargetPlayerId(target.playerId);
+      setError(null);
+      // Fire the recommendations fetch immediately with the explicit
+      // target id — avoids waiting on the next render cycle of the
+      // targetPlayerId state update.
+      void fetchRecommendations(target.playerId);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedLeagueId, tierAllowed, assetPlayerIds, assetPicks]
+  );
 
   // Reset "has searched" state whenever inputs change so the empty
   // state goes away until the user re-runs the search.
@@ -535,16 +616,181 @@ export function TradeFinderView({
         </div>
       )}
 
-      {/* Target player picker + refinement + Suggest Offers button */}
+      {/* Suggested Targets — deterministic "players you should
+          pursue" list grouped by need bucket. This is the browse
+          step: users see 10 ranked targets on opponents without
+          making an AI call, and click any to drop into the
+          per-target offer flow below. */}
+      {selectedLeagueId && (
+        <div
+          className={`rounded-xl border p-4 ${
+            isDarkMode ? 'bg-slate-900/50 border-slate-700' : 'bg-white border-slate-200'
+          }`}
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <Target
+              className={`w-4 h-4 ${
+                isDarkMode ? 'text-purple-400' : 'text-purple-600'
+              }`}
+            />
+            <p
+              className={`text-sm font-semibold ${
+                isDarkMode ? 'text-slate-300' : 'text-slate-700'
+              }`}
+            >
+              Players to target
+            </p>
+            <span
+              className={`text-[10px] uppercase tracking-wide ml-auto ${
+                isDarkMode ? 'text-slate-500' : 'text-slate-400'
+              }`}
+            >
+              Ranked by fit
+            </span>
+          </div>
+
+          {isLoadingTargets ? (
+            <div className="flex items-center gap-2 py-4">
+              <Loader2
+                className={`w-4 h-4 animate-spin ${
+                  isDarkMode ? 'text-slate-400' : 'text-slate-500'
+                }`}
+              />
+              <span
+                className={`text-sm ${
+                  isDarkMode ? 'text-slate-400' : 'text-slate-500'
+                }`}
+              >
+                Scanning opponents...
+              </span>
+            </div>
+          ) : !suggestedTargets || suggestedTargets.targets.length === 0 ? (
+            <p
+              className={`text-sm py-4 ${
+                isDarkMode ? 'text-slate-500' : 'text-slate-400'
+              }`}
+            >
+              No clear targets found. Your roster may already be stacked, or
+              rosters haven&apos;t synced yet.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {suggestedTargets.needs.map((bucket) => {
+                const bucketTargets = suggestedTargets.targets.filter(
+                  (t) =>
+                    t.addresses.position === bucket.position &&
+                    t.addresses.level === bucket.level
+                );
+                if (bucketTargets.length === 0) return null;
+                return (
+                  <div key={`${bucket.position}-${bucket.level}`}>
+                    <p
+                      className={`text-[10px] font-bold uppercase tracking-wide mb-2 ${
+                        isDarkMode ? 'text-slate-400' : 'text-slate-500'
+                      }`}
+                    >
+                      {bucket.label}
+                    </p>
+                    <div className="grid gap-2">
+                      {bucketTargets.map((t) => {
+                        const isSelected = targetPlayerId === t.playerId;
+                        return (
+                          <button
+                            key={t.playerId}
+                            type="button"
+                            onClick={() => pickSuggestedTarget(t)}
+                            disabled={isLoadingRecs}
+                            className={`flex items-center gap-3 text-left p-3 rounded-lg border transition-colors ${
+                              isSelected
+                                ? isDarkMode
+                                  ? 'bg-blue-500/10 border-blue-500/40'
+                                  : 'bg-blue-50 border-blue-300'
+                                : isDarkMode
+                                ? 'bg-slate-800/40 border-slate-700 hover:border-blue-500/40 hover:bg-slate-800/70'
+                                : 'bg-white border-slate-200 hover:border-blue-300 hover:bg-blue-50/40'
+                            } ${isLoadingRecs ? 'opacity-60 cursor-wait' : ''}`}
+                          >
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-center gap-2 mb-0.5">
+                                <span
+                                  className={`text-[9px] font-bold px-1.5 py-0.5 rounded ${
+                                    isDarkMode
+                                      ? 'bg-slate-700 text-slate-300'
+                                      : 'bg-slate-100 text-slate-600'
+                                  }`}
+                                >
+                                  {t.position}
+                                </span>
+                                <span
+                                  className={`text-sm font-semibold truncate ${
+                                    isDarkMode ? 'text-white' : 'text-slate-900'
+                                  }`}
+                                >
+                                  {t.playerName}
+                                </span>
+                                <span
+                                  className={`text-[10px] ${
+                                    isDarkMode ? 'text-slate-500' : 'text-slate-400'
+                                  }`}
+                                >
+                                  {t.nflTeam}
+                                </span>
+                              </div>
+                              <div
+                                className={`text-xs truncate ${
+                                  isDarkMode ? 'text-slate-400' : 'text-slate-500'
+                                }`}
+                              >
+                                From {t.partnerTeamName} ({t.partnerRecord}) &middot; {t.rationale}
+                              </div>
+                            </div>
+                            <div className="flex-shrink-0 flex items-center gap-2">
+                              <span
+                                className={`text-[10px] font-semibold px-2 py-1 rounded-md ${
+                                  isDarkMode
+                                    ? 'bg-purple-500/20 text-purple-200'
+                                    : 'bg-purple-50 text-purple-700'
+                                }`}
+                              >
+                                Build Offer
+                              </span>
+                              <ArrowRight
+                                className={`w-4 h-4 ${
+                                  isDarkMode ? 'text-slate-500' : 'text-slate-400'
+                                }`}
+                              />
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <p
+            className={`text-[10px] mt-3 ${
+              isDarkMode ? 'text-slate-500' : 'text-slate-400'
+            }`}
+          >
+            Click any target to build 2-3 realistic offer packages for that player.
+          </p>
+        </div>
+      )}
+
+      {/* Manual target picker + refinement + Suggest Offers button.
+          This is the power-user path — the suggested targets list
+          above handles the common case. Use this when you already
+          know exactly who you want (even if they aren't in the
+          suggested list) or to re-run with narrower Trade Assets. */}
       {selectedLeagueId && (
         <div
           className={`rounded-xl border p-4 space-y-4 ${
             isDarkMode ? 'bg-slate-900/50 border-slate-700' : 'bg-white border-slate-200'
           }`}
         >
-          {/* Target a specific player (REQUIRED — this is now the
-              primary input. The finder is target-focused: pick a
-              player, get 2-3 realistic offers for them.) */}
           <div>
             <label
               className={`block text-xs font-semibold mb-1 flex items-center gap-1.5 ${
@@ -552,7 +798,7 @@ export function TradeFinderView({
               }`}
             >
               <Target className="w-3.5 h-3.5" />
-              Target a specific player
+              Or pick any player manually
             </label>
 
             {/* Current selection pill */}
@@ -838,7 +1084,7 @@ export function TradeFinderView({
 
           <button
             type="button"
-            onClick={fetchRecommendations}
+            onClick={() => fetchRecommendations()}
             disabled={isLoadingRecs || !targetPlayerId}
             className={`w-full sm:w-auto px-5 py-2.5 rounded-lg text-sm font-semibold transition-colors flex items-center justify-center gap-2 ${
               isLoadingRecs || !targetPlayerId


### PR DESCRIPTION
Option A's "pick a target player" flow was a step in the right direction — bounded, reliable — but it moved the hardest decision (who should I pursue?) onto the user. If they already knew that, they'd just type the name into the Analyzer. The real value of a trade tool is discovery.

This adds a browse step that runs BEFORE the offer flow:

  Scouting report
    ↓
  ** Players to target **   ← new, deterministic, zero AI calls
    ↓ (click any)
  Offer packages            ← existing target-focused flow
    ↓
  Trusted analyzer grades

Users see ~10 ranked targets grouped under need buckets ("Starting RB2", "WR depth", "Tier upgrade at QB") and click any to drop into the existing per-target offer flow. Zero AI calls for the browse step — pure deterministic scoring that can't fail the way open-ended generation does.

Backend — findSuggestedTargets() in tradeFinder.ts
  - Deterministic scoring: urgency × value × availability × recordMult
    - urgency: need-level weight (premium 3.0 / starter 2.0 / depth 1.0) or 1.0 for tier-upgrade targets at balanced positions
    - value: target's finalValue (scarcity-adjusted ROS projection)
    - availability: role-based — sole starter 0.3, starter w/ backup 0.8, bench/flex 1.0, surplus 1.3
    - recordMult: partner's record vs league average — rebuilding 1.3, mid 1.0, contender 0.85
  - Filters: no K/DEF, no players on user's roster, no injured/IR, no tiny-value bench fodder, no partner's sole elite starter
  - Must address a user need OR be a real tier upgrade (>= 20% above user's worst starter at the position)
  - Diversity: max 2 targets per opponent team, max 3 per position
  - Rationale strings: "Addresses your Starting RB2 need · partner has RB surplus · rebuilding team (2-8)"
  - Returns { targets, needs } — the needs list is the distinct buckets the UI uses for grouping
  - Zero AI calls, fully deterministic

Backend — POST /trade-finder/targets route
  - Same auth + tier gate as /recommendations
  - Cached per (league, user team, week, day) for 10min
  - Separate CACHE_VERSION since this endpoint is new

Frontend — TradeFinderView.tsx
  - New "Players to target" card rendered between the scouting report and the manual target picker
  - Loads automatically when the league is picked (no AI = fast)
  - Targets grouped under need bucket labels from the scouting layer (Idea B): "Starting RB2", "WR depth", "Tier upgrade at QB"
  - Each target is a clickable card showing: position + name + NFL team, partner team + record + rationale, "Build Offer" pill, arrow icon
  - Click handler pickSuggestedTarget() sets targetPlayerId and immediately fires fetchRecommendations with the explicit id — no waiting on the next state render cycle
  - Selected target gets a blue highlight border
  - fetchRecommendations now accepts optional explicit target id so the click handler can bypass state
  - Manual target picker below is relabeled "Or pick any player manually" — power-user path for when the suggested list doesn't have who you want
  - Empty state when no targets found: "No clear targets found. Your roster may already be stacked, or rosters haven't synced yet."

No behavior change to the existing offer flow — this is strictly additive. The manual target picker still works for power users.

https://claude.ai/code/session_01PaHiRFLZ8hUiFAzEC93XWT