### PR TITLE
Hide Trade Finder from every user-facing surface

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <!-- Primary Meta Tags (dynamic per-route via react-helmet-async) -->
     <title>FilmRoom - Fantasy Football Analysis & Management</title>
     <meta name="description" content="Manage your fantasy football leagues with advanced analytics, player projections, waiver wire analysis, and real-time stats from Sleeper and ESPN." />
-    <meta name="keywords" content="fantasy football, fantasy sports, NFL, player rankings, projections, waiver wire, sleeper, ESPN, league management, trade analyzer, trade finder, draft rankings" />
+    <meta name="keywords" content="fantasy football, fantasy sports, NFL, player rankings, projections, waiver wire, sleeper, ESPN, league management, trade analyzer, draft rankings" />
     <meta name="author" content="FilmRoom" />
     <link rel="canonical" href="https://filmroomfantasy.com/" />
 

--- a/landing.html
+++ b/landing.html
@@ -400,7 +400,7 @@
             <div class="step-num">3</div>
             <div>
                 <h3>Make better decisions</h3>
-                <p>Start/sit calls backed by data. Waiver pickups before your leaguemates notice. Grade any trade with AI, or pick a player you want and let the Trade Finder build realistic offers from your roster.</p>
+                <p>Start/sit calls backed by data. Waiver pickups before your leaguemates notice. Grade any trade with AI — fair value, roster impact, and whether you should smash accept.</p>
             </div>
         </div>
     </div>
@@ -432,7 +432,6 @@
             <ul>
                 <li class="highlight">Everything in Free</li>
                 <li class="highlight">Unlimited league syncs</li>
-                <li class="highlight">AI Trade Finder &mdash; target-based offer suggestions</li>
                 <li class="highlight">Trending players & add/drop data</li>
                 <li class="highlight">5 trade analyses per day</li>
             </ul>
@@ -445,7 +444,7 @@
             <ul>
                 <li class="highlight">Everything in Pro</li>
                 <li class="highlight">Deeper player research — stats, Vegas props, game logs, matchup grades</li>
