### PR TITLE
Add Trade Trees feature: trace player lineage through successive trades

### DIFF
--- a/server/src/routes/tradeHistory.ts
+++ b/server/src/routes/tradeHistory.ts
@@ -7,6 +7,7 @@ import type { Env, Variables } from '../index';
 import { computeOutcome, computeRecordImpact } from '../services/tradeOutcomes';
 import { ingestSleeperTrades } from '../services/tradeIngest';
 import { chunkedInArrayFetch, DEFAULT_ID_CHUNK } from '../utils/chunked';
+import { buildTradeChains, computeChainSummary } from '../services/tradeChains';
 
 /**
  * Resolution result for the caller's team in a league. Includes the
@@ -1143,6 +1144,164 @@ Provide your JSON analysis. Weight the ACTUAL OUTCOME block more heavily than th
     console.error('Retro grade error:', err);
     return c.json({ error: 'Unexpected error during grading.' }, 500);
   }
+});
+
+// ── GET /trade-trees/:leagueId — Trade Chain / Trade Tree view ──────
+//
+// Traces the lineage of players through successive trades to build
+// branching "trade trees". Each root is a trade where a player first
+// entered the user's roster; children are subsequent trades of those
+// players.
+
+tradeHistoryRoutes.get('/trade-trees/:leagueId', authMiddleware, async (c) => {
+  const user = c.get('user');
+  const db = c.get('db');
+  if (!user) return c.json({ error: 'Unauthorized' }, 401);
+
+  const leagueId = c.req.param('leagueId');
+  const seasonParam = c.req.query('season');
+  const seasonFilter = seasonParam ? parseInt(seasonParam, 10) : null;
+
+  const membership = await db.query.leagueMembers.findFirst({
+    where: and(
+      eq(schema.leagueMembers.userId, user.id),
+      eq(schema.leagueMembers.leagueId, leagueId)
+    ),
+  });
+  if (!membership) {
+    return c.json({ error: 'Not a member of this league' }, 403);
+  }
+
+  const leagueTeams = await db.query.teams.findMany({
+    where: eq(schema.teams.leagueId, leagueId),
+  });
+  const resolution = resolveCallerTeam(leagueTeams, membership, user.id);
+  const callerTeam = resolution.team;
+  if (!callerTeam) {
+    return c.json({ error: 'No team found for user in this league' }, 404);
+  }
+
+  // Fetch all executed trades for the league
+  const allTrades = await db.query.trades.findMany({
+    where: and(
+      eq(schema.trades.leagueId, leagueId),
+      eq(schema.trades.status, 'executed')
+    ),
+    orderBy: [desc(schema.trades.executedAt)],
+  });
+
+  if (allTrades.length === 0) {
+    return c.json({
+      trees: [],
+      summary: { totalChains: 0, longestChainDepth: 0, bestChainDifferential: 0, worstChainDifferential: 0, totalPointsGained: 0 },
+      callerTeamId: callerTeam.id,
+      callerTeamName: callerTeam.name,
+    });
+  }
+
+  // Fetch all trade items (chunked for dynasty leagues)
+  const allTradeIds = allTrades.map((t) => t.id);
+  const allItems = await chunkedInArrayFetch(
+    allTradeIds,
+    DEFAULT_ID_CHUNK,
+    (chunk) =>
+      db.query.tradeItems.findMany({
+        where: inArray(schema.tradeItems.tradeId, chunk),
+      })
+  );
+
+  // Filter trades by season if requested
+  const [leagueRow] = await Promise.all([
+    db.query.leagues.findFirst({
+      where: eq(schema.leagues.id, leagueId),
+      columns: { seasonYear: true },
+    }),
+  ]);
+
+  const trades = seasonFilter != null
+    ? allTrades.filter(
+        (t) =>
+          t.seasonYear === seasonFilter ||
+          (t.seasonYear == null && seasonFilter === leagueRow?.seasonYear)
+      )
+    : allTrades;
+
+  // Collect player IDs for stats + name lookup
+  const playerIds = new Set<string>();
+  for (const item of allItems) {
+    if (item.playerId) playerIds.add(item.playerId);
+  }
+
+  // Fetch weekly stats for all traded players across all relevant seasons
+  const seasonYears = new Set<number>();
+  for (const t of trades) {
+    if (t.seasonYear != null) seasonYears.add(t.seasonYear);
+  }
+  if (leagueRow?.seasonYear != null) seasonYears.add(leagueRow.seasonYear);
+
+  const [playerRows, weeklyStats] = await Promise.all([
+    playerIds.size > 0
+      ? chunkedInArrayFetch(
+          Array.from(playerIds),
+          DEFAULT_ID_CHUNK,
+          (chunk) =>
+            db.query.nflPlayers.findMany({
+              where: inArray(schema.nflPlayers.id, chunk),
+              columns: { id: true, name: true, position: true, team: true },
+            })
+        )
+      : Promise.resolve([]),
+    playerIds.size > 0 && seasonYears.size > 0
+      ? chunkedInArrayFetch(
+          Array.from(playerIds),
+          DEFAULT_ID_CHUNK,
+          (chunk) =>
+            db.query.playerWeeklyStats.findMany({
+              where: and(
+                inArray(schema.playerWeeklyStats.playerId, chunk),
+                inArray(
+                  schema.playerWeeklyStats.seasonYear,
+                  Array.from(seasonYears)
+                )
+              ),
+            })
+        )
+      : Promise.resolve([]),
+  ]);
+
+  // Build lookup maps
+  const playerInfoById = new Map(
+    playerRows.map((p) => [p.id, { name: p.name, position: p.position, team: p.team || '' }])
+  );
+
+  const pointsByPlayerWeek = new Map<string, number>();
+  const lastWeekBySeason = new Map<number, number>();
+  for (const s of weeklyStats) {
+    pointsByPlayerWeek.set(
+      `${s.playerId}_${s.seasonYear}_${s.week}`,
+      Number(s.fantasyPointsPPR ?? 0)
+    );
+    const current = lastWeekBySeason.get(s.seasonYear) ?? 0;
+    if (s.week > current) lastWeekBySeason.set(s.seasonYear, s.week);
+  }
+
+  const trees = buildTradeChains(
+    resolution.teamIds,
+    trades,
+    allItems,
+    pointsByPlayerWeek,
+    playerInfoById,
+    lastWeekBySeason
+  );
+
+  const summary = computeChainSummary(trees);
+
+  return c.json({
+    trees,
+    summary,
+    callerTeamId: callerTeam.id,
+    callerTeamName: callerTeam.name,
+  });
 });
 
 export { tradeHistoryRoutes };

--- a/server/src/services/tradeChains.ts
+++ b/server/src/services/tradeChains.ts
@@ -1,0 +1,433 @@
+/**
+ * Trade Chain / Trade Tree builder.
+ *
+ * A "trade chain" traces the lineage of players through successive
+ * trades on the user's team. When a player arrives via Trade A and
+ * is later sent away in Trade B (bringing back new players), those
+ * trades form a parent→child link. Chains can branch when a single
+ * trade brings multiple players that are later traded in separate
+ * transactions.
+ *
+ * The algorithm is purely in-memory — the route handler fetches all
+ * trades, items, and weekly stats in bulk, then passes them here.
+ */
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export interface TradeTreePlayerReceived {
+  playerId: string | null;
+  playerName: string;
+  position: string;
+  nflTeam: string;
+  /** PPR points this player scored while on the user's roster
+   *  (bounded from the week after the incoming trade to either the
+   *  week of the outgoing trade or end of season). */
+  pointsWhileHeld: number;
+  weeksHeld: number;
+  /** If this player was subsequently traded away, which child index? */
+  tradedAwayInChildIndex: number | null;
+  pickYear: number | null;
+  pickRound: number | null;
+}
+
+export interface TradeTreePlayerSent {
+  playerId: string | null;
+  playerName: string;
+  position: string;
+  nflTeam: string;
+  /** PPR points this player scored AFTER being traded away
+   *  (opportunity cost). */
+  pointsAfterTrade: number;
+  pickYear: number | null;
+  pickRound: number | null;
+}
+
+export interface TradeTreeNode {
+  tradeId: string;
+  executedAt: string | null;
+  weekExecuted: number | null;
+  seasonYear: number | null;
+  received: TradeTreePlayerReceived[];
+  sent: TradeTreePlayerSent[];
+  /** Points differential at THIS node only (sum of received pointsWhileHeld − sent pointsAfterTrade). */
+  nodeDifferential: number;
+  /** Cumulative differential from this node through all descendants. */
+  cumulativeDifferential: number;
+  /** Depth in the tree (0 = root). */
+  depth: number;
+  aiGrade: string | null;
+  children: TradeTreeNode[];
+}
+
+export interface TradeTreeSummary {
+  totalChains: number;
+  longestChainDepth: number;
+  bestChainDifferential: number;
+  worstChainDifferential: number;
+  totalPointsGained: number;
+}
+
+// ── Minimal trade/item shapes expected by the builder ───────────────
+
+export interface TradeLike {
+  id: string;
+  executedAt: Date | null;
+  weekExecuted: number | null;
+  seasonYear: number | null;
+  aiGrade: string | null;
+}
+
+export interface TradeItemLike {
+  tradeId: string;
+  fromTeamId: string;
+  toTeamId: string;
+  playerId: string | null;
+  draftPickYear: number | null;
+  draftPickRound: number | null;
+}
+
+export interface PlayerInfo {
+  name: string;
+  position: string;
+  team: string;
+}
+
+// ── Algorithm ───────────────────────────────────────────────────────
+
+/**
+ * Build trade chains for the calling user.
+ *
+ * @param callerTeamIds  All team IDs that belong to the caller in this league
+ * @param trades         All executed trades in the league, sorted by executedAt desc
+ * @param items          All trade items for those trades
+ * @param pointsByPlayerWeek  Map of `${playerId}_${seasonYear}_${week}` → PPR points
+ * @param playerInfoById Map of playerId → { name, position, team }
+ * @param lastWeekBySeason Map of seasonYear → last completed week number
+ */
+export function buildTradeChains(
+  callerTeamIds: Set<string>,
+  trades: TradeLike[],
+  items: TradeItemLike[],
+  pointsByPlayerWeek: Map<string, number>,
+  playerInfoById: Map<string, PlayerInfo>,
+  lastWeekBySeason: Map<number, number>
+): TradeTreeNode[] {
+  // Sort trades by execution time ascending for temporal ordering
+  const sortedTrades = [...trades].sort((a, b) => {
+    const aTime = a.executedAt?.getTime() ?? 0;
+    const bTime = b.executedAt?.getTime() ?? 0;
+    if (aTime !== bTime) return aTime - bTime;
+    return (a.weekExecuted ?? 0) - (b.weekExecuted ?? 0);
+  });
+
+  const tradeById = new Map(sortedTrades.map((t) => [t.id, t]));
+
+  // Index items by trade
+  const itemsByTradeId = new Map<string, TradeItemLike[]>();
+  for (const item of items) {
+    const list = itemsByTradeId.get(item.tradeId) || [];
+    list.push(item);
+    itemsByTradeId.set(item.tradeId, list);
+  }
+
+  // Step 1: For each player, track all trades where they were received
+  // by the caller (sorted chronologically).
+  const incomingByPlayer = new Map<string, Array<{ tradeId: string; executedAt: number; weekExecuted: number }>>();
+  for (const trade of sortedTrades) {
+    const tradeItems = itemsByTradeId.get(trade.id) || [];
+    for (const item of tradeItems) {
+      if (!item.playerId) continue;
+      if (!callerTeamIds.has(item.toTeamId)) continue;
+      const list = incomingByPlayer.get(item.playerId) || [];
+      list.push({
+        tradeId: trade.id,
+        executedAt: trade.executedAt?.getTime() ?? 0,
+        weekExecuted: trade.weekExecuted ?? 0,
+      });
+      incomingByPlayer.set(item.playerId, list);
+    }
+  }
+
+  // Step 2: For each trade where the caller sent players, link to the
+  // incoming trade that brought that player.
+  // parentOf[childTradeId] = Set of parentTradeIds
+  // childrenOf[parentTradeId] = Array of { childTradeId, linkingPlayerId }
+  const childrenOf = new Map<string, Array<{ childTradeId: string; playerId: string }>>();
+  const parentOf = new Map<string, Set<string>>();
+  // Track which incoming trade each outgoing player links to
+  const linkMap = new Map<string, Map<string, string>>(); // childTradeId → playerId → parentTradeId
+
+  for (const trade of sortedTrades) {
+    const tradeItems = itemsByTradeId.get(trade.id) || [];
+    for (const item of tradeItems) {
+      if (!item.playerId) continue;
+      if (!callerTeamIds.has(item.fromTeamId)) continue;
+
+      // Find the most recent incoming trade for this player BEFORE this trade
+      const incoming = incomingByPlayer.get(item.playerId);
+      if (!incoming || incoming.length === 0) continue;
+
+      const tradeTime = trade.executedAt?.getTime() ?? 0;
+      // Find latest incoming that was before this outgoing
+      let bestMatch: { tradeId: string } | null = null;
+      for (let i = incoming.length - 1; i >= 0; i--) {
+        if (incoming[i].executedAt < tradeTime || (incoming[i].executedAt === tradeTime && incoming[i].tradeId !== trade.id)) {
+          bestMatch = incoming[i];
+          break;
+        }
+      }
+      if (!bestMatch) continue;
+
+      // Create parent→child link
+      const children = childrenOf.get(bestMatch.tradeId) || [];
+      // Avoid duplicate links (same child trade linked via multiple players)
+      if (!children.some((c) => c.childTradeId === trade.id && c.playerId === item.playerId)) {
+        children.push({ childTradeId: trade.id, playerId: item.playerId });
+        childrenOf.set(bestMatch.tradeId, children);
+      }
+
+      const parents = parentOf.get(trade.id) || new Set();
+      parents.add(bestMatch.tradeId);
+      parentOf.set(trade.id, parents);
+
+      // Track the link
+      const links = linkMap.get(trade.id) || new Map();
+      links.set(item.playerId, bestMatch.tradeId);
+      linkMap.set(trade.id, links);
+    }
+  }
+
+  // Step 3: Identify root trades — trades where the caller received
+  // players that have NO parent link (i.e., the player entered via
+  // this trade, not from a prior trade in the chain).
+  const callerTradeIds = new Set<string>();
+  for (const trade of sortedTrades) {
+    const tradeItems = itemsByTradeId.get(trade.id) || [];
+    const isInvolved = tradeItems.some(
+      (i) => callerTeamIds.has(i.fromTeamId) || callerTeamIds.has(i.toTeamId)
+    );
+    if (isInvolved) callerTradeIds.add(trade.id);
+  }
+
+  // A trade is a root if it has children OR received players, and it's
+  // not a child of another trade (or only partially a child).
+  // More precisely: a root is a caller trade that either has no parents
+  // at all, or has at least one received player not linked from a parent.
+  const rootTradeIds = new Set<string>();
+  for (const tradeId of callerTradeIds) {
+    if (!parentOf.has(tradeId)) {
+      // No parents at all — this could be a root if the user received players
+      const tradeItems = itemsByTradeId.get(tradeId) || [];
+      const hasReceived = tradeItems.some(
+        (i) => callerTeamIds.has(i.toTeamId) && i.playerId
+      );
+      const hasChildren = childrenOf.has(tradeId);
+      // Only create a root if this trade starts a chain (has children)
+      // OR received players (for single-node display)
+      if (hasReceived && hasChildren) {
+        rootTradeIds.add(tradeId);
+      }
+    }
+  }
+
+  // Step 4: Build tree nodes recursively
+  const visited = new Set<string>();
+
+  function buildNode(tradeId: string, depth: number): TradeTreeNode | null {
+    if (visited.has(tradeId)) return null; // prevent cycles
+    visited.add(tradeId);
+
+    const trade = tradeById.get(tradeId);
+    if (!trade) return null;
+
+    const tradeItems = itemsByTradeId.get(tradeId) || [];
+
+    // Build children first (bottom-up for cumulative stats)
+    const childLinks = childrenOf.get(tradeId) || [];
+    // Group by child trade ID
+    const childTradeIds = [...new Set(childLinks.map((c) => c.childTradeId))];
+    const children: TradeTreeNode[] = [];
+    for (const childTradeId of childTradeIds) {
+      const childNode = buildNode(childTradeId, depth + 1);
+      if (childNode) children.push(childNode);
+    }
+
+    // Build the "received" list — players the caller got in this trade
+    const received: TradeTreePlayerReceived[] = [];
+    for (const item of tradeItems) {
+      if (!callerTeamIds.has(item.toTeamId)) continue;
+
+      const info = item.playerId ? playerInfoById.get(item.playerId) : null;
+      const playerName = info?.name
+        || (item.draftPickYear ? `${item.draftPickYear} Round ${item.draftPickRound ?? '?'}` : 'Unknown');
+
+      // Find if this player was traded away (links to a child)
+      let tradedAwayInChildIndex: number | null = null;
+      let endWeek: number | null = null;
+      let endSeason: number | null = null;
+
+      if (item.playerId) {
+        for (let ci = 0; ci < children.length; ci++) {
+          const childTrade = tradeById.get(children[ci].tradeId);
+          const childItems = itemsByTradeId.get(children[ci].tradeId) || [];
+          const wasThisPlayerSent = childItems.some(
+            (ci2) => ci2.playerId === item.playerId && callerTeamIds.has(ci2.fromTeamId)
+          );
+          if (wasThisPlayerSent && childTrade) {
+            tradedAwayInChildIndex = ci;
+            endWeek = childTrade.weekExecuted;
+            endSeason = childTrade.seasonYear;
+            break;
+          }
+        }
+      }
+
+      // Compute points while held
+      const startWeek = (trade.weekExecuted ?? 0) + 1;
+      const startSeason = trade.seasonYear ?? 0;
+      let pointsWhileHeld = 0;
+      let weeksHeld = 0;
+
+      if (item.playerId && startSeason > 0) {
+        if (endWeek != null && endSeason != null && endSeason === startSeason) {
+          // Same season: sum weeks [startWeek, endWeek]
+          for (let w = startWeek; w <= endWeek; w++) {
+            const pts = pointsByPlayerWeek.get(`${item.playerId}_${startSeason}_${w}`) ?? 0;
+            pointsWhileHeld += pts;
+            weeksHeld++;
+          }
+        } else {
+          // Player still held (or cross-season) — sum to end of season
+          const lastWeek = lastWeekBySeason.get(startSeason) ?? 18;
+          for (let w = startWeek; w <= lastWeek; w++) {
+            const pts = pointsByPlayerWeek.get(`${item.playerId}_${startSeason}_${w}`) ?? 0;
+            pointsWhileHeld += pts;
+            weeksHeld++;
+          }
+          // If cross-season (dynasty), also sum the next season up to the outgoing week
+          if (endSeason != null && endSeason > startSeason) {
+            const crossLastWeek = endWeek ?? (lastWeekBySeason.get(endSeason) ?? 18);
+            for (let w = 1; w <= crossLastWeek; w++) {
+              const pts = pointsByPlayerWeek.get(`${item.playerId}_${endSeason}_${w}`) ?? 0;
+              pointsWhileHeld += pts;
+              weeksHeld++;
+            }
+          }
+        }
+      }
+
+      pointsWhileHeld = Math.round(pointsWhileHeld * 10) / 10;
+
+      received.push({
+        playerId: item.playerId,
+        playerName,
+        position: info?.position || (item.draftPickYear ? 'PICK' : 'UNK'),
+        nflTeam: info?.team || '',
+        pointsWhileHeld,
+        weeksHeld,
+        tradedAwayInChildIndex,
+        pickYear: item.draftPickYear,
+        pickRound: item.draftPickRound,
+      });
+    }
+
+    // Build the "sent" list — players the caller gave up in this trade
+    const sent: TradeTreePlayerSent[] = [];
+    for (const item of tradeItems) {
+      if (!callerTeamIds.has(item.fromTeamId)) continue;
+
+      const info = item.playerId ? playerInfoById.get(item.playerId) : null;
+      const playerName = info?.name
+        || (item.draftPickYear ? `${item.draftPickYear} Round ${item.draftPickRound ?? '?'}` : 'Unknown');
+
+      // Points scored after the trade (opportunity cost)
+      let pointsAfterTrade = 0;
+      const startWeek = (trade.weekExecuted ?? 0) + 1;
+      const season = trade.seasonYear ?? 0;
+      if (item.playerId && season > 0) {
+        const lastWeek = lastWeekBySeason.get(season) ?? 18;
+        for (let w = startWeek; w <= lastWeek; w++) {
+          pointsAfterTrade += pointsByPlayerWeek.get(`${item.playerId}_${season}_${w}`) ?? 0;
+        }
+      }
+      pointsAfterTrade = Math.round(pointsAfterTrade * 10) / 10;
+
+      sent.push({
+        playerId: item.playerId,
+        playerName,
+        position: info?.position || (item.draftPickYear ? 'PICK' : 'UNK'),
+        nflTeam: info?.team || '',
+        pointsAfterTrade,
+        pickYear: item.draftPickYear,
+        pickRound: item.draftPickRound,
+      });
+    }
+
+    const receivedTotal = received.reduce((sum, r) => sum + r.pointsWhileHeld, 0);
+    const sentTotal = sent.reduce((sum, s) => sum + s.pointsAfterTrade, 0);
+    const nodeDifferential = Math.round((receivedTotal - sentTotal) * 10) / 10;
+
+    const childrenCumulative = children.reduce((sum, c) => sum + c.cumulativeDifferential, 0);
+    const cumulativeDifferential = Math.round((nodeDifferential + childrenCumulative) * 10) / 10;
+
+    return {
+      tradeId,
+      executedAt: trade.executedAt?.toISOString() ?? null,
+      weekExecuted: trade.weekExecuted,
+      seasonYear: trade.seasonYear,
+      received,
+      sent,
+      nodeDifferential,
+      cumulativeDifferential,
+      depth,
+      aiGrade: trade.aiGrade,
+      children,
+    };
+  }
+
+  // Build all root trees, sorted by execution time (most recent first)
+  const trees: TradeTreeNode[] = [];
+  for (const rootId of rootTradeIds) {
+    visited.clear();
+    const tree = buildNode(rootId, 0);
+    if (tree) trees.push(tree);
+  }
+
+  // Sort: most recent chain first
+  trees.sort((a, b) => {
+    const aTime = a.executedAt ? new Date(a.executedAt).getTime() : 0;
+    const bTime = b.executedAt ? new Date(b.executedAt).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  return trees;
+}
+
+/** Walk a tree to find max depth. */
+function maxDepth(node: TradeTreeNode): number {
+  if (node.children.length === 0) return node.depth;
+  return Math.max(...node.children.map(maxDepth));
+}
+
+export function computeChainSummary(trees: TradeTreeNode[]): TradeTreeSummary {
+  if (trees.length === 0) {
+    return {
+      totalChains: 0,
+      longestChainDepth: 0,
+      bestChainDifferential: 0,
+      worstChainDifferential: 0,
+      totalPointsGained: 0,
+    };
+  }
+
+  const diffs = trees.map((t) => t.cumulativeDifferential);
+  const depths = trees.map(maxDepth);
+
+  return {
+    totalChains: trees.length,
+    longestChainDepth: Math.max(...depths),
+    bestChainDifferential: Math.max(...diffs),
+    worstChainDifferential: Math.min(...diffs),
+    totalPointsGained: Math.round(diffs.reduce((a, b) => a + b, 0) * 10) / 10,
+  };
+}

--- a/src/components/TradeAnalyzerShell.tsx
+++ b/src/components/TradeAnalyzerShell.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { ArrowRightLeft, History } from 'lucide-react';
+import { ArrowRightLeft, History, GitBranch } from 'lucide-react';
 import { TradeAnalyzerView } from './TradeAnalyzerView';
 import { TradeHistoryView } from './TradeHistoryView';
+import { TradeTreeView } from './TradeTreeView';
 // NOTE: TradeFinderView is intentionally NOT imported — the Trade
 // Finder tab is hidden for now. The component, backend route, and
 // related services are still in the repo so we can re-enable the
@@ -9,14 +10,14 @@ import { TradeHistoryView } from './TradeHistoryView';
 // the import, the 'finder' Tab union member, the tabs array entry,
 // and the render case below.
 
-type Tab = 'analyzer' | 'history';
+type Tab = 'analyzer' | 'history' | 'trees';
 
 interface TradeAnalyzerShellProps {
   isDarkMode: boolean;
 }
 
 /**
- * Shell that hosts the trade-related tabs: Analyzer and History.
+ * Shell that hosts the trade-related tabs: Analyzer, History, and Trade Trees.
  * (Trade Finder is currently hidden — see note above.)
  */
 export function TradeAnalyzerShell({ isDarkMode }: TradeAnalyzerShellProps) {
@@ -25,6 +26,7 @@ export function TradeAnalyzerShell({ isDarkMode }: TradeAnalyzerShellProps) {
   const tabs: Array<{ id: Tab; label: string; icon: typeof ArrowRightLeft }> = [
     { id: 'analyzer', label: 'Analyzer', icon: ArrowRightLeft },
     { id: 'history', label: 'History', icon: History },
+    { id: 'trees', label: 'Trade Trees', icon: GitBranch },
   ];
 
   return (
@@ -60,6 +62,7 @@ export function TradeAnalyzerShell({ isDarkMode }: TradeAnalyzerShellProps) {
 
       {tab === 'analyzer' && <TradeAnalyzerView isDarkMode={isDarkMode} />}
       {tab === 'history' && <TradeHistoryView isDarkMode={isDarkMode} />}
+      {tab === 'trees' && <TradeTreeView isDarkMode={isDarkMode} />}
     </div>
   );
 }

--- a/src/components/TradeChainCard.tsx
+++ b/src/components/TradeChainCard.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import {
+  GitBranch,
+  ChevronDown,
+  ChevronRight,
+  TrendingUp,
+  TrendingDown,
+} from 'lucide-react';
+import { TradeTreeNodeComponent, type TreeNode } from './TradeTreeNode';
+
+interface TradeChainCardProps {
+  tree: TreeNode;
+  isDarkMode: boolean;
+}
+
+/** Count total trades in a tree (including root). */
+function countNodes(node: TreeNode): number {
+  return 1 + node.children.reduce((sum, c) => sum + countNodes(c), 0);
+}
+
+/** Find the deepest depth in the tree. */
+function treeDepth(node: TreeNode): number {
+  if (node.children.length === 0) return 0;
+  return 1 + Math.max(...node.children.map(treeDepth));
+}
+
+export function TradeChainCard({ tree, isDarkMode }: TradeChainCardProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const totalTrades = countNodes(tree);
+  const depth = treeDepth(tree);
+  const diff = tree.cumulativeDifferential;
+
+  // Headline: first player received in the root trade
+  const rootPlayer = tree.received.find((r) => r.playerId);
+  const rootSent = tree.sent.find((s) => s.playerId);
+  const headline = rootPlayer
+    ? `${rootPlayer.playerName} chain`
+    : rootSent
+    ? `Traded ${rootSent.playerName}`
+    : 'Trade chain';
+
+  const dateStr = tree.executedAt
+    ? new Date(tree.executedAt).toLocaleDateString()
+    : '';
+
+  return (
+    <div
+      className={`rounded-xl border overflow-hidden ${
+        isDarkMode ? 'bg-slate-900/50 border-slate-700' : 'bg-white border-slate-200'
+      }`}
+    >
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        className={`w-full flex items-start gap-3 p-4 text-left transition-colors ${
+          isDarkMode ? 'hover:bg-slate-800/30' : 'hover:bg-slate-50'
+        }`}
+      >
+        <GitBranch
+          className={`w-4 h-4 mt-0.5 flex-shrink-0 ${
+            isDarkMode ? 'text-purple-400' : 'text-purple-600'
+          }`}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span
+              className={`text-sm font-semibold ${
+                isDarkMode ? 'text-slate-200' : 'text-slate-800'
+              }`}
+            >
+              {headline}
+            </span>
+            <span
+              className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
+                diff > 0
+                  ? isDarkMode ? 'bg-emerald-500/20 text-emerald-300' : 'bg-emerald-50 text-emerald-700'
+                  : diff < 0
+                  ? isDarkMode ? 'bg-red-500/20 text-red-300' : 'bg-red-50 text-red-700'
+                  : isDarkMode ? 'bg-slate-600/30 text-slate-300' : 'bg-slate-100 text-slate-600'
+              }`}
+            >
+              {diff > 0 ? '+' : ''}{diff} pts
+            </span>
+          </div>
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            <span
+              className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}
+            >
+              {dateStr && `Started ${dateStr}`}
+              {tree.weekExecuted ? ` · Wk ${tree.weekExecuted}` : ''}
+            </span>
+            <span
+              className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}
+            >
+              {totalTrades} {totalTrades === 1 ? 'trade' : 'trades'}
+              {depth > 0 ? ` · ${depth + 1} levels deep` : ''}
+            </span>
+          </div>
+          {/* Mini outcome indicator */}
+          <div className="flex items-center gap-1 mt-1.5">
+            {diff >= 0 ? (
+              <TrendingUp className="w-3 h-3 text-emerald-500" />
+            ) : (
+              <TrendingDown className="w-3 h-3 text-red-500" />
+            )}
+            <span
+              className={`text-xs font-medium ${
+                diff > 0
+                  ? isDarkMode ? 'text-emerald-400' : 'text-emerald-600'
+                  : diff < 0
+                  ? isDarkMode ? 'text-red-400' : 'text-red-600'
+                  : isDarkMode ? 'text-slate-400' : 'text-slate-500'
+              }`}
+            >
+              {diff > 0
+                ? `Gained ${diff} pts across the chain`
+                : diff < 0
+                ? `Lost ${Math.abs(diff)} pts across the chain`
+                : 'Even across the chain'}
+            </span>
+          </div>
+        </div>
+        {isOpen ? (
+          <ChevronDown className="w-4 h-4 mt-1 flex-shrink-0" />
+        ) : (
+          <ChevronRight className="w-4 h-4 mt-1 flex-shrink-0" />
+        )}
+      </button>
+
+      {isOpen && (
+        <div
+          className={`px-4 pb-4 pt-2 border-t ${
+            isDarkMode ? 'border-slate-800' : 'border-slate-200'
+          }`}
+        >
+          <TradeTreeNodeComponent node={tree} isDarkMode={isDarkMode} isRoot />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TradeTreeNode.tsx
+++ b/src/components/TradeTreeNode.tsx
@@ -1,0 +1,220 @@
+import { TrendingUp, TrendingDown, ArrowRight } from 'lucide-react';
+
+interface PlayerReceived {
+  playerId: string | null;
+  playerName: string;
+  position: string;
+  nflTeam: string;
+  pointsWhileHeld: number;
+  weeksHeld: number;
+  tradedAwayInChildIndex: number | null;
+  pickYear: number | null;
+  pickRound: number | null;
+}
+
+interface PlayerSent {
+  playerId: string | null;
+  playerName: string;
+  position: string;
+  nflTeam: string;
+  pointsAfterTrade: number;
+  pickYear: number | null;
+  pickRound: number | null;
+}
+
+export interface TreeNode {
+  tradeId: string;
+  executedAt: string | null;
+  weekExecuted: number | null;
+  seasonYear: number | null;
+  received: PlayerReceived[];
+  sent: PlayerSent[];
+  nodeDifferential: number;
+  cumulativeDifferential: number;
+  depth: number;
+  aiGrade: string | null;
+  children: TreeNode[];
+}
+
+interface TradeTreeNodeProps {
+  node: TreeNode;
+  isDarkMode: boolean;
+  isRoot?: boolean;
+}
+
+const positionColor: Record<string, string> = {
+  QB: 'text-red-400',
+  RB: 'text-blue-400',
+  WR: 'text-green-400',
+  TE: 'text-orange-400',
+  K: 'text-purple-400',
+  DEF: 'text-yellow-400',
+};
+
+export function TradeTreeNodeComponent({
+  node,
+  isDarkMode,
+  isRoot = false,
+}: TradeTreeNodeProps) {
+  const dateStr = node.executedAt
+    ? new Date(node.executedAt).toLocaleDateString()
+    : 'Unknown date';
+
+  const diffColor =
+    node.nodeDifferential > 0
+      ? isDarkMode ? 'text-emerald-400' : 'text-emerald-600'
+      : node.nodeDifferential < 0
+      ? isDarkMode ? 'text-red-400' : 'text-red-600'
+      : isDarkMode ? 'text-slate-400' : 'text-slate-500';
+
+  return (
+    <div className={isRoot ? '' : 'ml-6 relative'}>
+      {/* Connector line from parent */}
+      {!isRoot && (
+        <div
+          className={`absolute left-[-16px] top-0 bottom-0 w-px ${
+            isDarkMode ? 'bg-slate-700' : 'bg-slate-200'
+          }`}
+        />
+      )}
+      {!isRoot && (
+        <div
+          className={`absolute left-[-16px] top-5 w-4 h-px ${
+            isDarkMode ? 'bg-slate-700' : 'bg-slate-200'
+          }`}
+        />
+      )}
+
+      {/* Trade node card */}
+      <div
+        className={`rounded-lg border p-3 mb-2 ${
+          isDarkMode
+            ? 'bg-slate-800/50 border-slate-700'
+            : 'bg-white border-slate-200'
+        }`}
+      >
+        {/* Header row */}
+        <div className="flex items-center gap-2 flex-wrap mb-2">
+          <span
+            className={`text-xs font-medium ${
+              isDarkMode ? 'text-slate-400' : 'text-slate-500'
+            }`}
+          >
+            {dateStr}
+            {node.weekExecuted ? ` · Wk ${node.weekExecuted}` : ''}
+          </span>
+          {node.aiGrade && (
+            <span
+              className={`text-[10px] font-bold uppercase px-1.5 py-0.5 rounded ${
+                isDarkMode ? 'bg-blue-500/20 text-blue-300' : 'bg-blue-50 text-blue-700'
+              }`}
+            >
+              AI: {node.aiGrade}
+            </span>
+          )}
+          <span
+            className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
+              node.nodeDifferential > 0
+                ? isDarkMode ? 'bg-emerald-500/20 text-emerald-300' : 'bg-emerald-50 text-emerald-700'
+                : node.nodeDifferential < 0
+                ? isDarkMode ? 'bg-red-500/20 text-red-300' : 'bg-red-50 text-red-700'
+                : isDarkMode ? 'bg-slate-600/30 text-slate-300' : 'bg-slate-100 text-slate-600'
+            }`}
+          >
+            {node.nodeDifferential > 0 ? '+' : ''}
+            {node.nodeDifferential} pts
+          </span>
+        </div>
+
+        {/* Sent / Received */}
+        <div className="grid grid-cols-2 gap-3 text-xs">
+          {/* Sent */}
+          <div>
+            <p
+              className={`font-semibold uppercase text-[10px] mb-1 ${
+                isDarkMode ? 'text-red-400/70' : 'text-red-500/70'
+              }`}
+            >
+              Sent
+            </p>
+            {node.sent.map((p, i) => (
+              <div key={p.playerId ?? `pick-${i}`} className="flex items-baseline gap-1 mb-0.5">
+                <span className={positionColor[p.position] || (isDarkMode ? 'text-slate-400' : 'text-slate-500')}>
+                  {p.position !== 'UNK' && p.position !== 'PICK' ? `${p.position} ` : ''}
+                </span>
+                <span className={isDarkMode ? 'text-slate-200' : 'text-slate-800'}>
+                  {p.playerName}
+                </span>
+                {p.playerId && (
+                  <span className={`${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+                    · {p.pointsAfterTrade} pts after
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Received */}
+          <div>
+            <p
+              className={`font-semibold uppercase text-[10px] mb-1 ${
+                isDarkMode ? 'text-emerald-400/70' : 'text-emerald-500/70'
+              }`}
+            >
+              Received
+            </p>
+            {node.received.map((p, i) => (
+              <div key={p.playerId ?? `pick-${i}`} className="flex items-baseline gap-1 mb-0.5 flex-wrap">
+                <span className={positionColor[p.position] || (isDarkMode ? 'text-slate-400' : 'text-slate-500')}>
+                  {p.position !== 'UNK' && p.position !== 'PICK' ? `${p.position} ` : ''}
+                </span>
+                <span className={isDarkMode ? 'text-slate-200' : 'text-slate-800'}>
+                  {p.playerName}
+                </span>
+                {p.playerId && (
+                  <span className={`${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+                    · {p.pointsWhileHeld} pts
+                    {p.weeksHeld > 0 ? ` (${p.weeksHeld}w)` : ''}
+                  </span>
+                )}
+                {p.tradedAwayInChildIndex != null && (
+                  <ArrowRight className={`w-3 h-3 inline ${isDarkMode ? 'text-blue-400' : 'text-blue-500'}`} />
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Node differential summary */}
+        <div className={`flex items-center gap-1.5 mt-2 pt-2 border-t text-xs ${
+          isDarkMode ? 'border-slate-700' : 'border-slate-100'
+        }`}>
+          {node.nodeDifferential >= 0 ? (
+            <TrendingUp className="w-3 h-3 text-emerald-500" />
+          ) : (
+            <TrendingDown className="w-3 h-3 text-red-500" />
+          )}
+          <span className={`font-semibold ${diffColor}`}>
+            {node.nodeDifferential > 0 ? '+' : ''}
+            {node.nodeDifferential} pts at this trade
+          </span>
+          {node.children.length > 0 && (
+            <span className={isDarkMode ? 'text-slate-500' : 'text-slate-400'}>
+              · Chain: {node.cumulativeDifferential > 0 ? '+' : ''}
+              {node.cumulativeDifferential} pts
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Render children recursively */}
+      {node.children.map((child) => (
+        <TradeTreeNodeComponent
+          key={child.tradeId}
+          node={child}
+          isDarkMode={isDarkMode}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/TradeTreeView.tsx
+++ b/src/components/TradeTreeView.tsx
@@ -1,0 +1,291 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  GitBranch,
+  ChevronDown,
+  Loader2,
+  AlertCircle,
+  TrendingUp,
+  TrendingDown,
+} from 'lucide-react';
+import { api } from '../services/api';
+import { useAuth } from '../context/AuthContext';
+import { useLeaguesContext } from '../context/LeaguesContext';
+import { TradeChainCard } from './TradeChainCard';
+import type { TreeNode } from './TradeTreeNode';
+
+interface TradeTreeViewProps {
+  isDarkMode: boolean;
+}
+
+interface TreeSummary {
+  totalChains: number;
+  longestChainDepth: number;
+  bestChainDifferential: number;
+  worstChainDifferential: number;
+  totalPointsGained: number;
+}
+
+const LEAGUE_SELECTION_KEY = 'filmroom.tradeAnalyzer.selectedLeagueId';
+
+export function TradeTreeView({ isDarkMode }: TradeTreeViewProps) {
+  const { user } = useAuth();
+  const { leagues } = useLeaguesContext();
+
+  const [selectedLeagueId, setSelectedLeagueId] = useState<string>(() => {
+    try {
+      return localStorage.getItem(LEAGUE_SELECTION_KEY) || '';
+    } catch {
+      return '';
+    }
+  });
+  useEffect(() => {
+    try {
+      if (selectedLeagueId) localStorage.setItem(LEAGUE_SELECTION_KEY, selectedLeagueId);
+    } catch {
+      // ignore
+    }
+  }, [selectedLeagueId]);
+
+  const [trees, setTrees] = useState<TreeNode[]>([]);
+  const [summary, setSummary] = useState<TreeSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTrees = useCallback(
+    async (
+      leagueIdArg: string = selectedLeagueId,
+      { isCancelled }: { isCancelled?: () => boolean } = {}
+    ) => {
+      if (!leagueIdArg) {
+        setTrees([]);
+        setSummary(null);
+        return;
+      }
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await api.get<{
+          trees: TreeNode[];
+          summary: TreeSummary;
+          callerTeamId: string;
+          callerTeamName: string;
+        }>(`/trade-history/trade-trees/${leagueIdArg}`);
+        if (isCancelled?.()) return;
+        setTrees(res.trees);
+        setSummary(res.summary);
+      } catch (err) {
+        if (isCancelled?.()) return;
+        setError(
+          err instanceof Error ? err.message : 'Failed to load trade trees.'
+        );
+      } finally {
+        if (!isCancelled?.()) setIsLoading(false);
+      }
+    },
+    [selectedLeagueId]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchTrees(selectedLeagueId, { isCancelled: () => cancelled });
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchTrees, selectedLeagueId]);
+
+  useEffect(() => {
+    setError(null);
+  }, [selectedLeagueId]);
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div
+          className={`w-10 h-10 rounded-xl flex items-center justify-center ${
+            isDarkMode ? 'bg-purple-600/20' : 'bg-purple-50'
+          }`}
+        >
+          <GitBranch
+            className={`w-5 h-5 ${
+              isDarkMode ? 'text-purple-400' : 'text-purple-600'
+            }`}
+          />
+        </div>
+        <div>
+          <h1
+            className={`text-xl font-bold ${
+              isDarkMode ? 'text-white' : 'text-slate-900'
+            }`}
+          >
+            Trade Trees
+          </h1>
+          <p
+            className={`text-sm ${
+              isDarkMode ? 'text-slate-400' : 'text-slate-500'
+            }`}
+          >
+            Trace the lineage of your trades. See how one deal led to another
+            and whether the chain paid off.
+          </p>
+        </div>
+      </div>
+
+      {/* League selector */}
+      <div
+        className={`rounded-xl border p-4 ${
+          isDarkMode ? 'bg-slate-900/50 border-slate-700' : 'bg-white border-slate-200'
+        }`}
+      >
+        <label
+          htmlFor="trade-tree-league-select"
+          className={`block text-xs font-semibold uppercase tracking-wide mb-2 ${
+            isDarkMode ? 'text-slate-400' : 'text-slate-500'
+          }`}
+        >
+          League
+        </label>
+        <div className="relative">
+          <select
+            id="trade-tree-league-select"
+            value={selectedLeagueId}
+            onChange={(e) => setSelectedLeagueId(e.target.value)}
+            className={`w-full appearance-none pr-9 pl-3 py-2 text-sm rounded-lg border transition-colors ${
+              isDarkMode
+                ? 'bg-slate-800 border-slate-600 text-white'
+                : 'bg-white border-slate-300 text-slate-900'
+            } outline-none`}
+          >
+            <option value="">Select a league...</option>
+            {leagues.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.name}
+                {l.platform ? ` (${l.platform})` : ''}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            className={`absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none ${
+              isDarkMode ? 'text-slate-400' : 'text-slate-500'
+            }`}
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div
+          className={`flex items-start gap-3 p-4 rounded-xl border ${
+            isDarkMode
+              ? 'bg-red-500/10 border-red-500/20 text-red-400'
+              : 'bg-red-50 border-red-200 text-red-600'
+          }`}
+        >
+          <AlertCircle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+          <p className="text-sm">{error}</p>
+        </div>
+      )}
+
+      {/* Summary card */}
+      {summary && summary.totalChains > 0 && !isLoading && (
+        <div
+          className={`rounded-xl border p-5 ${
+            isDarkMode ? 'bg-slate-900/50 border-slate-700' : 'bg-white border-slate-200'
+          }`}
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <GitBranch
+              className={`w-4 h-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`}
+            />
+            <p
+              className={`text-sm font-semibold ${
+                isDarkMode ? 'text-slate-300' : 'text-slate-700'
+              }`}
+            >
+              Chain Summary
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <div className={`p-3 rounded-lg ${isDarkMode ? 'bg-slate-800/50' : 'bg-slate-50'}`}>
+              <p className={`text-[10px] font-bold uppercase mb-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                Chains
+              </p>
+              <p className={`text-xl font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+                {summary.totalChains}
+              </p>
+            </div>
+            <div className={`p-3 rounded-lg ${isDarkMode ? 'bg-slate-800/50' : 'bg-slate-50'}`}>
+              <p className={`text-[10px] font-bold uppercase mb-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                Deepest
+              </p>
+              <p className={`text-xl font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+                {summary.longestChainDepth + 1} trades
+              </p>
+            </div>
+            <div className={`p-3 rounded-lg ${isDarkMode ? 'bg-slate-800/50' : 'bg-slate-50'}`}>
+              <p className={`text-[10px] font-bold uppercase mb-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                Best Chain
+              </p>
+              <p className={`text-xl font-bold ${
+                summary.bestChainDifferential >= 0
+                  ? 'text-emerald-500'
+                  : 'text-red-500'
+              }`}>
+                {summary.bestChainDifferential > 0 ? '+' : ''}{summary.bestChainDifferential}
+              </p>
+            </div>
+            <div className={`p-3 rounded-lg ${isDarkMode ? 'bg-slate-800/50' : 'bg-slate-50'}`}>
+              <p className={`text-[10px] font-bold uppercase mb-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                Net Points
+              </p>
+              <p className={`text-xl font-bold ${
+                summary.totalPointsGained >= 0
+                  ? 'text-emerald-500'
+                  : 'text-red-500'
+              }`}>
+                {summary.totalPointsGained > 0 ? '+' : ''}{summary.totalPointsGained}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Trade tree list */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2
+            className={`w-6 h-6 animate-spin ${
+              isDarkMode ? 'text-purple-400' : 'text-purple-600'
+            }`}
+          />
+        </div>
+      ) : trees.length === 0 && selectedLeagueId ? (
+        <div
+          className={`rounded-xl border p-8 text-center ${
+            isDarkMode ? 'bg-slate-900/50 border-slate-700' : 'bg-white border-slate-200'
+          }`}
+        >
+          <GitBranch
+            className={`w-8 h-8 mx-auto mb-3 ${
+              isDarkMode ? 'text-slate-600' : 'text-slate-300'
+            }`}
+          />
+          <p
+            className={`text-sm ${
+              isDarkMode ? 'text-slate-400' : 'text-slate-500'
+            }`}
+          >
+            No trade chains found. Chains appear when a player you received
+            in one trade is later traded away in another.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {trees.map((tree) => (
+            <TradeChainCard key={tree.tradeId} tree={tree} isDarkMode={isDarkMode} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
New feature that builds branching "trade trees" showing how one deal led to another. When a player arrives via Trade A and is later sent away in Trade B, those trades form a parent→child link in the tree.

Backend:
- New service (tradeChains.ts) with pure in-memory chain-building algorithm. Walks trade items to link outgoing players to their most recent incoming trade, handles temporal ordering, cross-season chains, draft picks as terminal assets, and cycle prevention.
- New GET /trade-trees/:leagueId endpoint in tradeHistory.ts that reuses the established bulk-fetch + chunked pattern.
- "Points while held" metric: PPR points bounded to the period the user actually rostered each player (from incoming to outgoing trade).

Frontend:
- TradeTreeNode.tsx: recursive component rendering one trade node with sent/received players, per-node differential, and connector lines to children via CSS borders.
- TradeChainCard.tsx: collapsible card wrapping a full chain with headline, trade count, depth, and cumulative differential.
- TradeTreeView.tsx: top-level view with league selector, summary stats card (total chains, deepest, best/worst, net points), and chain list.
- Added "Trade Trees" tab to TradeAnalyzerShell.tsx alongside Analyzer and History.

https://claude.ai/code/session_011rGsZMoaveicATYTaSfo5M