### PR TITLE
Remove noindexed pages from prerender, add missing /privacy and /terms

### DIFF
--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -69,12 +69,12 @@ const ROUTES = [
   '/game-slate',
   '/trends',
   '/pricing',
-  '/login',
   '/articles',
   '/playoff-predictor',
-  '/draft-rankings',
-  '/league-analyzer',
-  '/research',
+  '/privacy',
+  '/terms',
+  // login, register: utility screens (noindex)
+  // draft-rankings, league-analyzer, research: Coming Soon placeholders (noindex)
   // Individual articles
   '/articles/how-vegas-lines-predict-fantasy-football-points',
   '/articles/fantasy-football-waiver-wire-strategy-guide',


### PR DESCRIPTION
Stop prerendering pages that carry noindex meta tags (login,
draft-rankings, league-analyzer, research) — Google was crawling the
prerendered HTML, finding the noindex tag, and flagging them in
Search Console as "Excluded by noindex tag."

Also add /privacy and /terms which were missing from prerender but
present in sitemap.xml and generate-static-pages.js.

https://claude.ai/code/session_01GTc2GWi5fUC5yZdNjD3uXL