-                <li class="highlight">Unlimited trade analyses & Trade Finder searches</li>
+                <li class="highlight">Unlimited trade analyses</li>
                 <li>Custom scoring models (coming soon)</li>
                 <li>Early access to new features</li>
             </ul>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -292,7 +292,7 @@ export function LandingPage({ onNavigate }: LandingPageProps) {
                 AI Trade Analyzer
               </div>
               <div className="tab-pills">
-                {['Analyzer', 'Trade Finder', 'History'].map(t => (
+                {['Analyzer', 'History'].map(t => (
                   <button key={t} className={`tab-pill${activeTab === t ? ' on' : ''}`} onClick={() => setActiveTab(t)}>{t}</button>
                 ))}
               </div>
@@ -354,61 +354,6 @@ export function LandingPage({ onNavigate }: LandingPageProps) {
                       }{' '}Click players to simulate different trade packages.
                     </div>
                   </div>
-                </>
-              )}
-
-              {activeTab === 'Trade Finder' && (
-                <>
-                  <input
-                    className="finder-search"
-                    placeholder="Pick a player you want to acquire — e.g. CeeDee Lamb"
-                    readOnly
-                  />
-                  <div className="finder-target">
-                    <span className="finder-target-label">Target</span>
-                    <span className={`pos WR`}>WR</span>
-                    <span className="finder-target-name">CeeDee Lamb</span>
-                    <span className="finder-target-team">Ball Whackers</span>
-                  </div>
-                  <div className="finder-row">
-                    <div className="finder-players">
-                      <span className={`pos RB`}>RB</span>
-                      <span style={{ fontWeight: 600, color: 'var(--text-bright)' }}>Javonte Williams</span>
-                      <span className="finder-plus">+</span>
-                      <span className="finder-pick">2026 1st</span>
-                      <span className="finder-arrow">→</span>
-                      <span className={`pos WR`}>WR</span>
-                      <span style={{ fontWeight: 600, color: 'var(--text-bright)' }}>CeeDee Lamb</span>
-                    </div>
-                    <span className="finder-tag offer">Offer</span>
-                    <span className="finder-grade" style={{ color: 'var(--green)' }}>A</span>
-                  </div>
-                  <div className="finder-row">
-                    <div className="finder-players">
-                      <span className={`pos WR`}>WR</span>
-                      <span style={{ fontWeight: 600, color: 'var(--text-bright)' }}>DK Metcalf</span>
-                      <span className="finder-plus">+</span>
-                      <span className={`pos RB`}>RB</span>
-                      <span style={{ fontWeight: 600, color: 'var(--text-bright)' }}>Tony Pollard</span>
-                      <span className="finder-arrow">→</span>
-                      <span className={`pos WR`}>WR</span>
-                      <span style={{ fontWeight: 600, color: 'var(--text-bright)' }}>CeeDee Lamb</span>
-                    </div>
-                    <span className="finder-tag offer">Offer</span>
-                    <span className="finder-grade" style={{ color: 'var(--blue)' }}>B+</span>
-                  </div>
-                  <div className="finder-row">
-                    <div className="finder-players">
-                      <span className={`pos RB`}>RB</span>
-                      <span style={{ fontWeight: 600, color: 'var(--text-bright)' }}>Saquon Barkley</span>
-                      <span className="finder-arrow">→</span>
-                      <span className={`pos WR`}>WR</span>
-                      <span style={{ fontWeight: 600, color: 'var(--text-bright)' }}>CeeDee Lamb</span>
-                    </div>
-                    <span className="finder-tag offer">Offer</span>
-                    <span className="finder-grade" style={{ color: 'var(--blue)' }}>B</span>
-                  </div>
-                  <div className="finder-hint">Pick a player → AI builds 2-3 realistic offers from your roster.</div>
                 </>
               )}
 
@@ -568,7 +513,7 @@ export function LandingPage({ onNavigate }: LandingPageProps) {
                 <li>Redraft, Dynasty, and Keeper</li>
                 <li>AI counter-offer suggestions</li>
                 <li>Playoff schedule comparisons</li>
-                <li>Trade Finder &amp; Trade History</li>
+                <li>Trade History with AI grades</li>
                 <li>3-day free trial</li>
               </ul>
               <button className="price-btn primary" onClick={nav('Pricing')}>Start Free Trial</button>

--- a/src/components/PricingView.tsx
+++ b/src/components/PricingView.tsx
@@ -85,7 +85,6 @@ export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = f
       features: [
         { text: 'Everything in Free', highlight: true },
         { text: 'Unlimited league syncs', highlight: true },
-        { text: 'AI Trade Finder — target-based offer suggestions', highlight: true },
         { text: 'Trending players & add/drop data', highlight: true },
         { text: '5 trade analyses per day', highlight: true },
         { text: '3-day free trial', highlight: true },
@@ -103,7 +102,7 @@ export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = f
         { text: 'Everything in Pro', highlight: true },
         { text: 'Unlimited league syncs', highlight: true },
         { text: 'Deeper player research — stats, Vegas props, game logs, matchup grades', highlight: true },
-        { text: 'Unlimited trade analyses & Trade Finder searches', highlight: true },
+        { text: 'Unlimited trade analyses', highlight: true },
         { text: '3-day free trial', highlight: true },
         { text: 'Custom scoring models', highlight: false, comingSoon: true },
         { text: 'Early access to new features', highlight: false },

--- a/src/components/TradeAnalyzerShell.tsx
+++ b/src/components/TradeAnalyzerShell.tsx
@@ -1,41 +1,29 @@
-import { useState, useCallback } from 'react';
-import { ArrowRightLeft, History, Search } from 'lucide-react';
+import { useState } from 'react';
+import { ArrowRightLeft, History } from 'lucide-react';
 import { TradeAnalyzerView } from './TradeAnalyzerView';
 import { TradeHistoryView } from './TradeHistoryView';
-import { TradeFinderView, type TradeRecommendation } from './TradeFinderView';
+// NOTE: TradeFinderView is intentionally NOT imported — the Trade
+// Finder tab is hidden for now. The component, backend route, and
+// related services are still in the repo so we can re-enable the
+// tab without re-implementing anything. To bring it back: re-add
+// the import, the 'finder' Tab union member, the tabs array entry,
+// and the render case below.
 
-type Tab = 'analyzer' | 'finder' | 'history';
+type Tab = 'analyzer' | 'history';
 
 interface TradeAnalyzerShellProps {
   isDarkMode: boolean;
 }
 
 /**
- * Shell that hosts the three trade-related tabs: Analyzer, Finder, History.
- * Each tab is a self-contained view (for now they share the selectedLeagueId
- * via localStorage, which is good enough — the shell just handles tab state
- * and the Finder -> Analyzer "send" handoff via sessionStorage.
+ * Shell that hosts the trade-related tabs: Analyzer and History.
+ * (Trade Finder is currently hidden — see note above.)
  */
 export function TradeAnalyzerShell({ isDarkMode }: TradeAnalyzerShellProps) {
   const [tab, setTab] = useState<Tab>('analyzer');
 
-  // When a recommendation is sent from the Finder to the Analyzer we stash
-  // it in sessionStorage so the Analyzer can pick it up on mount.
-  const handleSendToAnalyzer = useCallback((rec: TradeRecommendation) => {
-    try {
-      sessionStorage.setItem(
-        'filmroom.tradeAnalyzer.incoming',
-        JSON.stringify(rec)
-      );
-    } catch {
-      // non-critical
-    }
-    setTab('analyzer');
-  }, []);
-
   const tabs: Array<{ id: Tab; label: string; icon: typeof ArrowRightLeft }> = [
     { id: 'analyzer', label: 'Analyzer', icon: ArrowRightLeft },
-    { id: 'finder', label: 'Trade Finder', icon: Search },
     { id: 'history', label: 'History', icon: History },
   ];
 
@@ -71,12 +59,6 @@ export function TradeAnalyzerShell({ isDarkMode }: TradeAnalyzerShellProps) {
       </div>
 
       {tab === 'analyzer' && <TradeAnalyzerView isDarkMode={isDarkMode} />}
-      {tab === 'finder' && (
-        <TradeFinderView
-          isDarkMode={isDarkMode}
-          onSendToAnalyzer={handleSendToAnalyzer}
-        />
-      )}
       {tab === 'history' && <TradeHistoryView isDarkMode={isDarkMode} />}
     </div>
   );


### PR DESCRIPTION
Trade Finder iteration hit a wall — it works mechanically but the output quality isn't good enough to ship. Pulling it from the UI while leaving all the backend code, the TradeFinderView component, the /trade-finder/* routes, and the Suggested Targets experiment intact so we can bring it back cleanly if we ever solve the discovery problem or repackage the feature.

Only the Trade Analyzer and Trade History tabs are visible now.

- TradeAnalyzerShell.tsx: dropped the 'finder' Tab union member, removed the tab bar entry and render case, removed the TradeFinderView import and the handleSendToAnalyzer handoff callback (which only existed to bridge Finder → Analyzer). Added a comment explaining how to re-enable.
- LandingPage.tsx: dropped "Trade Finder" from the widget tab pills array, removed the entire `activeTab === 'Trade Finder'` render block (the target-focused offer demo), and changed the Pro tier bullet "Trade Finder & Trade History" → "Trade History with AI grades".
- PricingView.tsx: removed the "AI Trade Finder" Pro bullet and reverted the Elite "Unlimited trade analyses & Trade Finder searches" back to "Unlimited trade analyses".
- landing.html: same pricing bullet removal, and reverted step 3 copy from "Grade any trade... or pick a player..." back to "Grade any trade with AI — fair value, roster impact..."
- index.html: removed "trade finder" from the SEO keywords meta.

Kept in the repo (not deleted):
- TradeFinderView.tsx — full component with Suggested Targets UI
- server/src/services/tradeFinder.ts — findTradeRecommendations, findSuggestedTargets, buildTeamNeeds, etc.
- server/src/services/tradeConstructor.ts — constructOffersForTarget
- server/src/routes/tradeFinder.ts — /needs, /recommendations, /targets route handlers
- team_scouting_reports table + migration
- BACKLOG.md Trade Finder entries

https://claude.ai/code/session_01PaHiRFLZ8hUiFAzEC93XWT