### PR TITLE
Add AI-powered draft rankings with redraft and dynasty rookie modes

### DIFF
--- a/server/migrations/0031_add_draft_rankings.sql
+++ b/server/migrations/0031_add_draft_rankings.sql
@@ -1,0 +1,20 @@
+-- Draft Rankings table for AI-generated draft rankings
+CREATE TABLE IF NOT EXISTS `draft_rankings` (
+  `id` text PRIMARY KEY NOT NULL,
+  `player_id` text NOT NULL REFERENCES `nfl_players`(`id`) ON DELETE CASCADE,
+  `ranking_type` text NOT NULL,
+  `scoring_format` text NOT NULL,
+  `superflex` integer NOT NULL DEFAULT 0,
+  `overall_rank` integer NOT NULL,
+  `position_rank` integer NOT NULL,
+  `tier` integer NOT NULL,
+  `projected_points` real,
+  `adp` real,
+  `adp_delta` real,
+  `rationale` text NOT NULL,
+  `season_year` integer NOT NULL,
+  `generated_at` integer NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `draft_rank_unique` ON `draft_rankings` (`player_id`, `ranking_type`, `scoring_format`, `superflex`, `season_year`);
+CREATE INDEX IF NOT EXISTS `idx_draft_rank_type` ON `draft_rankings` (`ranking_type`, `scoring_format`, `superflex`, `season_year`);

--- a/server/migrations/0032_add_draft_ranking_analysis.sql
+++ b/server/migrations/0032_add_draft_ranking_analysis.sql
@@ -1,0 +1,2 @@
+-- Add analysis column for detailed AI player breakdowns
+ALTER TABLE `draft_rankings` ADD COLUMN `analysis` text;

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -689,6 +689,7 @@ export const draftRankings = sqliteTable('draft_rankings', {
   adp: real('adp'), // average draft position from Sleeper
   adpDelta: real('adp_delta'), // rank - ADP (negative = value, positive = reach)
   rationale: text('rationale').notNull(), // AI-generated 1-2 sentence blurb
+  analysis: text('analysis'), // AI-generated detailed player analysis (strengths, risks, outlook)
   seasonYear: integer('season_year').notNull(),
   generatedAt: integer('generated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
 }, (table) => ({

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -668,6 +668,42 @@ export type TeamScoutingReport = typeof teamScoutingReports.$inferSelect;
 export type NewTeamScoutingReport = typeof teamScoutingReports.$inferInsert;
 
 // ============================================
+// DRAFT RANKINGS
+// ============================================
+//
+// Pre-computed AI draft rankings. Redraft rankings are anchored on
+// Sleeper ADP + Claude analysis; dynasty rookie rankings are
+// generated entirely by Claude from player context. Rankings are
+// regenerated on-demand from the admin panel or via cron.
+
+export const draftRankings = sqliteTable('draft_rankings', {
+  id: text('id').primaryKey(),
+  playerId: text('player_id').notNull().references(() => nflPlayers.id, { onDelete: 'cascade' }),
+  rankingType: text('ranking_type').notNull(), // 'redraft' | 'dynasty_rookie'
+  scoringFormat: text('scoring_format').notNull(), // 'ppr' | 'half-ppr' | 'standard'
+  superflex: integer('superflex', { mode: 'boolean' }).notNull().default(false),
+  overallRank: integer('overall_rank').notNull(),
+  positionRank: integer('position_rank').notNull(),
+  tier: integer('tier').notNull(), // 1-8 tier grouping
+  projectedPoints: real('projected_points'), // full-season projected total (null for rookies without data)
+  adp: real('adp'), // average draft position from Sleeper
+  adpDelta: real('adp_delta'), // rank - ADP (negative = value, positive = reach)
+  rationale: text('rationale').notNull(), // AI-generated 1-2 sentence blurb
+  seasonYear: integer('season_year').notNull(),
+  generatedAt: integer('generated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+}, (table) => ({
+  draftRankUnique: uniqueIndex('draft_rank_unique').on(table.playerId, table.rankingType, table.scoringFormat, table.superflex, table.seasonYear),
+  draftRankTypeIdx: index('idx_draft_rank_type').on(table.rankingType, table.scoringFormat, table.superflex, table.seasonYear),
+}));
+
+export const draftRankingsRelations = relations(draftRankings, ({ one }) => ({
+  player: one(nflPlayers, { fields: [draftRankings.playerId], references: [nflPlayers.id] }),
+}));
+
+export type DraftRanking = typeof draftRankings.$inferSelect;
+export type NewDraftRanking = typeof draftRankings.$inferInsert;
+
+// ============================================
 // TYPE EXPORTS
 // ============================================
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -287,6 +287,13 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
     await callSync('/api/admin/sync-twitter-news');
     await callSync('/api/admin/sync-espn-news');
     await callSync('/api/admin/sync-rotowire-news');
+  } else if (event.cron === '0 14 * * 1') {
+    // Weekly Monday 8 AM CT: regenerate AI draft rankings
+    // Generate PPR + Half PPR for both redraft and dynasty rookie
+    await callSync('/api/admin/generate-draft-rankings', { type: 'redraft', scoring: 'ppr' });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'redraft', scoring: 'half-ppr' });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty_rookie', scoring: 'ppr' });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty_rookie', scoring: 'half-ppr' });
   }
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -287,8 +287,8 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
     await callSync('/api/admin/sync-twitter-news');
     await callSync('/api/admin/sync-espn-news');
     await callSync('/api/admin/sync-rotowire-news');
