### PR TITLE
claude/free-elite-signup-TqIni

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -189,6 +189,29 @@
     </div>
 </nav>
 
+<!-- Promo Banner -->
+<div id="promo-banner" style="display:none; background: linear-gradient(90deg, #92400e 0%, #b45309 50%, #92400e 100%); text-align:center; padding:12px 16px; font-size:15px; font-weight:600; color:#fef3c7; position:relative; z-index:99;">
+    Sign up now for <span style="color:#fff; text-decoration:underline;">free Elite access</span> — offer ends in <span id="promo-countdown" style="font-family:monospace; color:#fff;"></span>
+</div>
+<script>
+(function(){
+  var deadline = new Date('2026-04-17T00:00:00Z').getTime();
+  var banner = document.getElementById('promo-banner');
+  var span = document.getElementById('promo-countdown');
+  function tick(){
+    var diff = deadline - Date.now();
+    if(diff <= 0){ banner.style.display='none'; return; }
+    var h = Math.floor(diff/3600000);
+    var m = Math.floor((diff%3600000)/60000);
+    var s = Math.floor((diff%60000)/1000);
+    span.textContent = String(h).padStart(2,'0')+':'+String(m).padStart(2,'0')+':'+String(s).padStart(2,'0');
+    banner.style.display='block';
+  }
+  tick();
+  setInterval(tick, 1000);
+})();
+</script>
+
 <!-- Hero -->
 <section class="hero">
     <div class="hero-label"><span class="dot"></span> 2026 NFL Season — Data Updated Every 4 Hours</div>

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -176,8 +176,8 @@ authRoutes.post('/register', authRateLimit, async (c) => {
     const passwordHash = await hashPassword(password);
 
     // Create user
-    // Promo: grant elite (forever) to all signups through April 1, 2026
-    const isPromoActive = new Date() < new Date('2026-04-01T00:00:00Z');
+    // Promo: grant elite (forever) to all signups within 24h (through April 17, 2026)
+    const isPromoActive = new Date() < new Date('2026-04-17T00:00:00Z');
 
     const userId = generateId();
     await db.insert(schema.users).values({
@@ -535,8 +535,8 @@ authRoutes.post('/google', authRateLimit, async (c) => {
 
         const userId = generateId();
 
-        // Promo: grant elite (forever) to all signups through April 1, 2026
-        const isPromoActive = new Date() < new Date('2026-04-01T00:00:00Z');
+        // Promo: grant elite (forever) to all signups within 24h (through April 17, 2026)
+        const isPromoActive = new Date() < new Date('2026-04-17T00:00:00Z');
 
         await db.insert(schema.users).values({
           id: userId,

--- a/src/components/PricingView.tsx
+++ b/src/components/PricingView.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback } from 'react';
-import { CreditCard, Check, AlertCircle } from 'lucide-react';
+import { useState, useCallback, useEffect } from 'react';
+import { CreditCard, Check, AlertCircle, Clock } from 'lucide-react';
 import { api } from '../services/api';
 
 interface PricingViewProps {
@@ -9,11 +9,30 @@ interface PricingViewProps {
   onNavigate?: (view: string) => void;
 }
 
+const PROMO_DEADLINE = new Date('2026-04-17T00:00:00Z');
+
+function useCountdown(deadline: Date) {
+  const [timeLeft, setTimeLeft] = useState(() => Math.max(0, deadline.getTime() - Date.now()));
+  useEffect(() => {
+    if (timeLeft <= 0) return;
+    const id = setInterval(() => {
+      setTimeLeft(Math.max(0, deadline.getTime() - Date.now()));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [deadline, timeLeft]);
+  const hours = Math.floor(timeLeft / (1000 * 60 * 60));
+  const minutes = Math.floor((timeLeft % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((timeLeft % (1000 * 60)) / 1000);
+  return { hours, minutes, seconds, expired: timeLeft <= 0 };
+}
+
 export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = false, onNavigate }: PricingViewProps) {
   const [isAnnual, setIsAnnual] = useState(false);
   const [loading, setLoading] = useState<'pro' | 'elite' | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [hoveredTier, setHoveredTier] = useState<string | null>(null);
+  const countdown = useCountdown(PROMO_DEADLINE);
+  const showPromo = !countdown.expired && !isAuthenticated;
 
   const handleUpgrade = useCallback(async (tier: 'pro' | 'elite') => {
     if (!isAuthenticated) {
@@ -116,6 +135,28 @@ export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = f
   return (
     <div className={`min-h-screen py-12 px-4 sm:px-6 lg:px-8 ${isDarkMode ? 'bg-slate-950' : 'bg-white'}`}>
       <div className="max-w-7xl mx-auto">
+        {/* Promo Banner */}
+        {showPromo && (
+          <div className={`mb-8 p-4 rounded-xl text-center border ${isDarkMode ? 'bg-amber-900/20 border-amber-700/50' : 'bg-amber-50 border-amber-200'}`}>
+            <div className="flex items-center justify-center gap-2 mb-1">
+              <Clock className={`w-5 h-5 ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`} />
+              <span className={`font-bold text-lg ${isDarkMode ? 'text-amber-300' : 'text-amber-800'}`}>
+                Limited Time: Free Elite Access
+              </span>
+            </div>
+            <p className={`text-sm mb-2 ${isDarkMode ? 'text-amber-400/80' : 'text-amber-700'}`}>
+              Sign up now and get Elite features completely free — no credit card required.
+            </p>
+            <div className={`inline-flex items-center gap-1 font-mono text-lg font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+              <span className={`px-2 py-1 rounded ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>{String(countdown.hours).padStart(2, '0')}</span>
+              <span>:</span>
+              <span className={`px-2 py-1 rounded ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>{String(countdown.minutes).padStart(2, '0')}</span>
+              <span>:</span>
+              <span className={`px-2 py-1 rounded ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>{String(countdown.seconds).padStart(2, '0')}</span>
+            </div>
+          </div>
+        )}
+
         {/* Header */}
         <div className="text-center mb-12">
           <h1 className={`text-4xl sm:text-5xl font-bold mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>


### PR DESCRIPTION
Extend the signup promo deadline from April 1 to April 17, 2026 so new
registrations (email/password and Google OAuth) receive elite tier.
Add countdown banners to the pricing page and landing page so visitors
see the limited-time offer.

https://claude.ai/code/session_01RxBaHwwy16iSQFs73KPYaz