### PR TITLE
Improve AdSense compliance with content quality checks

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,14 @@ User-agent: *
 Allow: /
 Disallow: /api/
 
+# Thin/utility pages — no substantial publisher content (AdSense compliance)
+Disallow: /login
+Disallow: /register
+Disallow: /research
+Disallow: /draft-rankings
+Disallow: /league-analyzer
+Disallow: /settings
+Disallow: /profile
+Disallow: /admin
+
 Sitemap: https://filmroomfantasy.com/sitemap.xml

--- a/src/components/AdUnit.tsx
+++ b/src/components/AdUnit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const ADSENSE_SRC = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6355054767351119';
 
@@ -24,6 +24,18 @@ function loadAdSenseScript(): Promise<void> {
   });
 }
 
+/**
+ * Minimum amount of visible text (in characters) on the page for ads to render.
+ * Prevents ads from showing on thin/empty screens (AdSense "low value content" policy).
+ */
+const MIN_PAGE_TEXT_LENGTH = 500;
+
+function pageHasEnoughContent(): boolean {
+  const main = document.querySelector('main');
+  const textContent = (main || document.body).innerText || '';
+  return textContent.length >= MIN_PAGE_TEXT_LENGTH;
+}
+
 interface AdUnitProps {
   slot: string;
   format?: 'auto' | 'rectangle' | 'horizontal' | 'vertical';
@@ -33,14 +45,23 @@ interface AdUnitProps {
 
 export function AdUnit({ slot, format = 'auto', className = '', isDarkMode }: AdUnitProps) {
   const adRef = useRef<HTMLDivElement>(null);
+  const [hasContent, setHasContent] = useState(false);
 
   useEffect(() => {
-    loadAdSenseScript().then(() => {
-      try {
-        ((window as any).adsbygoogle = (window as any).adsbygoogle || []).push({});
-      } catch {}
-    });
+    // Defer the content check so the page has time to render
+    const timer = setTimeout(() => {
+      if (!pageHasEnoughContent()) return;
+      setHasContent(true);
+      loadAdSenseScript().then(() => {
+        try {
+          ((window as any).adsbygoogle = (window as any).adsbygoogle || []).push({});
+        } catch {}
+      });
+    }, 100);
+    return () => clearTimeout(timer);
   }, []);
+
+  if (!hasContent) return null;
 
   return (
     <div className={`ad-unit ${className}`} ref={adRef}>

--- a/src/components/GameSlateView.tsx
+++ b/src/components/GameSlateView.tsx
@@ -406,8 +406,8 @@ export function GameSlateView({ onSelectGame, isDarkMode = true }: GameSlateView
           </div>
           );
 
-          // Show ad after every 4th game
-          const showAd = (idx + 1) % 4 === 0 && idx !== displayGames.length - 1;
+          // Show a single ad after the 6th game (only when 8+ games provide enough content)
+          const showAd = displayGames.length >= 8 && idx === 5;
 
           return (
             <div key={game.id} className="contents">

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -6,7 +6,7 @@ import api from '../services/api';
 import { playerService } from '../services';
 import type { PlayerNews, MatchupGradeResponse } from '../services';
 import { NewsSnippet } from './NewsSnippet';
-import { AdUnit } from './AdUnit';
+
 
 
 interface PlayerCardProps {
@@ -1238,11 +1238,6 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
               );
             })() : null}
 
-            {/* AdSense Ad Unit */}
-            <div className="my-4 rounded-lg overflow-hidden">
-              <div className={`text-[10px] text-slate-600 text-center mb-1`}>Ad</div>
-              <AdUnit slot="playercard-bottom" isDarkMode={isDarkMode} />
-            </div>
           </div>
         </div>
       </div>

--- a/src/components/PlayerTable.tsx
+++ b/src/components/PlayerTable.tsx
@@ -559,8 +559,8 @@ export function PlayerTable({
           </div>
         )}
 
-        {/* AdSense Ad Unit */}
-        {!error && totalPlayers > 0 && (
+        {/* AdSense Ad Unit — only when table has substantial content */}
+        {!error && totalPlayers >= 10 && (
           <div className="my-4 rounded-lg overflow-hidden px-6">
             <div className={`text-[10px] text-slate-600 text-center mb-1`}>Ad</div>
             <AdUnit slot="board-below-table" isDarkMode={isDarkMode} />


### PR DESCRIPTION
## Summary
This PR implements AdSense policy compliance improvements by ensuring ads only render on pages with sufficient content and preventing ads from appearing on thin utility pages.

## Key Changes

- **AdUnit component enhancement**: Added content validation that checks for minimum 500 characters of text before rendering ads, with a 100ms delay to allow page rendering to complete
- **robots.txt updates**: Added disallow rules for utility/thin pages (login, register, research, draft-rankings, league-analyzer, settings, profile, admin) to prevent search engine indexing of low-content pages
- **PlayerCard**: Removed inline ad unit that was displaying on player detail cards
- **GameSlateView**: Changed ad display logic from showing ads after every 4th game to showing a single ad after the 6th game only when 8+ games are present (ensuring sufficient content)
- **PlayerTable**: Updated ad display condition to require at least 10 players in the table instead of just 1+ players

## Implementation Details

The `pageHasEnoughContent()` function checks the text content of the main element (or document body as fallback) to ensure pages meet AdSense's "low value content" policy requirements. The content check is deferred with a 100ms timeout to allow the DOM to fully render before validation. The component returns null if content requirements aren't met, preventing ad rendering entirely.

These changes align with AdSense policies that prohibit ads on pages with insufficient original content while maintaining ad placement on content-rich pages.

https://claude.ai/code/session_01BcregWGTcixvnM42RNQ3an