-  } else if (event.cron === '0 14 * * 1') {
-    // Weekly Monday 8 AM CT: regenerate AI draft rankings
+  } else if (event.cron === '0 20 * * 1') {
+    // Weekly Monday 3 PM CT: regenerate AI draft rankings
     // Generate PPR + Half PPR for both redraft and dynasty rookie
     await callSync('/api/admin/generate-draft-rankings', { type: 'redraft', scoring: 'ppr' });
     await callSync('/api/admin/generate-draft-rankings', { type: 'redraft', scoring: 'half-ppr' });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,7 @@ import { tradeHistoryRoutes } from './routes/tradeHistory';
 import { tradeFinderRoutes } from './routes/tradeFinder';
 import { analyticsRoutes } from './routes/analytics';
 import { articleRoutes } from './routes/articles';
+import { draftRankingsRoutes } from './routes/draftRankings';
 
 // Types
 export type Env = {
@@ -188,6 +189,7 @@ app.route('/api/rosters', rostersRoutes);
 app.route('/api/admin', adminStatsRoutes);
 app.route('/api/analytics', analyticsRoutes);
 app.route('/api/articles', articleRoutes);
+app.route('/api/draft-rankings', draftRankingsRoutes);
 
 // 404 handler
 app.notFound((c) => {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -8,6 +8,7 @@ import { generateId } from '../utils/id';
 import { invalidateCache } from '../utils/cache';
 import { fetchCurrentOdds, fetchHistoricalOdds, parseOddsResponse, fetchPlayerProps, parsePlayerProps } from '../services/odds';
 import { generateProjectionsFromProps } from '../services/projections';
+import { generateDraftRankings } from '../services/draftRankings';
 import { adminAuthMiddleware } from '../middleware/adminAuth';
 import type { Env, Variables } from '../index';
 
@@ -1924,5 +1925,71 @@ adminRoutes.post('/bulk-set-tier', async (c) => {
       },
       500
     );
+  }
+});
+
+/**
+ * POST /api/admin/generate-draft-rankings
+ *
+ * Triggers AI draft ranking generation. Body:
+ *  - type: 'redraft' | 'dynasty_rookie' (default: 'redraft')
+ *  - scoring: 'ppr' | 'half-ppr' | 'standard' (default: 'ppr')
+ *  - superflex: boolean (default: false)
+ *  - season: number (default: current year)
+ */
+adminRoutes.post('/generate-draft-rankings', async (c) => {
+  const db = c.get('db');
+  const anthropicKey = c.env.ANTHROPIC_API_KEY;
+
+  if (!anthropicKey) {
+    return c.json({ error: 'ANTHROPIC_API_KEY not configured' }, 500);
+  }
+
+  try {
+    const body = await c.req.json().catch(() => ({})) as {
+      type?: string;
+      scoring?: string;
+      superflex?: boolean;
+      season?: number;
+    };
+
+    const rankingType = (body.type || 'redraft') as 'redraft' | 'dynasty_rookie';
+    const scoringFormat = (body.scoring || 'ppr') as 'ppr' | 'half-ppr' | 'standard';
+    const superflex = body.superflex ?? false;
+    const seasonYear = body.season || new Date().getFullYear();
+
+    if (!['redraft', 'dynasty_rookie'].includes(rankingType)) {
+      return c.json({ error: 'Invalid type — use "redraft" or "dynasty_rookie"' }, 400);
+    }
+    if (!['ppr', 'half-ppr', 'standard'].includes(scoringFormat)) {
+      return c.json({ error: 'Invalid scoring — use "ppr", "half-ppr", or "standard"' }, 400);
+    }
+
+    const result = await generateDraftRankings({
+      db,
+      anthropicKey,
+      rankingType,
+      scoringFormat,
+      superflex,
+      seasonYear,
+    });
+
+    // Invalidate cache for this combination
+    invalidateCache('draft-rankings:', true);
+
+    if (!result.ok) {
+      return c.json({ error: result.error, count: 0 }, 500);
+    }
+
+    return c.json({
+      message: `Generated ${result.count} ${rankingType} rankings (${scoringFormat}, superflex=${superflex})`,
+      count: result.count,
+    });
+  } catch (err) {
+    console.error('[admin] generate-draft-rankings error:', err);
+    return c.json({
+      error: 'Failed to generate draft rankings',
+      message: err instanceof Error ? err.message : 'Unknown error',
+    }, 500);
   }
 });

--- a/server/src/routes/draftRankings.ts
+++ b/server/src/routes/draftRankings.ts
@@ -1,0 +1,86 @@
+import { Hono } from 'hono';
+import { eq, and, asc } from 'drizzle-orm';
+import * as schema from '../db/schema';
+import { cached } from '../utils/cache';
+import type { Env, Variables } from '../index';
+
+export const draftRankingsRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
+
+/**
+ * GET /api/draft-rankings
+ *
+ * Query params:
+ *  - type: 'redraft' | 'dynasty_rookie' (default: 'redraft')
+ *  - scoring: 'ppr' | 'half-ppr' | 'standard' (default: 'ppr')
+ *  - superflex: '0' | '1' (default: '0')
+ *  - season: number (default: current year)
+ */
+draftRankingsRoutes.get('/', async (c) => {
+  const db = c.get('db');
+  const rankingType = (c.req.query('type') || 'redraft') as 'redraft' | 'dynasty_rookie';
+  const scoringFormat = (c.req.query('scoring') || 'ppr') as 'ppr' | 'half-ppr' | 'standard';
+  const superflex = c.req.query('superflex') === '1';
+  const season = parseInt(c.req.query('season') || String(new Date().getFullYear()), 10);
+
+  // Validate
+  if (!['redraft', 'dynasty_rookie'].includes(rankingType)) {
+    return c.json({ error: 'Invalid ranking type' }, 400);
+  }
+  if (!['ppr', 'half-ppr', 'standard'].includes(scoringFormat)) {
+    return c.json({ error: 'Invalid scoring format' }, 400);
+  }
+
+  const cacheKey = `draft-rankings:${rankingType}:${scoringFormat}:${superflex}:${season}`;
+  const result = await cached(cacheKey, 5 * 60 * 1000, async () => {
+    const rankings = await db.query.draftRankings.findMany({
+      where: and(
+        eq(schema.draftRankings.rankingType, rankingType),
+        eq(schema.draftRankings.scoringFormat, scoringFormat),
+        eq(schema.draftRankings.superflex, superflex),
+        eq(schema.draftRankings.seasonYear, season),
+      ),
+      orderBy: asc(schema.draftRankings.overallRank),
+      with: {
+        player: {
+          columns: {
+            id: true,
+            name: true,
+            position: true,
+            team: true,
+            age: true,
+            yearsExp: true,
+            status: true,
+            injuryNote: true,
+            headshotUrl: true,
+            externalId: true,
+          },
+        },
+      },
+    });
+
+    return rankings.map(r => ({
+      id: r.id,
+      overallRank: r.overallRank,
+      positionRank: r.positionRank,
+      tier: r.tier,
+      projectedPoints: r.projectedPoints,
+      adp: r.adp,
+      adpDelta: r.adpDelta,
+      rationale: r.rationale,
+      generatedAt: r.generatedAt,
+      player: r.player,
+    }));
+  });
+
+  return c.json({
+    rankings: result,
+    meta: {
+      rankingType,
+      scoringFormat,
+      superflex,
+      season,
+      count: result.length,
+      generatedAt: result.length > 0 ? result[0].generatedAt : null,
+    },
+  });
+});

--- a/server/src/routes/draftRankings.ts
+++ b/server/src/routes/draftRankings.ts
@@ -67,6 +67,7 @@ draftRankingsRoutes.get('/', async (c) => {
       adp: r.adp,
       adpDelta: r.adpDelta,
       rationale: r.rationale,
+      analysis: r.analysis,
       generatedAt: r.generatedAt,
       player: r.player,
     }));

--- a/server/src/services/draftRankings.ts
+++ b/server/src/services/draftRankings.ts
@@ -189,7 +189,8 @@ RESPOND WITH ONLY VALID JSON — an array of objects, one per ranked player. Ran
     "positionRank": 1,
     "tier": 1,
     "projectedPoints": 320.5,
-    "rationale": "1-2 sentence explanation of ranking and any ADP disagreement"
+    "rationale": "1 concise sentence summarizing rank and ADP value",
+    "analysis": "3-5 sentence detailed breakdown covering: key strengths, primary risks/concerns, situation/opportunity outlook, and fantasy upside/ceiling vs floor. Reference specific stats, coaching changes, depth chart battles, or scheme fit."
   }
 ]
 
@@ -208,7 +209,8 @@ IMPORTANT:
 - Tiers should have natural breakpoints — don't force exact counts
 - Flag players where you meaningfully disagree with ADP in the rationale
 - Account for injury risk, age, opportunity changes, and coaching/scheme changes
-- Be specific in rationale — "elite volume" is lazy, "led NFL in targets last season at age 24 with a healthy QB returning" is good`;
+- rationale: 1 punchy sentence (shown inline in the rankings table)
+- analysis: 3-5 sentences of real scouting — strengths, weaknesses, situation, fantasy outlook. This is the main value-add. Be specific: reference stats, scheme, coaching, age curves, injury history. "Elite volume" is lazy; "led NFL with 178 targets at age 24, now gets a healthy Dak back after relying on Cooper Rush for 6 games" is good.`;
 }
 
 function buildDynastyRookiePrompt(
@@ -245,7 +247,8 @@ RESPOND WITH ONLY VALID JSON — an array of objects, one per ranked rookie:
     "positionRank": 1,
     "tier": 1,
     "projectedPoints": null,
-    "rationale": "1-2 sentence explanation focusing on draft capital, landing spot, and path to production"
+    "rationale": "1 concise sentence on rank and value",
+    "analysis": "3-5 sentence detailed breakdown covering: draft capital and what it signals, landing spot quality (scheme, coaching, offensive line), path to playing time (who's ahead, competition), college production profile, and realistic year-1 vs long-term dynasty outlook."
   }
 ]
 
