### PR TITLE
Auto-sync league format when switching leagues in Trade Analyzer

### DIFF
--- a/src/components/TradeAnalyzerView.tsx
+++ b/src/components/TradeAnalyzerView.tsx
@@ -1399,7 +1399,7 @@ function createInitialTeams(count: number): TradeTeam[] {
 
 export function TradeAnalyzerView({ isDarkMode }: TradeAnalyzerViewProps) {
   const { user } = useAuth();
-  const { leagues } = useLeaguesContext();
+  const { leagues, refetch: refetchLeagues } = useLeaguesContext();
   const [teamCount, setTeamCount] = useState<2 | 3 | 4>(2);
   const [teams, setTeams] = useState<TradeTeam[]>(createInitialTeams(2));
   const [leagueType, setLeagueType] = useState<LeagueType>('redraft');
@@ -1503,21 +1503,64 @@ export function TradeAnalyzerView({ isDarkMode }: TradeAnalyzerViewProps) {
     () => leagues.find((l) => l.id === selectedLeagueId) || null,
     [leagues, selectedLeagueId]
   );
+
+  // Track the last leagueId we auto-synced so we can re-run whenever
+  // the user actually picks a different league (but not on every
+  // leagues-array mutation, which could otherwise clobber a manual
+  // override right after a context refetch).
+  const lastAutoSyncedLeagueId = useRef<string | null>(null);
   useEffect(() => {
-    if (!selectedLeague) return;
+    if (!selectedLeagueId) {
+      lastAutoSyncedLeagueId.current = null;
+      return;
+    }
+    const current = leagues.find((l) => l.id === selectedLeagueId);
+    if (!current) return;
+    // Only auto-sync when the user actually switches leagues. Context
+    // refetches that return the same league shouldn't overwrite any
+    // manual override the user just made.
+    if (lastAutoSyncedLeagueId.current === selectedLeagueId) return;
+    lastAutoSyncedLeagueId.current = selectedLeagueId;
+
     setAdvanced((prev) => ({
       ...prev,
       scoringFormat:
-        (selectedLeague.scoringFormat as ScoringFormat) || prev.scoringFormat,
-      teamCount: selectedLeague.teamCount || prev.teamCount,
-      superflex: selectedLeague.hasSuperflex ?? prev.superflex,
-      tePremium: selectedLeague.hasTePremium ?? prev.tePremium,
+        (current.scoringFormat as ScoringFormat) || prev.scoringFormat,
+      teamCount: current.teamCount || prev.teamCount,
+      superflex: current.hasSuperflex ?? prev.superflex,
+      tePremium: current.hasTePremium ?? prev.tePremium,
     }));
-    if (selectedLeague.leagueType) {
-      setLeagueType(selectedLeague.leagueType);
+    // leagueType column has a NOT NULL default of 'redraft' in the DB,
+    // so this is always present. Set unconditionally so switching to a
+    // dynasty/keeper league always flips the Format pill.
+    if (
+      current.leagueType === 'redraft' ||
+      current.leagueType === 'dynasty' ||
+      current.leagueType === 'keeper'
+    ) {
+      setLeagueType(current.leagueType);
     }
     setResult(null);
-  }, [selectedLeague]);
+
+    // Kick off a background re-sync so a stale stored leagueType (e.g.,
+    // league connected before derived-type detection landed) gets
+    // corrected. When it finishes, refetch the leagues context; the
+    // effect's lastAutoSyncedLeagueId guard prevents it from clobbering
+    // a manual override the user may have made in the meantime.
+    (async () => {
+      try {
+        await api.post(`/leagues/${selectedLeagueId}/sync`);
+        await refetchLeagues();
+        // Reset the guard for this one league so the effect re-runs
+        // once against the refreshed data.
+        if (lastAutoSyncedLeagueId.current === selectedLeagueId) {
+          lastAutoSyncedLeagueId.current = null;
+        }
+      } catch {
+        // Silent — fallback to whatever leagueType we already have.
+      }
+    })();
+  }, [selectedLeagueId, leagues, refetchLeagues]);
 
   // Fetch my roster whenever selectedLeagueId changes
   useEffect(() => {

--- a/src/components/TradeHistoryView.tsx
+++ b/src/components/TradeHistoryView.tsx
@@ -813,9 +813,14 @@ export function TradeHistoryView({ isDarkMode }: TradeHistoryViewProps) {
                               )}
                             </div>
                             <div className={`fr-text-11 mt-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-                              Actual: <b className={isDarkMode ? 'text-white' : 'text-slate-900'}>{fw.actualScore.toFixed(1)}</b>
-                              {' · '}Hypothetical: <b className={isDarkMode ? 'text-white' : 'text-slate-900'}>{fw.hypotheticalScore.toFixed(1)}</b>
-                              {' → '}<b className={isDarkMode ? 'text-white' : 'text-slate-900'}>{fw.opponentScore.toFixed(1)}</b>
+                              <div>
+                                You: <b className={isDarkMode ? 'text-white' : 'text-slate-900'}>{fw.actualScore.toFixed(1)}</b> actual
+                                {' · '}
+                                <b className={isDarkMode ? 'text-white' : 'text-slate-900'}>{fw.hypotheticalScore.toFixed(1)}</b> without the trade
+                              </div>
+                              <div>
+                                Opp: <b className={isDarkMode ? 'text-white' : 'text-slate-900'}>{fw.opponentScore.toFixed(1)}</b>
+                              </div>
                             </div>
                           </div>
                         );


### PR DESCRIPTION
The Trade Analyzer was supposed to auto-detect dynasty/keeper/redraft and flip the Format pill when the user switched leagues, but users reported the format staying on whatever they last picked. Two problems:

1. The auto-sync effect depended on selectedLeague (a useMemo result), which only updated its reference when leagues or selectedLeagueId changed. Switched the effect's dep directly to [selectedLeagueId, leagues, refetchLeagues] and resolved the league inline for clarity.

2. Leagues connected before the derived-leagueType detection landed in sleeper.ts have a stale 'redraft' value in the DB regardless of their actual Sleeper settings.type. Switching to them always said 'redraft'. Fix: on league change, kick off a background POST /leagues/:id/sync to refresh the stored settings, then refetch the leagues context and re-apply. A lastAutoSyncedLeagueId ref guards against overwriting a manual override on subsequent context refetches while still allowing the one-time post-sync correction.

Also tightened the leagueType match: the DB column is NOT NULL with default 'redraft', so we now explicitly match against the three known values instead of relying on a truthy check.