@@ -258,7 +261,8 @@ TIER RULES (dynasty rookie context):
 
 IMPORTANT:
 - projectedPoints can be null for rookies with high uncertainty, or a rough estimate if you're confident
-- Be specific about WHY a player is ranked where they are — "Day 2 pick in a run-heavy offense behind an aging starter" is better than "good prospect"
+- rationale: 1 punchy sentence (shown inline in the rankings table)
+- analysis: 3-5 sentences of real scouting — draft capital, landing spot, depth chart, college production, year-1 vs long-term outlook. Be specific: "Day 2 pick in a run-heavy offense behind an aging Derrick Henry, with the offensive line ranked 5th in run blocking" is good. "Good prospect with upside" is worthless.
 - Landing spot matters MORE than college tape for year-1 fantasy value`;
 }
 
@@ -354,6 +358,7 @@ export async function generateDraftRankings(
     tier: number;
     projectedPoints: number | null;
     rationale: string;
+    analysis?: string;
   }>;
 
   try {
@@ -412,6 +417,7 @@ export async function generateDraftRankings(
       adp: player.adp,
       adpDelta: player.adp != null ? r.overallRank - player.adp : null,
       rationale: r.rationale || '',
+      analysis: r.analysis || null,
       seasonYear,
       generatedAt: now,
     });

--- a/server/src/services/draftRankings.ts
+++ b/server/src/services/draftRankings.ts
@@ -1,0 +1,428 @@
+/**
+ * draftRankings — generates AI-powered draft rankings.
+ *
+ * Two modes:
+ *  1. Redraft: Pulls Sleeper ADP as a baseline, enriches with player context
+ *     (age, stats, injury, depth chart, news), and asks Claude to generate
+ *     tiers, rationale, and value flags where it disagrees with ADP.
+ *  2. Dynasty Rookie: Filters to rookies (yearsExp === 0), and asks Claude
+ *     to generate full rankings from player context since rookies lack
+ *     extensive fantasy history.
+ *
+ * Rankings are pre-computed and stored in the draft_rankings table.
+ * They are NOT generated per-request — an admin trigger or cron job
+ * calls generateDraftRankings() and results are served from the DB.
+ */
+
+import { eq, and, desc, inArray } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/d1';
+import * as schema from '../db/schema';
+import { generateId } from '../utils/id';
+
+type DB = ReturnType<typeof drizzle<typeof schema>>;
+
+// ── Sleeper ADP ─────────────────────────────────────────────────────
+
+interface SleeperADPEntry {
+  player_id: string;
+  adp: number;
+}
+
+/**
+ * Fetch ADP data from Sleeper's undocumented ADP endpoint.
+ * Returns a map of sleeper_player_id → adp value.
+ */
+async function fetchSleeperADP(
+  scoringFormat: 'ppr' | 'half-ppr' | 'standard',
+): Promise<Map<string, number>> {
+  // Sleeper ADP endpoint: players/nfl/trending/add (past 24h activity as proxy)
+  // More reliable: use their draft ADP endpoint
+  const scoringParam = scoringFormat === 'ppr' ? 'ppr' : scoringFormat === 'half-ppr' ? 'half_ppr' : 'std';
+  const url = `https://api.sleeper.app/v1/players/nfl/trending/add?lookback_hours=720&limit=200`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.warn(`[draftRankings] Sleeper trending API returned ${res.status}`);
+      return new Map();
+    }
+    const data = (await res.json()) as { player_id: string; count: number }[];
+    // Use the ranking order as a rough ADP proxy (most-added = highest demand)
+    const adpMap = new Map<string, number>();
+    data.forEach((entry, idx) => {
+      adpMap.set(entry.player_id, idx + 1);
+    });
+    return adpMap;
+  } catch (err) {
+    console.error('[draftRankings] Failed to fetch Sleeper ADP:', err);
+    return new Map();
+  }
+}
+
+// ── Player context builder ──────────────────────────────────────────
+
+interface PlayerContext {
+  id: string;
+  externalId: string | null;
+  name: string;
+  position: string;
+  team: string;
+  age: number | null;
+  yearsExp: number | null;
+  status: string;
+  injuryNote: string | null;
+  depthChartOrder: number | null;
+  lastSeasonPoints: number | null;
+  lastSeasonGames: number | null;
+  recentNews: string[];
+  adp: number | null;
+}
+
+async function buildPlayerContexts(
+  db: DB,
+  rankingType: 'redraft' | 'dynasty_rookie',
+  scoringFormat: 'ppr' | 'half-ppr' | 'standard',
+  seasonYear: number,
+  sleeperADP: Map<string, number>,
+): Promise<PlayerContext[]> {
+  // Fetch players
+  const posFilter = ['QB', 'RB', 'WR', 'TE'];
+  const allPlayers = await db.query.nflPlayers.findMany({
+    where: inArray(schema.nflPlayers.position, posFilter),
+  });
+
+  // Filter for dynasty rookie: only players with 0 years experience
+  let players = rankingType === 'dynasty_rookie'
+    ? allPlayers.filter(p => p.yearsExp === 0)
+    : allPlayers.filter(p => p.status !== 'inactive' && p.team !== 'FA');
+
+  // Get last season stats for each player
+  const prevSeason = seasonYear - 1;
+  const pointsCol = scoringFormat === 'ppr'
+    ? 'fantasyPointsPPR'
+    : scoringFormat === 'half-ppr'
+    ? 'fantasyPointsHalf'
+    : 'fantasyPointsStd';
+
+  const statsRows = await db.query.playerWeeklyStats.findMany({
+    where: eq(schema.playerWeeklyStats.seasonYear, prevSeason),
+  });
+
+  // Group stats by player
+  const statsByPlayer = new Map<string, { totalPoints: number; gamesPlayed: number }>();
+  for (const row of statsRows) {
+    const pts = (row as any)[pointsCol] || 0;
+    if (pts === 0) continue;
+    const entry = statsByPlayer.get(row.playerId) || { totalPoints: 0, gamesPlayed: 0 };
+    entry.totalPoints += pts;
+    entry.gamesPlayed += 1;
+    statsByPlayer.set(row.playerId, entry);
+  }
+
+  // Get recent news (last 30 days worth)
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  const newsRows = await db.query.playerNews.findMany({
+    columns: { playerId: true, headline: true, aiSummary: true },
+    orderBy: desc(schema.playerNews.publishedAt),
+  });
+  const newsByPlayer = new Map<string, string[]>();
+  for (const n of newsRows) {
+    const list = newsByPlayer.get(n.playerId) || [];
+    if (list.length < 3) { // max 3 news items per player
+      list.push(n.aiSummary || n.headline);
+    }
+    newsByPlayer.set(n.playerId, list);
+  }
+
+  return players.map(p => ({
+    id: p.id,
+    externalId: p.externalId,
+    name: p.name,
+    position: p.position,
+    team: p.team,
+    age: p.age,
+    yearsExp: p.yearsExp,
+    status: p.status,
+    injuryNote: p.injuryNote,
+    depthChartOrder: p.depthChartOrder,
+    lastSeasonPoints: statsByPlayer.get(p.id)?.totalPoints ?? null,
+    lastSeasonGames: statsByPlayer.get(p.id)?.gamesPlayed ?? null,
+    recentNews: newsByPlayer.get(p.id) || [],
+    adp: p.externalId ? (sleeperADP.get(p.externalId) ?? null) : null,
+  }));
+}
+
+// ── Claude prompt builders ──────────────────────────────────────────
+
+function buildRedraftPrompt(
+  players: PlayerContext[],
+  scoringFormat: string,
+  superflex: boolean,
+): string {
+  const playerLines = players
+    .filter(p => p.lastSeasonPoints !== null || p.adp !== null)
+    .sort((a, b) => (a.adp ?? 999) - (b.adp ?? 999))
+    .slice(0, 250) // cap to keep within token limits
+    .map(p => {
+      const ppg = p.lastSeasonPoints && p.lastSeasonGames
+        ? (p.lastSeasonPoints / p.lastSeasonGames).toFixed(1)
+        : 'N/A';
+      const newsStr = p.recentNews.length > 0 ? ` | News: ${p.recentNews.join('; ')}` : '';
+      return `${p.name} (${p.position}, ${p.team}) | Age: ${p.age ?? '?'} | Exp: ${p.yearsExp ?? '?'}yr | Status: ${p.status}${p.injuryNote ? ` (${p.injuryNote})` : ''} | Depth: ${p.depthChartOrder ?? '?'} | Last Season: ${p.lastSeasonPoints?.toFixed(1) ?? 'N/A'} pts in ${p.lastSeasonGames ?? 0} games (${ppg} ppg) | ADP: ${p.adp ?? 'N/A'}${newsStr}`;
+    })
+    .join('\n');
+
+  return `You are an expert fantasy football analyst generating ${scoringFormat.toUpperCase()} redraft rankings for the upcoming NFL season.${superflex ? ' This is a SUPERFLEX league (QBs are significantly more valuable).' : ''}
+
+TASK: Rank these players for a full-season redraft draft. Use ADP as a starting reference but adjust based on your analysis of each player's situation, age, injury risk, depth chart position, and recent news.
+
+PLAYER DATA:
+${playerLines}
+
+RESPOND WITH ONLY VALID JSON — an array of objects, one per ranked player. Rank the top 200 players:
+[
+  {
+    "name": "Player Name",
+    "position": "QB|RB|WR|TE",
+    "overallRank": 1,
+    "positionRank": 1,
+    "tier": 1,
+    "projectedPoints": 320.5,
+    "rationale": "1-2 sentence explanation of ranking and any ADP disagreement"
+  }
+]
+
+TIER RULES:
+- Tier 1: Elite studs (top ~8-10 overall)
+- Tier 2: High-end starters (top ~20)
+- Tier 3: Solid starters (top ~40)
+- Tier 4: Starter-quality (top ~70)
+- Tier 5: Flex-worthy starters (top ~100)
+- Tier 6: Bench players with upside (top ~140)
+- Tier 7: Late-round fliers (top ~180)
+- Tier 8: Deep sleepers (180+)
+
+IMPORTANT:
+- projectedPoints is the full-season total for ${scoringFormat} scoring
+- Tiers should have natural breakpoints — don't force exact counts
+- Flag players where you meaningfully disagree with ADP in the rationale
+- Account for injury risk, age, opportunity changes, and coaching/scheme changes
+- Be specific in rationale — "elite volume" is lazy, "led NFL in targets last season at age 24 with a healthy QB returning" is good`;
+}
+
+function buildDynastyRookiePrompt(
+  players: PlayerContext[],
+  scoringFormat: string,
+  superflex: boolean,
+): string {
+  const playerLines = players
+    .slice(0, 100) // rookies list is smaller
+    .map(p => {
+      const newsStr = p.recentNews.length > 0 ? ` | News: ${p.recentNews.join('; ')}` : '';
+      return `${p.name} (${p.position}, ${p.team}) | Age: ${p.age ?? '?'} | Status: ${p.status}${p.injuryNote ? ` (${p.injuryNote})` : ''} | Depth: ${p.depthChartOrder ?? '?'}${newsStr}`;
+    })
+    .join('\n');
+
+  return `You are an expert fantasy football dynasty analyst generating rookie rankings for the upcoming NFL season in ${scoringFormat.toUpperCase()} scoring.${superflex ? ' This is a SUPERFLEX league (rookie QBs are significantly more valuable).' : ''}
+
+TASK: Rank these rookies for a dynasty rookie draft. Focus on:
+- NFL draft capital (round drafted — higher picks get more opportunity)
+- Landing spot and path to playing time (depth chart position)
+- Team offensive scheme and coaching staff
+- Athletic profile and college production trajectory
+- Recent news (OTA reports, training camp buzz, injuries)
+
+ROOKIE PLAYER DATA:
+${playerLines}
+
+RESPOND WITH ONLY VALID JSON — an array of objects, one per ranked rookie:
+[
+  {
+    "name": "Player Name",
+    "position": "QB|RB|WR|TE",
+    "overallRank": 1,
+    "positionRank": 1,
+    "tier": 1,
+    "projectedPoints": null,
+    "rationale": "1-2 sentence explanation focusing on draft capital, landing spot, and path to production"
+  }
+]
+
+TIER RULES (dynasty rookie context):
+- Tier 1: Consensus top picks — elite draft capital + premium landing spot (top ~3-5)
+- Tier 2: Strong starters — high draft capital or great situation (top ~10-12)
+- Tier 3: Solid picks with clear path (top ~18-20)
+- Tier 4: Upside picks with some risk (top ~24-28)
+- Tier 5: Dart throws — late-round NFL picks or crowded backfields (28+)
+
+IMPORTANT:
+- projectedPoints can be null for rookies with high uncertainty, or a rough estimate if you're confident
+- Be specific about WHY a player is ranked where they are — "Day 2 pick in a run-heavy offense behind an aging starter" is better than "good prospect"
+- Landing spot matters MORE than college tape for year-1 fantasy value`;
+}
+
+// ── Core generation function ────────────────────────────────────────
+
+export interface GenerateRankingsArgs {
+  db: DB;
+  anthropicKey: string;
+  rankingType: 'redraft' | 'dynasty_rookie';
+  scoringFormat: 'ppr' | 'half-ppr' | 'standard';
+  superflex: boolean;
+  seasonYear: number;
+}
+
+export interface GenerateRankingsResult {
+  ok: boolean;
+  count: number;
+  error?: string;
+}
+
+export async function generateDraftRankings(
+  args: GenerateRankingsArgs,
+): Promise<GenerateRankingsResult> {
+  const { db, anthropicKey, rankingType, scoringFormat, superflex, seasonYear } = args;
+
+  // 1. Fetch ADP data (for redraft only)
+  const sleeperADP = rankingType === 'redraft'
+    ? await fetchSleeperADP(scoringFormat)
+    : new Map<string, number>();
+
+  // 2. Build player contexts
+  const playerContexts = await buildPlayerContexts(
+    db, rankingType, scoringFormat, seasonYear, sleeperADP,
+  );
+
+  if (playerContexts.length === 0) {
+    return { ok: false, count: 0, error: `No players found for ${rankingType}` };
+  }
+
+  // 3. Build prompt and call Claude
+  const prompt = rankingType === 'redraft'
+    ? buildRedraftPrompt(playerContexts, scoringFormat, superflex)
+    : buildDynastyRookiePrompt(playerContexts, scoringFormat, superflex);
+
+  let res: Response;
+  try {
+    res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': anthropicKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 16000,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0.3,
+      }),
+      signal: AbortSignal.timeout(120000), // 2 min timeout for large ranking generation
+    });
+  } catch (err) {
+    console.error('[draftRankings] Claude API fetch failed:', err);
+    return { ok: false, count: 0, error: 'AI ranking generation network failure' };
+  }
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '');
+    console.error('[draftRankings] Claude API error:', res.status, errText);
+    return { ok: false, count: 0, error: `AI API error: ${res.status}` };
+  }
+
+  let data: { content?: { type: string; text?: string }[] };
+  try {
+    data = (await res.json()) as { content?: { type: string; text?: string }[] };
+  } catch {
+    return { ok: false, count: 0, error: 'AI returned malformed response' };
+  }
+
+  const textBlock = data.content?.find(b => b.type === 'text');
+  const rawText = textBlock?.text?.trim();
+  if (!rawText) {
+    return { ok: false, count: 0, error: 'AI returned empty response' };
+  }
+
+  // Parse JSON (strip markdown fences if present)
+  const jsonStr = rawText.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+  let rankings: Array<{
+    name: string;
+    position: string;
+    overallRank: number;
+    positionRank: number;
+    tier: number;
+    projectedPoints: number | null;
+    rationale: string;
+  }>;
+
+  try {
+    rankings = JSON.parse(jsonStr);
+  } catch {
+    console.error('[draftRankings] JSON parse failed:', rawText.slice(0, 500));
+    return { ok: false, count: 0, error: 'AI returned invalid JSON' };
+  }
+
+  if (!Array.isArray(rankings) || rankings.length === 0) {
+    return { ok: false, count: 0, error: 'AI returned empty rankings array' };
+  }
+
+  // 4. Match AI output back to player IDs
+  // Build name→player lookup (case-insensitive)
+  const playerByName = new Map<string, PlayerContext>();
+  for (const p of playerContexts) {
+    playerByName.set(p.name.toLowerCase(), p);
+  }
+
+  const now = new Date();
+  const superflexInt = superflex ? 1 : 0;
+
+  // 5. Delete old rankings for this combination
+  await db.delete(schema.draftRankings).where(
+    and(
+      eq(schema.draftRankings.rankingType, rankingType),
+      eq(schema.draftRankings.scoringFormat, scoringFormat),
+      eq(schema.draftRankings.superflex, superflex),
+      eq(schema.draftRankings.seasonYear, seasonYear),
+    ),
+  );
+
+  // 6. Insert new rankings in batches
+  const BATCH_SIZE = 50;
+  let inserted = 0;
+
+  const rows: schema.NewDraftRanking[] = [];
+  for (const r of rankings) {
+    const player = playerByName.get(r.name?.toLowerCase());
+    if (!player) {
+      console.warn(`[draftRankings] Could not match AI player "${r.name}" to DB`);
+      continue;
+    }
+
+    rows.push({
+      id: generateId(),
+      playerId: player.id,
+      rankingType,
+      scoringFormat,
+      superflex,
+      overallRank: r.overallRank,
+      positionRank: r.positionRank,
+      tier: Math.min(Math.max(r.tier, 1), 8), // clamp 1-8
+      projectedPoints: r.projectedPoints,
+      adp: player.adp,
+      adpDelta: player.adp != null ? r.overallRank - player.adp : null,
+      rationale: r.rationale || '',
+      seasonYear,
+      generatedAt: now,
+    });
+  }
+
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE);
+    await db.insert(schema.draftRankings).values(batch);
+    inserted += batch.length;
+  }
+
+  console.log(`[draftRankings] Generated ${inserted} ${rankingType} rankings (${scoringFormat}, sf=${superflex})`);
+  return { ok: true, count: inserted };
+}

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -58,6 +58,7 @@ crons = [
   "0 12 * * *",   # Daily 6 AM CT (12 PM UTC): sync players, injury news, games
   "0 */4 * * *",  # Every 4 hours: sync stats and projections
   "0 */6 * * *",  # Every 6 hours: sync RSS sports news
+  "0 14 * * 1",   # Weekly Monday 8 AM CT (14 PM UTC): regenerate AI draft rankings
 ]
 
 # Local development

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -58,7 +58,7 @@ crons = [
   "0 12 * * *",   # Daily 6 AM CT (12 PM UTC): sync players, injury news, games
   "0 */4 * * *",  # Every 4 hours: sync stats and projections
   "0 */6 * * *",  # Every 6 hours: sync RSS sports news
-  "0 14 * * 1",   # Weekly Monday 8 AM CT (14 PM UTC): regenerate AI draft rankings
+  "0 20 * * 1",   # Weekly Monday 3 PM CT (20 UTC): regenerate AI draft rankings
 ]
 
 # Local development

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ const ArticlesView = lazy(() => import('./components/ArticlesView').then(m => ({
 const ArticleDetailView = lazy(() => import('./components/ArticleDetailView').then(m => ({ default: m.ArticleDetailView })));
 const PrivacyPolicyView = lazy(() => import('./components/PrivacyPolicyView').then(m => ({ default: m.PrivacyPolicyView })));
 const TermsOfServiceView = lazy(() => import('./components/TermsOfServiceView').then(m => ({ default: m.TermsOfServiceView })));
+const DraftRankingsView = lazy(() => import('./components/DraftRankingsView').then(m => ({ default: m.DraftRankingsView })));
 import { LoginView } from './components/LoginView';
 import { RegisterView } from './components/RegisterView';
 import { ForgotPasswordView, ResetPasswordView } from './components/ForgotPasswordView';
@@ -624,7 +625,7 @@ function AppContent() {
                 <Suspense fallback={suspenseFallback}><WaiversView onPlayerClick={setSelectedPlayer} onViewAll={handleViewAllFromWaivers} isDarkMode={isDarkMode} /></Suspense>
               )
             ) : activeView === 'DraftRankings' ? (
-              <ComingSoonView title="Draft Rankings" description="AI-powered draft rankings with ADP tracking, tier breakdowns, and custom scoring projections." icon="draft" isDarkMode={isDarkMode} />
+              <Suspense fallback={suspenseFallback}><DraftRankingsView onPlayerClick={setSelectedPlayer} isDarkMode={isDarkMode} /></Suspense>
             ) : activeView === 'LeagueAnalyzer' ? (
               <ComingSoonView title="League Analyzer" description="Deep dive into your league with power rankings, strength of schedule analysis, and roster composition breakdowns." icon="league" isDarkMode={isDarkMode} />
             ) : activeView === 'TradeAnalyzer' ? (

--- a/src/components/DraftRankingsView.tsx
+++ b/src/components/DraftRankingsView.tsx
@@ -1,0 +1,566 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Medal, Loader2, Search, ChevronDown, ArrowUp, ArrowDown, Minus, Info } from 'lucide-react';
+import { Player } from '../App';
+import { useLeagueContext } from '../context/LeagueContext';
+import api from '../services/api';
+import { PlayerAvatar } from './PlayerAvatar';
+
+// ── Types ───────────────────────────────────────────────────────────
+
+interface DraftRankingPlayer {
+  id: string;
+  name: string;
+  position: string;
+  team: string;
+  age: number | null;
+  yearsExp: number | null;
+  status: string;
+  injuryNote: string | null;
+  headshotUrl: string | null;
+  externalId: string | null;
+}
+
+interface DraftRanking {
+  id: string;
+  overallRank: number;
+  positionRank: number;
+  tier: number;
+  projectedPoints: number | null;
+  adp: number | null;
+  adpDelta: number | null;
+  rationale: string;
+  generatedAt: string;
+  player: DraftRankingPlayer;
+}
+
+interface DraftRankingsResponse {
+  rankings: DraftRanking[];
+  meta: {
+    rankingType: string;
+    scoringFormat: string;
+    superflex: boolean;
+    season: number;
+    count: number;
+    generatedAt: string | null;
+  };
+}
+
+interface DraftRankingsViewProps {
+  onPlayerClick: (player: Player) => void;
+  isDarkMode: boolean;
+}
+
+// ── Constants ───────────────────────────────────────────────────────
+
+type RankingType = 'redraft' | 'dynasty_rookie';
+type ScoringFormat = 'ppr' | 'half-ppr' | 'standard';
+type PositionFilter = 'ALL' | 'QB' | 'RB' | 'WR' | 'TE';
+
+const TIER_LABELS: Record<string, Record<number, string>> = {
+  redraft: {
+    1: 'Elite',
+    2: 'High-End Starters',
+    3: 'Solid Starters',
+    4: 'Starter-Quality',
+    5: 'Flex-Worthy',
+    6: 'Bench Upside',
+    7: 'Late-Round Fliers',
+    8: 'Deep Sleepers',
+  },
+  dynasty_rookie: {
+    1: 'Top Picks',
+    2: 'Strong Starters',
+    3: 'Solid Picks',
+    4: 'Upside Picks',
+    5: 'Dart Throws',
+  },
+};
+
+const TIER_COLORS: Record<number, { dark: string; light: string }> = {
+  1: { dark: 'bg-amber-500/10 border-amber-500/30', light: 'bg-amber-50 border-amber-200' },
+  2: { dark: 'bg-blue-500/10 border-blue-500/30', light: 'bg-blue-50 border-blue-200' },
+  3: { dark: 'bg-green-500/10 border-green-500/30', light: 'bg-green-50 border-green-200' },
+  4: { dark: 'bg-purple-500/10 border-purple-500/30', light: 'bg-purple-50 border-purple-200' },
+  5: { dark: 'bg-slate-500/10 border-slate-500/30', light: 'bg-slate-50 border-slate-200' },
+  6: { dark: 'bg-slate-500/10 border-slate-500/20', light: 'bg-slate-50 border-slate-200' },
+  7: { dark: 'bg-slate-500/10 border-slate-500/20', light: 'bg-slate-50 border-slate-200' },
+  8: { dark: 'bg-slate-500/10 border-slate-500/20', light: 'bg-slate-50 border-slate-200' },
+};
+
+const POSITION_COLORS: Record<string, string> = {
+  QB: 'text-red-400',
+  RB: 'text-green-400',
+  WR: 'text-blue-400',
+  TE: 'text-orange-400',
+};
+
+// ── Component ───────────────────────────────────────────────────────
+
+export function DraftRankingsView({ onPlayerClick, isDarkMode }: DraftRankingsViewProps) {
+  const { league } = useLeagueContext();
+
+  // Derive defaults from connected league
+  const defaultScoring: ScoringFormat = (league?.scoringFormat as ScoringFormat) || 'ppr';
+  const defaultSuperflex = (league as any)?.hasSuperflex ?? false;
+
+  const [rankingType, setRankingType] = useState<RankingType>('redraft');
+  const [scoringFormat, setScoringFormat] = useState<ScoringFormat>(defaultScoring);
+  const [superflex, setSuperflex] = useState(defaultSuperflex);
+  const [positionFilter, setPositionFilter] = useState<PositionFilter>('ALL');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [expandedRationale, setExpandedRationale] = useState<string | null>(null);
+  const [rankings, setRankings] = useState<DraftRanking[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [generatedAt, setGeneratedAt] = useState<string | null>(null);
+
+  const fetchRankings = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const sf = superflex ? '1' : '0';
+      const season = new Date().getFullYear();
+      const data = await api.get<DraftRankingsResponse>(
+        `/draft-rankings?type=${rankingType}&scoring=${scoringFormat}&superflex=${sf}&season=${season}`,
+      );
+      setRankings(data.rankings);
+      setGeneratedAt(data.meta.generatedAt);
+    } catch (err) {
+      console.error('Failed to fetch draft rankings:', err);
+      setError('Failed to load draft rankings');
+      setRankings([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [rankingType, scoringFormat, superflex]);
+
+  useEffect(() => {
+    fetchRankings();
+  }, [fetchRankings]);
+
+  // Filter and group by tier
+  const filteredRankings = useMemo(() => {
+    let filtered = rankings;
+    if (positionFilter !== 'ALL') {
+      filtered = filtered.filter(r => r.player.position === positionFilter);
+    }
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      filtered = filtered.filter(
+        r => r.player.name.toLowerCase().includes(q) || r.player.team.toLowerCase().includes(q),
+      );
+    }
+    return filtered;
+  }, [rankings, positionFilter, searchQuery]);
+
+  const tierGroups = useMemo(() => {
+    const groups = new Map<number, DraftRanking[]>();
+    for (const r of filteredRankings) {
+      const tier = r.tier;
+      const list = groups.get(tier) || [];
+      list.push(r);
+      groups.set(tier, list);
+    }
+    return Array.from(groups.entries()).sort((a, b) => a[0] - b[0]);
+  }, [filteredRankings]);
+
+  const handlePlayerClick = useCallback((ranking: DraftRanking) => {
+    const p = ranking.player;
+    onPlayerClick({
+      id: p.id,
+      rank: ranking.overallRank,
+      name: p.name,
+      team: p.team,
+      position: p.position as Player['position'],
+      keyLine: ranking.rationale,
+      projectedPoints: ranking.projectedPoints ?? 0,
+      weekChange: 0,
+      headshotUrl: p.headshotUrl,
+    });
+  }, [onPlayerClick]);
+
+  const tierLabels = TIER_LABELS[rankingType] || TIER_LABELS.redraft;
+
+  // ── Render ──────────────────────────────────────────────────────────
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 pb-8">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${isDarkMode ? 'bg-blue-600/20' : 'bg-blue-50'}`}>
+          <Medal className={`w-5 h-5 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`} />
+        </div>
+        <div>
+          <h1 className={`text-xl font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+            Draft Rankings
+          </h1>
+          {generatedAt && (
+            <p className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+              Updated {new Date(generatedAt).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        {/* Ranking Type Tabs */}
+        <div className={`inline-flex rounded-lg p-0.5 ${isDarkMode ? 'bg-slate-800' : 'bg-slate-100'}`}>
+          {(['redraft', 'dynasty_rookie'] as RankingType[]).map(type => (
+            <button
+              key={type}
+              onClick={() => setRankingType(type)}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                rankingType === type
+                  ? isDarkMode ? 'bg-blue-600 text-white' : 'bg-white text-blue-700 shadow-sm'
+                  : isDarkMode ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'
+              }`}
+            >
+              {type === 'redraft' ? 'Redraft' : 'Dynasty Rookie'}
+            </button>
+          ))}
+        </div>
+
+        {/* Scoring Format */}
+        <div className="relative">
+          <select
+            value={scoringFormat}
+            onChange={e => setScoringFormat(e.target.value as ScoringFormat)}
+            className={`appearance-none pl-3 pr-8 py-1.5 text-sm font-medium rounded-lg border cursor-pointer ${
+              isDarkMode
+                ? 'bg-slate-800 border-slate-700 text-slate-200'
+                : 'bg-white border-slate-200 text-slate-700'
+            }`}
+          >
+            <option value="ppr">PPR</option>
+            <option value="half-ppr">Half PPR</option>
+            <option value="standard">Standard</option>
+          </select>
+          <ChevronDown className={`absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 pointer-events-none ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`} />
+        </div>
+
+        {/* Superflex Toggle */}
+        <button
+          onClick={() => setSuperflex(!superflex)}
+          className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
+            superflex
+              ? isDarkMode ? 'bg-blue-600/20 border-blue-500/40 text-blue-400' : 'bg-blue-50 border-blue-200 text-blue-700'
+              : isDarkMode ? 'bg-slate-800 border-slate-700 text-slate-400' : 'bg-white border-slate-200 text-slate-500'
+          }`}
+        >
+          Superflex {superflex ? 'ON' : 'OFF'}
+        </button>
+
+        {/* Position Filter */}
+        <div className={`inline-flex rounded-lg p-0.5 ${isDarkMode ? 'bg-slate-800' : 'bg-slate-100'}`}>
+          {(['ALL', 'QB', 'RB', 'WR', 'TE'] as PositionFilter[]).map(pos => (
+            <button
+              key={pos}
+              onClick={() => setPositionFilter(pos)}
+              className={`px-2.5 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                positionFilter === pos
+                  ? isDarkMode ? 'bg-slate-600 text-white' : 'bg-white text-slate-900 shadow-sm'
+                  : isDarkMode ? 'text-slate-400 hover:text-white' : 'text-slate-500 hover:text-slate-900'
+              }`}
+            >
+              {pos}
+            </button>
+          ))}
+        </div>
+
+        {/* Search */}
+        <div className="relative ml-auto">
+          <Search className={`absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`} />
+          <input
+            type="text"
+            placeholder="Search player..."
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            className={`pl-8 pr-3 py-1.5 text-sm rounded-lg border w-48 ${
+              isDarkMode
+                ? 'bg-slate-800 border-slate-700 text-slate-200 placeholder:text-slate-500'
+                : 'bg-white border-slate-200 text-slate-700 placeholder:text-slate-400'
+            }`}
+          />
+        </div>
+      </div>
+
+      {/* Content */}
+      {loading ? (
+        <div className="flex flex-col items-center justify-center py-20">
+          <Loader2 className={`w-8 h-8 animate-spin ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`} />
+          <p className={`mt-3 text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+            Loading rankings...
+          </p>
+        </div>
+      ) : error ? (
+        <div className="flex flex-col items-center justify-center py-20">
+          <p className={`text-sm ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}>{error}</p>
+        </div>
+      ) : rankings.length === 0 ? (
+        <EmptyState rankingType={rankingType} isDarkMode={isDarkMode} />
+      ) : filteredRankings.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-20">
+          <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+            No players match your filters.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {tierGroups.map(([tier, players]) => (
+            <TierGroup
+              key={tier}
+              tier={tier}
+              label={tierLabels[tier] || `Tier ${tier}`}
+              rankings={players}
+              rankingType={rankingType}
+              isDarkMode={isDarkMode}
+              expandedRationale={expandedRationale}
+              onToggleRationale={id => setExpandedRationale(prev => prev === id ? null : id)}
+              onPlayerClick={handlePlayerClick}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Sub-components ──────────────────────────────────────────────────
+
+function EmptyState({ rankingType, isDarkMode }: { rankingType: RankingType; isDarkMode: boolean }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <Medal className={`w-12 h-12 mb-4 ${isDarkMode ? 'text-slate-600' : 'text-slate-300'}`} />
+      <h3 className={`text-lg font-semibold mb-2 ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}>
+        No {rankingType === 'dynasty_rookie' ? 'Dynasty Rookie' : 'Redraft'} Rankings Yet
+      </h3>
+      <p className={`text-sm max-w-md ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+        Rankings are generated by our AI and updated periodically. Check back soon for the latest rankings.
+      </p>
+    </div>
+  );
+}
+
+function TierGroup({
+  tier,
+  label,
+  rankings,
+  rankingType,
+  isDarkMode,
+  expandedRationale,
+  onToggleRationale,
+  onPlayerClick,
+}: {
+  tier: number;
+  label: string;
+  rankings: DraftRanking[];
+  rankingType: RankingType;
+  isDarkMode: boolean;
+  expandedRationale: string | null;
+  onToggleRationale: (id: string) => void;
+  onPlayerClick: (ranking: DraftRanking) => void;
+}) {
+  const colors = TIER_COLORS[tier] || TIER_COLORS[5];
+  const colorClass = isDarkMode ? colors.dark : colors.light;
+
+  return (
+    <div>
+      {/* Tier Header */}
+      <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border mb-2 ${colorClass}`}>
+        <span className={`text-xs font-bold ${isDarkMode ? 'text-slate-300' : 'text-slate-600'}`}>
+          TIER {tier}
+        </span>
+        <span className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+          {label}
+        </span>
+        <span className={`text-xs ml-auto ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+          {rankings.length} player{rankings.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Player Rows */}
+      <div className="space-y-1">
+        {rankings.map(ranking => (
+          <PlayerRow
+            key={ranking.id}
+            ranking={ranking}
+            rankingType={rankingType}
+            isDarkMode={isDarkMode}
+            isExpanded={expandedRationale === ranking.id}
+            onToggleRationale={() => onToggleRationale(ranking.id)}
+            onPlayerClick={() => onPlayerClick(ranking)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PlayerRow({
+  ranking,
+  rankingType,
+  isDarkMode,
+  isExpanded,
+  onToggleRationale,
+  onPlayerClick,
+}: {
+  ranking: DraftRanking;
+  rankingType: RankingType;
+  isDarkMode: boolean;
+  isExpanded: boolean;
+  onToggleRationale: () => void;
+  onPlayerClick: () => void;
+}) {
+  const p = ranking.player;
+  const posColor = POSITION_COLORS[p.position] || 'text-slate-400';
+
+  // ADP value indicator
+  const adpDelta = ranking.adpDelta;
+  let valueIndicator: React.ReactNode = null;
+  if (adpDelta !== null && Math.abs(adpDelta) >= 3) {
+    if (adpDelta < 0) {
+      // Ranked HIGHER than ADP = value (they go before ADP says)
+      valueIndicator = (
+        <span className="inline-flex items-center gap-0.5 text-xs font-medium text-green-400" title={`Ranked ${Math.abs(adpDelta).toFixed(0)} spots above ADP — value pick`}>
+          <ArrowUp className="w-3 h-3" />
+          {Math.abs(adpDelta).toFixed(0)}
+        </span>
+      );
+    } else {
+      // Ranked LOWER than ADP = reach
+      valueIndicator = (
+        <span className="inline-flex items-center gap-0.5 text-xs font-medium text-red-400" title={`Ranked ${adpDelta.toFixed(0)} spots below ADP — potential reach`}>
+          <ArrowDown className="w-3 h-3" />
+          {adpDelta.toFixed(0)}
+        </span>
+      );
+    }
+  } else if (adpDelta !== null) {
+    valueIndicator = (
+      <span className="inline-flex items-center text-xs text-slate-500" title="Ranked near ADP">
+        <Minus className="w-3 h-3" />
+      </span>
+    );
+  }
+
+  return (
+    <div
+      className={`group rounded-lg border transition-colors ${
+        isDarkMode
+          ? 'bg-slate-800/50 border-slate-700/50 hover:bg-slate-800'
+          : 'bg-white border-slate-200 hover:bg-slate-50'
+      }`}
+    >
+      <div
+        className="flex items-center gap-3 px-3 py-2.5 cursor-pointer"
+        onClick={onPlayerClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onPlayerClick(); } }}
+      >
+        {/* Rank */}
+        <span className={`w-8 text-center text-sm font-bold ${isDarkMode ? 'text-slate-300' : 'text-slate-600'}`}>
+          {ranking.overallRank}
+        </span>
+
+        {/* Avatar */}
+        <div className={`w-9 h-9 rounded-full overflow-hidden flex-shrink-0 flex items-center justify-center ${isDarkMode ? 'bg-slate-700' : 'bg-slate-100'}`}>
+          <PlayerAvatar name={p.name} headshotUrl={p.headshotUrl} isDarkMode={isDarkMode} />
+        </div>
+
+        {/* Name & Position */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className={`text-sm font-semibold truncate ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+              {p.name}
+            </span>
+            {p.status !== 'active' && (
+              <span className="text-[10px] px-1 py-0.5 rounded bg-red-500/20 text-red-400 font-medium uppercase">
+                {p.status === 'injured_reserve' ? 'IR' : p.status === 'questionable' ? 'Q' : p.status === 'doubtful' ? 'D' : 'OUT'}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5 text-xs">
+            <span className={`font-medium ${posColor}`}>{p.position}{ranking.positionRank}</span>
+            <span className={isDarkMode ? 'text-slate-500' : 'text-slate-400'}>{p.team}</span>
+            {p.age && (
+              <span className={isDarkMode ? 'text-slate-600' : 'text-slate-300'}>
+                Age {p.age}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Projected Points */}
+        {ranking.projectedPoints != null && (
+          <div className="text-right hidden sm:block">
+            <div className={`text-sm font-semibold ${isDarkMode ? 'text-slate-200' : 'text-slate-700'}`}>
+              {ranking.projectedPoints.toFixed(1)}
+            </div>
+            <div className={`text-[10px] ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+              proj pts
+            </div>
+          </div>
+        )}
+
+        {/* ADP */}
+        {ranking.adp != null && (
+          <div className="text-right hidden sm:block">
+            <div className={`text-sm ${isDarkMode ? 'text-slate-300' : 'text-slate-600'}`}>
+              {ranking.adp.toFixed(1)}
+            </div>
+            <div className={`text-[10px] ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+              ADP
+            </div>
+          </div>
+        )}
+
+        {/* Value Indicator */}
+        <div className="w-10 text-center hidden sm:block">
+          {valueIndicator}
+        </div>
+
+        {/* Rationale toggle */}
+        <button
+          onClick={e => { e.stopPropagation(); onToggleRationale(); }}
+          className={`p-1 rounded-md transition-colors ${
+            isDarkMode
+              ? 'hover:bg-slate-700 text-slate-500 hover:text-slate-300'
+              : 'hover:bg-slate-100 text-slate-400 hover:text-slate-600'
+          }`}
+          title="View AI analysis"
+        >
+          <Info className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Expanded Rationale */}
+      {isExpanded && ranking.rationale && (
+        <div className={`px-3 pb-3 pt-0 ml-11`}>
+          <p className={`text-xs leading-relaxed ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+            {ranking.rationale}
+          </p>
+          {/* Mobile-only: show projected points and ADP */}
+          <div className="flex gap-4 mt-2 sm:hidden">
+            {ranking.projectedPoints != null && (
+              <span className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                Proj: {ranking.projectedPoints.toFixed(1)} pts
+              </span>
+            )}
+            {ranking.adp != null && (
+              <span className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                ADP: {ranking.adp.toFixed(1)}
+              </span>
+            )}
+            {valueIndicator && (
+              <span className="text-xs">
+                {valueIndicator}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/DraftRankingsView.tsx
+++ b/src/components/DraftRankingsView.tsx
@@ -29,6 +29,7 @@ interface DraftRanking {
   adp: number | null;
   adpDelta: number | null;
   rationale: string;
+  analysis: string | null;
   generatedAt: string;
   player: DraftRankingPlayer;
 }
@@ -535,12 +536,23 @@ function PlayerRow({
         </button>
       </div>
 
-      {/* Expanded Rationale */}
-      {isExpanded && ranking.rationale && (
+      {/* Expanded Analysis */}
+      {isExpanded && (ranking.analysis || ranking.rationale) && (
         <div className={`px-3 pb-3 pt-0 ml-11`}>
-          <p className={`text-xs leading-relaxed ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-            {ranking.rationale}
-          </p>
+          {ranking.analysis ? (
+            <div className="space-y-1.5">
+              <p className={`text-xs font-medium ${isDarkMode ? 'text-slate-300' : 'text-slate-600'}`}>
+                AI Analysis
+              </p>
+              <p className={`text-xs leading-relaxed ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                {ranking.analysis}
+              </p>
+            </div>
+          ) : (
+            <p className={`text-xs leading-relaxed ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+              {ranking.rationale}
+            </p>
+          )}
           {/* Mobile-only: show projected points and ADP */}
           <div className="flex gap-4 mt-2 sm:hidden">
             {ranking.projectedPoints != null && (

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -187,7 +187,7 @@ export function getSEOPropsForView(view: string, authView?: string): SEOProps {
   const noindexViews = [
     'Home', 'Team', 'Matchup', 'Settings', 'Profile', 'Admin', 'AllPlayers', // private
     'Login', 'Register',                                                       // utility screens
-    'Research', 'DraftRankings', 'LeagueAnalyzer',                             // Coming Soon placeholders
+    'Research', 'LeagueAnalyzer',                                               // Coming Soon placeholders
   ];
   if (noindexViews.includes(effectiveView)) {
     props.noindex = true;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -44,7 +44,7 @@ export function Sidebar({ activeView, onViewChange, isDarkMode, isAuthenticated 
       items: [
         { icon: LayoutDashboard, label: 'Player Rankings', view: 'Board', comingSoon: false },
         { icon: TrendingUp, label: 'Trends', view: 'Trends', comingSoon: false },
-        { icon: Medal, label: 'Draft Rankings', view: 'DraftRankings', comingSoon: true },
+        { icon: Medal, label: 'Draft Rankings', view: 'DraftRankings', comingSoon: false },
       ],
     },
     {


### PR DESCRIPTION
## Summary
Introduces a comprehensive draft rankings system powered by Claude AI, featuring both redraft and dynasty rookie ranking modes. Rankings are pre-computed and cached, with support for multiple scoring formats (PPR, Half-PPR, Standard) and superflex configurations.

## Key Changes

### Frontend
- **New `DraftRankingsView` component** (`src/components/DraftRankingsView.tsx`): Full-featured rankings interface with:
  - Tier-based player grouping with color-coded visual hierarchy
  - Multi-filter controls (ranking type, scoring format, superflex toggle, position filter, search)
  - Expandable AI analysis cards showing detailed player breakdowns
  - ADP delta indicators (value picks vs reaches) with visual arrows
  - Responsive design with mobile-optimized layout
  - Dark mode support throughout
  - Player click-through to detailed view

- **Navigation integration**: Added Draft Rankings view to sidebar and routing in `App.tsx`

### Backend Services
- **`draftRankings.ts` service** (`server/src/services/draftRankings.ts`): Core ranking generation logic:
  - **Redraft mode**: Fetches Sleeper ADP as baseline, enriches with player context (age, stats, injury, depth chart, recent news), uses Claude to generate tiers and rationale with value flags
  - **Dynasty Rookie mode**: Filters to rookies (yearsExp === 0), generates full rankings from player context since rookies lack fantasy history
  - Builds detailed player context from DB (stats, news, depth chart position)
  - Calls Claude Sonnet 4 with structured prompts requesting JSON output
  - Matches AI output back to player IDs and batch-inserts results
  - Supports configurable scoring formats and superflex settings

- **`draftRankings.ts` route** (`server/src/routes/draftRankings.ts`): Public API endpoint:
  - `GET /api/draft-rankings` with query params for type, scoring, superflex, season
  - Returns cached rankings (5-minute TTL) with metadata
  - Includes full player details (headshot, status, injury notes)

- **Admin endpoint** (`server/src/routes/admin.ts`): 
  - `POST /api/admin/generate-draft-rankings` to trigger ranking generation on-demand
  - Accepts type, scoring, superflex, season parameters
  - Invalidates cache after generation

### Database
- **New `draft_rankings` table** with columns for:
  - Player reference, ranking type, scoring format, superflex flag
  - Overall and position-specific ranks, tier grouping (1-8)
  - Projected points, ADP, ADP delta (value indicator)
  - AI-generated rationale (1-line summary) and analysis (detailed breakdown)
  - Season year and generation timestamp
  - Unique constraint on (player_id, ranking_type, scoring_format, superflex, season_year)

- **Migrations**: Added schema definition and analysis column in separate migration

### Scheduling
- Added weekly cron job (`0 20 * * 1` — Mondays 8 PM UTC) to auto-generate rankings

## Notable Implementation Details

- **AI Prompt Engineering**: Separate, detailed prompts for redraft vs dynasty rookie modes with specific tier definitions and output requirements. Prompts emphasize specific scouting details (stats, scheme, coaching, age curves) over generic analysis.

- **ADP Integration**: Redraft rankings use Sleeper's trending API as ADP proxy; delta calculation flags value picks (ranked higher than ADP) and reaches (ranked lower).

- **Batch Processing**: Rankings inserted in 50-record batches to handle large result sets efficiently.

- **Caching**: 5-minute TTL on rankings endpoint to balance freshness with API load.

- **Error Handling**: Graceful fallbacks for missing ADP data, unmatched players, and AI API failures with detailed logging.

- **Responsive UI**: Mobile-optimized layout hides projected points/ADP columns on small screens, shows them in expanded analysis instead.

https://claude.ai/code/session_018kLgpBAHfHndxEh345qMvf