### PR TITLE
Add compliance pages, cookie consent banner, and global footer

### DIFF
--- a/scripts/generate-static-pages.js
+++ b/scripts/generate-static-pages.js
@@ -188,6 +188,97 @@ const ROUTES = [
       ],
     },
   },
+  {
+    path: '/cookies',
+    title: 'Cookie Policy | FilmRoom',
+    description: 'Learn about the cookies FilmRoom Fantasy uses, how we use them, and how to control your preferences.',
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      'itemListElement': [
+        { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': BASE_URL },
+        { '@type': 'ListItem', 'position': 2, 'name': 'Cookie Policy', 'item': `${BASE_URL}/cookies` },
+      ],
+    },
+  },
+  {
+    path: '/dmca',
+    title: 'DMCA & Copyright Policy | FilmRoom',
+    description: 'How to report copyright infringement on FilmRoom Fantasy and our process for handling DMCA takedown notices.',
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      'itemListElement': [
+        { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': BASE_URL },
+        { '@type': 'ListItem', 'position': 2, 'name': 'DMCA', 'item': `${BASE_URL}/dmca` },
+      ],
+    },
+  },
+  {
+    path: '/refunds',
+    title: 'Refund & Cancellation Policy | FilmRoom',
+    description: 'How FilmRoom Fantasy subscription billing, cancellations, and refunds work.',
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      'itemListElement': [
+        { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': BASE_URL },
+        { '@type': 'ListItem', 'position': 2, 'name': 'Refunds', 'item': `${BASE_URL}/refunds` },
+      ],
+    },
+  },
+  {
+    path: '/do-not-sell',
+    title: 'Do Not Sell or Share My Personal Information | FilmRoom',
+    description: 'California and state privacy rights. Opt out of the sale or sharing of your personal information on FilmRoom Fantasy.',
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      'itemListElement': [
+        { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': BASE_URL },
+        { '@type': 'ListItem', 'position': 2, 'name': 'Do Not Sell or Share', 'item': `${BASE_URL}/do-not-sell` },
+      ],
+    },
+  },
+  {
+    path: '/disclaimer',
+    title: 'Disclaimer | FilmRoom',
+    description: 'FilmRoom Fantasy disclaimer. Our rankings, projections, and analysis are for informational purposes only.',
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      'itemListElement': [
+        { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': BASE_URL },
+        { '@type': 'ListItem', 'position': 2, 'name': 'Disclaimer', 'item': `${BASE_URL}/disclaimer` },
+      ],
+    },
+  },
+  {
+    path: '/accessibility',
+    title: 'Accessibility Statement | FilmRoom',
+    description: "FilmRoom Fantasy's commitment to accessibility and our progress toward WCAG 2.1 AA conformance.",
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      'itemListElement': [
+        { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': BASE_URL },
+        { '@type': 'ListItem', 'position': 2, 'name': 'Accessibility', 'item': `${BASE_URL}/accessibility` },
+      ],
+    },
+  },
+  {
+    path: '/acceptable-use',
+    title: 'Acceptable Use Policy | FilmRoom',
+    description: 'The rules for using FilmRoom Fantasy. Prohibited activities and enforcement.',
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      'itemListElement': [
+        { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': BASE_URL },
+        { '@type': 'ListItem', 'position': 2, 'name': 'Acceptable Use', 'item': `${BASE_URL}/acceptable-use` },
+      ],
+    },
+  },
 ];
 
 // Individual article pages — hardcoded from src/data/articles.ts

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,13 @@ const ArticlesView = lazyWithReload(() => import('./components/ArticlesView').th
 const ArticleDetailView = lazyWithReload(() => import('./components/ArticleDetailView').then(m => ({ default: m.ArticleDetailView })));
 const PrivacyPolicyView = lazyWithReload(() => import('./components/PrivacyPolicyView').then(m => ({ default: m.PrivacyPolicyView })));
 const TermsOfServiceView = lazyWithReload(() => import('./components/TermsOfServiceView').then(m => ({ default: m.TermsOfServiceView })));
+const CookiePolicyView = lazyWithReload(() => import('./components/CookiePolicyView').then(m => ({ default: m.CookiePolicyView })));
+const DMCAView = lazyWithReload(() => import('./components/DMCAView').then(m => ({ default: m.DMCAView })));
+const RefundPolicyView = lazyWithReload(() => import('./components/RefundPolicyView').then(m => ({ default: m.RefundPolicyView })));
+const DoNotSellView = lazyWithReload(() => import('./components/DoNotSellView').then(m => ({ default: m.DoNotSellView })));
+const DisclaimerView = lazyWithReload(() => import('./components/DisclaimerView').then(m => ({ default: m.DisclaimerView })));
+const AccessibilityView = lazyWithReload(() => import('./components/AccessibilityView').then(m => ({ default: m.AccessibilityView })));
+const AcceptableUseView = lazyWithReload(() => import('./components/AcceptableUseView').then(m => ({ default: m.AcceptableUseView })));
 const DraftRankingsView = lazyWithReload(() => import('./components/DraftRankingsView').then(m => ({ default: m.DraftRankingsView })));
 import { LoginView } from './components/LoginView';
 import { RegisterView } from './components/RegisterView';
@@ -54,6 +61,8 @@ import { ForgotPasswordView, ResetPasswordView } from './components/ForgotPasswo
 import { ComingSoonView } from './components/ComingSoonView';
 import { LandingPage } from './components/LandingPage';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { CookieConsentBanner } from './components/CookieConsentBanner';
+import { AppFooter } from './components/AppFooter';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { LeagueProvider, useLeagueContext } from './context/LeagueContext';
 import { LeaguesProvider, useLeaguesContext } from './context/LeaguesContext';
@@ -201,6 +210,13 @@ const VIEW_TO_PATH: Record<string, string> = {
   ArticleDetail: '/articles', // handled with slug in URL
   Privacy: '/privacy',
   Terms: '/terms',
+  CookiePolicy: '/cookies',
+  DMCA: '/dmca',
+  Refunds: '/refunds',
+  DoNotSell: '/do-not-sell',
+  Disclaimer: '/disclaimer',
+  Accessibility: '/accessibility',
+  AcceptableUse: '/acceptable-use',
 };
 
 const PATH_TO_VIEW: Record<string, string> = Object.fromEntries(
@@ -251,7 +267,7 @@ function AppContent() {
     }
   }, [league?.id, league?.currentWeek]);
   // Initialize activeView from URL so direct navigation works
-  const [activeView, setActiveView] = useState<'Landing' | 'Board' | 'Team' | 'Matchup' | 'Waivers' | 'Home' | 'GameSlate' | 'Trends' | 'Research' | 'Playoffs' | 'Settings' | 'Profile' | 'Login' | 'AllPlayers' | 'Pricing' | 'TradeAnalyzer' | 'DraftRankings' | 'LeagueAnalyzer' | 'Admin' | 'Articles' | 'ArticleDetail' | 'Privacy' | 'Terms'>(() => getViewFromURL() as any);
+  const [activeView, setActiveView] = useState<'Landing' | 'Board' | 'Team' | 'Matchup' | 'Waivers' | 'Home' | 'GameSlate' | 'Trends' | 'Research' | 'Playoffs' | 'Settings' | 'Profile' | 'Login' | 'AllPlayers' | 'Pricing' | 'TradeAnalyzer' | 'DraftRankings' | 'LeagueAnalyzer' | 'Admin' | 'Articles' | 'ArticleDetail' | 'Privacy' | 'Terms' | 'CookiePolicy' | 'DMCA' | 'Refunds' | 'DoNotSell' | 'Disclaimer' | 'Accessibility' | 'AcceptableUse'>(() => getViewFromURL() as any);
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
   const [articleSlug, setArticleSlug] = useState<string | null>(() => getArticleSlugFromURL());
   // Local dark mode state for unauthenticated users (initialized from localStorage)
@@ -438,6 +454,10 @@ function AppContent() {
       <>
         <SEO {...seoProps} />
         <LandingPage onNavigate={(view) => setActiveView(view as any)} />
+        <CookieConsentBanner
+          isDarkMode={isDarkMode}
+          onNavigate={(view) => setActiveView(view as any)}
+        />
       </>
     );
   }
@@ -685,6 +705,20 @@ function AppContent() {
               <Suspense fallback={suspenseFallback}><PrivacyPolicyView isDarkMode={isDarkMode} /></Suspense>
             ) : activeView === 'Terms' ? (
               <Suspense fallback={suspenseFallback}><TermsOfServiceView isDarkMode={isDarkMode} /></Suspense>
+            ) : activeView === 'CookiePolicy' ? (
+              <Suspense fallback={suspenseFallback}><CookiePolicyView isDarkMode={isDarkMode} /></Suspense>
+            ) : activeView === 'DMCA' ? (
+              <Suspense fallback={suspenseFallback}><DMCAView isDarkMode={isDarkMode} /></Suspense>
+            ) : activeView === 'Refunds' ? (
+              <Suspense fallback={suspenseFallback}><RefundPolicyView isDarkMode={isDarkMode} /></Suspense>
+            ) : activeView === 'DoNotSell' ? (
+              <Suspense fallback={suspenseFallback}><DoNotSellView isDarkMode={isDarkMode} /></Suspense>
+            ) : activeView === 'Disclaimer' ? (
+              <Suspense fallback={suspenseFallback}><DisclaimerView isDarkMode={isDarkMode} /></Suspense>
+            ) : activeView === 'Accessibility' ? (
+              <Suspense fallback={suspenseFallback}><AccessibilityView isDarkMode={isDarkMode} /></Suspense>
+            ) : activeView === 'AcceptableUse' ? (
+              <Suspense fallback={suspenseFallback}><AcceptableUseView isDarkMode={isDarkMode} /></Suspense>
             ) : (
               <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
                 <h2 className={`text-2xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>Page Not Found</h2>
@@ -695,8 +729,15 @@ function AppContent() {
               </div>
             )}
           </PageTransition>
+          <AppFooter isDarkMode={isDarkMode} onNavigate={(view) => setActiveView(view as any)} />
         </main>
       </div>
+
+      {/* Cookie consent banner — shown on first visit until user chooses */}
+      <CookieConsentBanner
+        isDarkMode={isDarkMode}
+        onNavigate={(view) => setActiveView(view as any)}
+      />
 
       {/* Player Card Modal */}
       {selectedPlayer && (

--- a/src/components/AcceptableUseView.tsx
+++ b/src/components/AcceptableUseView.tsx
@@ -1,0 +1,96 @@
+interface AcceptableUseViewProps {
+  isDarkMode: boolean;
+}
+
+export function AcceptableUseView({ isDarkMode }: AcceptableUseViewProps) {
+  const h = isDarkMode ? 'text-white' : 'text-slate-900';
+  const p = isDarkMode ? 'text-slate-300' : 'text-slate-600';
+  const s = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const border = isDarkMode ? 'border-slate-800' : 'border-slate-200';
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className={`text-3xl font-bold mb-2 ${h}`}>Acceptable Use Policy</h1>
+      <p className={`text-sm mb-8 ${s}`}>Last updated: April 16, 2026</p>
+
+      <div className={`space-y-8 ${p}`}>
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>1. Purpose</h2>
+          <p>
+            This Acceptable Use Policy ("AUP") sets out the rules for using FilmRoom
+            Fantasy. It supplements and is incorporated into our{' '}
+            <a href="/terms" className={`underline ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}>
+              Terms of Service
+            </a>
+            . Violations may result in suspension or termination of your account.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>2. Prohibited activities</h2>
+          <p className="mb-3">You agree not to:</p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>Use FilmRoom in violation of any applicable law or regulation.</li>
+            <li>Circumvent or attempt to circumvent access controls, rate limits, or subscription tiers.</li>
+            <li>Attempt to gain unauthorized access to any account, server, or network connected to FilmRoom.</li>
+            <li>Scrape, spider, crawl, or use any automated tool to extract data from the site without our prior written consent.</li>
+            <li>Reverse engineer, decompile, or disassemble any portion of the service except where such restriction is prohibited by applicable law.</li>
+            <li>Resell, sublicense, or redistribute FilmRoom content, projections, rankings, or analysis in any form.</li>
+            <li>Use FilmRoom data to build or train a competing product, model, or dataset.</li>
+            <li>Upload or transmit malware, viruses, ransomware, or any other malicious code.</li>
+            <li>Interfere with the operation of the service, degrade performance, or attempt a denial-of-service attack.</li>
+            <li>Forge headers, impersonate another person, or misrepresent your affiliation with a person or entity.</li>
+            <li>Create multiple accounts to evade bans, rate limits, or free-tier quotas.</li>
+            <li>Use the service to harass, threaten, or defame another person.</li>
+            <li>Post content that is unlawful, infringing, obscene, hateful, or designed to promote illegal activity.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>3. Content you submit</h2>
+          <p>
+            If the service allows you to submit content (for example, team names,
+            comments, or support messages), you represent that you have the right to
+            do so and that the content does not violate this AUP or any third-party
+            rights. We may remove content that violates this AUP without notice.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>4. API and automation</h2>
+          <p>
+            We do not currently offer a public API. Any automated access is prohibited
+            unless specifically authorized in writing. If you need programmatic access
+            for a legitimate purpose, contact us.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>5. Reporting abuse</h2>
+          <p>
+            To report a violation of this AUP, email{' '}
+            <span className="font-medium">abuse@filmroomfantasy.com</span> with as
+            much detail as you can provide (URLs, timestamps, screenshots).
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>6. Enforcement</h2>
+          <p>
+            Depending on the nature and severity of the violation, we may warn the
+            user, remove content, suspend the account, terminate the account, or take
+            legal action. We may cooperate with law enforcement where required by law.
+          </p>
+        </section>
+
+        <section className={`border-t pt-6 ${border}`}>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
+          <p>
+            Abuse reports:{' '}
+            <span className="font-medium">abuse@filmroomfantasy.com</span>.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AccessibilityView.tsx
+++ b/src/components/AccessibilityView.tsx
@@ -1,0 +1,99 @@
+interface AccessibilityViewProps {
+  isDarkMode: boolean;
+}
+
+export function AccessibilityView({ isDarkMode }: AccessibilityViewProps) {
+  const h = isDarkMode ? 'text-white' : 'text-slate-900';
+  const p = isDarkMode ? 'text-slate-300' : 'text-slate-600';
+  const s = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const border = isDarkMode ? 'border-slate-800' : 'border-slate-200';
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className={`text-3xl font-bold mb-2 ${h}`}>Accessibility Statement</h1>
+      <p className={`text-sm mb-8 ${s}`}>Last updated: April 16, 2026</p>
+
+      <div className={`space-y-8 ${p}`}>
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>1. Our commitment</h2>
+          <p>
+            FilmRoom Fantasy is committed to making our website accessible to the
+            widest possible audience, regardless of ability or technology. We aim to
+            meet the Web Content Accessibility Guidelines (WCAG) 2.1 Level AA where
+            reasonably achievable, and we continue to improve as part of ongoing
+            development.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>2. What we've done</h2>
+          <ul className="list-disc list-inside space-y-2">
+            <li>Semantic HTML structure with proper heading hierarchy and landmark regions.</li>
+            <li>Keyboard navigation for all interactive elements.</li>
+            <li>Focus indicators on buttons, links, and form controls.</li>
+            <li>Alt text for meaningful images and ARIA labels for icon-only buttons.</li>
+            <li>Color-contrast testing against WCAG AA thresholds, with light and dark themes.</li>
+            <li>Support for the <code>prefers-reduced-motion</code> media query to disable non-essential animations.</li>
+            <li>Responsive layouts that work on mobile, tablet, and desktop.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>3. Known limitations</h2>
+          <p className="mb-3">
+            We're aware that some parts of the site may not yet meet our accessibility
+            goals, including:
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>Complex data tables (rankings, matchups) may be challenging with some screen readers on narrow viewports.</li>
+            <li>Some third-party embedded content (ads, charts) may not fully conform to WCAG AA.</li>
+            <li>Older content in articles may lack descriptive alt text.</li>
+          </ul>
+          <p className="mt-3">We're actively working on these and welcome your feedback.</p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>4. Assistive technologies</h2>
+          <p>
+            FilmRoom is designed to work with recent versions of major screen readers
+            (VoiceOver, NVDA, JAWS, TalkBack) and browsers (Chrome, Safari, Firefox,
+            Edge). If you encounter an issue with a specific assistive technology,
+            please let us know so we can investigate.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>5. Feedback &amp; requests</h2>
+          <p>
+            If you experience any difficulty accessing content on our site, or if you
+            have suggestions for improving accessibility, please contact us at{' '}
+            <span className="font-medium">accessibility@filmroomfantasy.com</span>.
+            We aim to respond within 5 business days. When possible, please include:
+          </p>
+          <ul className="list-disc list-inside space-y-2 mt-3">
+            <li>The URL of the page where you encountered the issue.</li>
+            <li>A description of the problem.</li>
+            <li>The assistive technology and browser you're using.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>6. Ongoing improvement</h2>
+          <p>
+            Accessibility is not a one-time project. We train our team, audit new
+            features before release, and revisit existing pages to raise the bar over
+            time. This statement is reviewed and updated as our site evolves.
+          </p>
+        </section>
+
+        <section className={`border-t pt-6 ${border}`}>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
+          <p>
+            Accessibility contact:{' '}
+            <span className="font-medium">accessibility@filmroomfantasy.com</span>.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AdUnit.tsx
+++ b/src/components/AdUnit.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { isAllowed, onConsentChange } from '../services/consent';
 
 const ADSENSE_SRC = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6355054767351119';
 
@@ -11,6 +12,19 @@ function loadAdSenseScript(): Promise<void> {
     return Promise.resolve();
   }
   return new Promise((resolve) => {
+    // Signal non-personalized ads to AdSense BEFORE the script loads if the user
+    // has not consented to advertising cookies. This is the Google-recommended
+    // mechanism for serving non-personalized ads under GDPR/ePrivacy and CCPA.
+    // See: https://support.google.com/adsense/answer/9009582
+    if (!isAllowed('advertising')) {
+      try {
+        (window as any).adsbygoogle = (window as any).adsbygoogle || [];
+        (window as any).adsbygoogle.requestNonPersonalizedAds = 1;
+      } catch {
+        // ignore
+      }
+    }
+
     const script = document.createElement('script');
     script.src = ADSENSE_SRC;
     script.async = true;
@@ -43,23 +57,54 @@ interface AdUnitProps {
   isDarkMode?: boolean;
 }
 
-export function AdUnit({ slot, format = 'auto', className = '', isDarkMode }: AdUnitProps) {
+export function AdUnit({ slot, format = 'auto', className = '' }: AdUnitProps) {
   const adRef = useRef<HTMLDivElement>(null);
   const [hasContent, setHasContent] = useState(false);
+  const [consentReady, setConsentReady] = useState(false);
+  const [consentVersion, setConsentVersion] = useState(0);
+
+  // Wait for consent state to be available before deciding whether/how to serve ads.
+  // - Advertising allowed  -> personalized ads
+  // - Advertising rejected -> non-personalized ads (still allowed under AdSense policy)
+  // - No decision yet      -> don't load AdSense until the user chooses (EU/UK compliant default)
+  useEffect(() => {
+    const unsub = onConsentChange(() => {
+      setConsentVersion((v) => v + 1);
+      setConsentReady(true);
+    });
+    return unsub;
+  }, []);
 
   useEffect(() => {
+    if (!consentReady) return;
+
     // Defer the content check so the page has time to render
     const timer = setTimeout(() => {
       if (!pageHasEnoughContent()) return;
+
+      // If the user hasn't made a decision yet, wait for one — don't load AdSense
+      // preemptively. If they have decided (accept OR reject), we can proceed:
+      // reject just means non-personalized ads.
+      const hasStoredDecision = (() => {
+        try {
+          return !!localStorage.getItem('fr_cookie_consent');
+        } catch {
+          return false;
+        }
+      })();
+      if (!hasStoredDecision) return;
+
       setHasContent(true);
       loadAdSenseScript().then(() => {
         try {
           ((window as any).adsbygoogle = (window as any).adsbygoogle || []).push({});
-        } catch {}
+        } catch {
+          // ignore
+        }
       });
     }, 100);
     return () => clearTimeout(timer);
-  }, []);
+  }, [consentReady, consentVersion]);
 
   if (!hasContent) return null;
 

--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -1,0 +1,87 @@
+import { openCookiePreferences } from './CookieConsentBanner';
+
+interface AppFooterProps {
+  isDarkMode: boolean;
+  onNavigate: (view: string) => void;
+}
+
+interface FooterLink {
+  label: string;
+  view: string;
+}
+
+const LEGAL_LINKS: FooterLink[] = [
+  { label: 'Privacy Policy', view: 'Privacy' },
+  { label: 'Terms of Service', view: 'Terms' },
+  { label: 'Cookie Policy', view: 'CookiePolicy' },
+  { label: 'Acceptable Use', view: 'AcceptableUse' },
+  { label: 'Disclaimer', view: 'Disclaimer' },
+  { label: 'Refunds', view: 'Refunds' },
+  { label: 'DMCA', view: 'DMCA' },
+  { label: 'Accessibility', view: 'Accessibility' },
+  { label: 'Do Not Sell / Share', view: 'DoNotSell' },
+];
+
+/**
+ * Global footer for authenticated/in-app views. Surfaces required compliance
+ * links on every page (Privacy, Terms, Cookie Policy, DMCA, CCPA opt-out, etc.)
+ * plus a button to reopen the cookie preferences center.
+ */
+export function AppFooter({ isDarkMode, onNavigate }: AppFooterProps) {
+  const border = isDarkMode ? 'border-slate-800' : 'border-slate-200';
+  const textMuted = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const linkClass = isDarkMode
+    ? 'text-slate-400 hover:text-slate-200'
+    : 'text-slate-600 hover:text-slate-900';
+  const bg = isDarkMode ? 'bg-slate-950' : 'bg-white';
+
+  const handleNav = (view: string) => (e: React.MouseEvent) => {
+    e.preventDefault();
+    onNavigate(view);
+  };
+
+  const viewToPath: Record<string, string> = {
+    Privacy: '/privacy',
+    Terms: '/terms',
+    CookiePolicy: '/cookies',
+    AcceptableUse: '/acceptable-use',
+    Disclaimer: '/disclaimer',
+    Refunds: '/refunds',
+    DMCA: '/dmca',
+    Accessibility: '/accessibility',
+    DoNotSell: '/do-not-sell',
+  };
+
+  return (
+    <footer className={`${bg} border-t ${border} mt-8`}>
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6">
+        <nav
+          aria-label="Footer"
+          className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-xs"
+        >
+          {LEGAL_LINKS.map((link) => (
+            <a
+              key={link.view}
+              href={viewToPath[link.view] || '#'}
+              onClick={handleNav(link.view)}
+              className={`${linkClass} transition-colors`}
+            >
+              {link.label}
+            </a>
+          ))}
+          <button
+            type="button"
+            onClick={openCookiePreferences}
+            className={`${linkClass} transition-colors`}
+          >
+            Cookie preferences
+          </button>
+        </nav>
+        <p className={`text-center text-xs mt-4 ${textMuted}`}>
+          © {new Date().getFullYear()} FilmRoom Fantasy. Fantasy football analysis &amp; management.
+          Not affiliated with the NFL or any fantasy platform.
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react';
+import { acceptAll, rejectAll, setConsent, getConsent, hasDecided } from '../services/consent';
+
+interface CookieConsentBannerProps {
+  isDarkMode: boolean;
+  onNavigate?: (view: string) => void;
+}
+
+/**
+ * Cookie consent banner shown at the bottom of the screen until the user
+ * makes a choice. Required for GDPR/ePrivacy (EU/UK/Swiss visitors) and for
+ * compliance with Google AdSense's EU User Consent Policy.
+ *
+ * Three actions:
+ *   - Accept All        — enables analytics + advertising cookies
+ *   - Reject All        — only essential cookies
+ *   - Manage Preferences — per-category toggles
+ *
+ * The banner listens for a global `fr:open-cookie-preferences` event so
+ * footer links can re-open it after the user has dismissed it.
+ */
+export function CookieConsentBanner({ isDarkMode, onNavigate }: CookieConsentBannerProps) {
+  const [visible, setVisible] = useState(false);
+  const [showPreferences, setShowPreferences] = useState(false);
+  const [analyticsOn, setAnalyticsOn] = useState(true);
+  const [advertisingOn, setAdvertisingOn] = useState(true);
+
+  useEffect(() => {
+    // Show banner on first visit (no stored decision)
+    if (!hasDecided()) {
+      setVisible(true);
+    }
+
+    // Allow footer links / settings page to re-open the banner
+    const openHandler = () => {
+      const current = getConsent();
+      if (current) {
+        setAnalyticsOn(current.analytics);
+        setAdvertisingOn(current.advertising);
+      }
+      setShowPreferences(true);
+      setVisible(true);
+    };
+    window.addEventListener('fr:open-cookie-preferences', openHandler);
+    return () => window.removeEventListener('fr:open-cookie-preferences', openHandler);
+  }, []);
+
+  if (!visible) return null;
+
+  const bg = isDarkMode ? 'bg-slate-900' : 'bg-white';
+  const border = isDarkMode ? 'border-slate-700' : 'border-slate-200';
+  const textPrimary = isDarkMode ? 'text-white' : 'text-slate-900';
+  const textSecondary = isDarkMode ? 'text-slate-300' : 'text-slate-600';
+  const textMuted = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const subBg = isDarkMode ? 'bg-slate-800/50' : 'bg-slate-50';
+
+  const handleAcceptAll = () => {
+    acceptAll();
+    setVisible(false);
+    setShowPreferences(false);
+  };
+
+  const handleRejectAll = () => {
+    rejectAll();
+    setVisible(false);
+    setShowPreferences(false);
+  };
+
+  const handleSavePreferences = () => {
+    setConsent({ analytics: analyticsOn, advertising: advertisingOn });
+    setVisible(false);
+    setShowPreferences(false);
+  };
+
+  const handleNavigateToPolicy = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (onNavigate) {
+      onNavigate('CookiePolicy');
+      setVisible(false);
+      setShowPreferences(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-labelledby="cookie-banner-title"
+      aria-describedby="cookie-banner-description"
+      className={`fixed inset-x-0 bottom-0 z-[70] ${bg} border-t ${border} shadow-2xl`}
+    >
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-4 sm:py-5">
+        {!showPreferences ? (
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex-1 min-w-0">
+              <h2 id="cookie-banner-title" className={`text-base font-semibold mb-1 ${textPrimary}`}>
+                We value your privacy
+              </h2>
+              <p id="cookie-banner-description" className={`text-sm ${textSecondary}`}>
+                We use cookies to keep you signed in, understand how the site is used,
+                and serve relevant ads through Google AdSense. You can accept all,
+                reject non-essential, or choose which categories to allow.{' '}
+                <a
+                  href="/cookies"
+                  onClick={handleNavigateToPolicy}
+                  className={`underline ${isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'}`}
+                >
+                  Learn more
+                </a>
+                .
+              </p>
+            </div>
+            <div className="flex flex-col sm:flex-row gap-2 sm:items-center flex-shrink-0">
+              <button
+                type="button"
+                onClick={() => setShowPreferences(true)}
+                className={`px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
+                  isDarkMode
+                    ? 'border-slate-600 text-slate-200 hover:bg-slate-800'
+                    : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                }`}
+              >
+                Manage preferences
+              </button>
+              <button
+                type="button"
+                onClick={handleRejectAll}
+                className={`px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
+                  isDarkMode
+                    ? 'border-slate-600 text-slate-200 hover:bg-slate-800'
+                    : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                }`}
+              >
+                Reject all
+              </button>
+              <button
+                type="button"
+                onClick={handleAcceptAll}
+                className="px-4 py-2 text-sm font-semibold rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+              >
+                Accept all
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className="flex items-start justify-between mb-4">
+              <h2 id="cookie-banner-title" className={`text-base font-semibold ${textPrimary}`}>
+                Cookie preferences
+              </h2>
+              <button
+                type="button"
+                onClick={() => setShowPreferences(false)}
+                className={`text-sm ${textMuted} hover:${textPrimary}`}
+                aria-label="Close preferences"
+              >
+                Back
+              </button>
+            </div>
+
+            <div className="space-y-3 mb-4">
+              <div className={`flex items-start gap-3 p-3 rounded-lg ${subBg}`}>
+                <div className="flex-1 min-w-0">
+                  <div className={`text-sm font-semibold ${textPrimary}`}>Essential</div>
+                  <p className={`text-xs ${textSecondary} mt-0.5`}>
+                    Required for sign-in, session security, and core site functionality.
+                    These cannot be disabled.
+                  </p>
+                </div>
+                <div className={`text-xs font-medium px-2 py-1 rounded ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-slate-200 text-slate-700'}`}>
+                  Always on
+                </div>
+              </div>
+
+              <label className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer ${subBg}`}>
+                <input
+                  type="checkbox"
+                  checked={analyticsOn}
+                  onChange={(e) => setAnalyticsOn(e.target.checked)}
+                  className="mt-0.5 h-4 w-4 rounded accent-blue-600"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className={`text-sm font-semibold ${textPrimary}`}>Analytics</div>
+                  <p className={`text-xs ${textSecondary} mt-0.5`}>
+                    Anonymous page-view tracking to help us understand how the site is used
+                    and improve features. No personal profiles are built.
+                  </p>
+                </div>
+              </label>
+
+              <label className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer ${subBg}`}>
+                <input
+                  type="checkbox"
+                  checked={advertisingOn}
+                  onChange={(e) => setAdvertisingOn(e.target.checked)}
+                  className="mt-0.5 h-4 w-4 rounded accent-blue-600"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className={`text-sm font-semibold ${textPrimary}`}>Advertising</div>
+                  <p className={`text-xs ${textSecondary} mt-0.5`}>
+                    Google AdSense cookies used to serve relevant ads. If disabled, you'll
+                    still see ads, but they won't be personalized.
+                  </p>
+                </div>
+              </label>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-2 justify-end">
+              <button
+                type="button"
+                onClick={handleRejectAll}
+                className={`px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
+                  isDarkMode
+                    ? 'border-slate-600 text-slate-200 hover:bg-slate-800'
+                    : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                }`}
+              >
+                Reject all
+              </button>
+              <button
+                type="button"
+                onClick={handleAcceptAll}
+                className={`px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
+                  isDarkMode
+                    ? 'border-slate-600 text-slate-200 hover:bg-slate-800'
+                    : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                }`}
+              >
+                Accept all
+              </button>
+              <button
+                type="button"
+                onClick={handleSavePreferences}
+                className="px-4 py-2 text-sm font-semibold rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+              >
+                Save preferences
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Dispatch an event to re-open the cookie preferences modal from anywhere. */
+export function openCookiePreferences(): void {
+  try {
+    window.dispatchEvent(new Event('fr:open-cookie-preferences'));
+  } catch {
+    // ignore
+  }
+}

--- a/src/components/CookiePolicyView.tsx
+++ b/src/components/CookiePolicyView.tsx
@@ -1,0 +1,214 @@
+import { openCookiePreferences } from './CookieConsentBanner';
+
+interface CookiePolicyViewProps {
+  isDarkMode: boolean;
+}
+
+export function CookiePolicyView({ isDarkMode }: CookiePolicyViewProps) {
+  const h = isDarkMode ? 'text-white' : 'text-slate-900';
+  const p = isDarkMode ? 'text-slate-300' : 'text-slate-600';
+  const s = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const border = isDarkMode ? 'border-slate-800' : 'border-slate-200';
+  const tableBorder = isDarkMode ? 'border-slate-700' : 'border-slate-300';
+  const tableHeadBg = isDarkMode ? 'bg-slate-800' : 'bg-slate-100';
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className={`text-3xl font-bold mb-2 ${h}`}>Cookie Policy</h1>
+      <p className={`text-sm mb-8 ${s}`}>Last updated: April 16, 2026</p>
+
+      <div className={`space-y-8 ${p}`}>
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>1. What are cookies?</h2>
+          <p>
+            Cookies are small text files placed on your device when you visit a website.
+            They allow the site to remember your actions and preferences (such as sign-in
+            state and dark mode) over time. This Cookie Policy explains which cookies
+            FilmRoom Fantasy uses, why we use them, and how you can control them.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>2. Categories of cookies we use</h2>
+
+          <h3 className={`text-lg font-medium mb-2 mt-4 ${h}`}>Essential (always on)</h3>
+          <p className="mb-3">
+            Required for the site to function. These include session cookies that keep
+            you signed in, CSRF tokens that protect form submissions, and preferences
+            that persist your dark mode selection. You cannot disable these because the
+            site will not work without them.
+          </p>
+
+          <h3 className={`text-lg font-medium mb-2 mt-4 ${h}`}>Analytics</h3>
+          <p className="mb-3">
+            First-party, anonymous page-view tracking that helps us understand which
+            features are used and where users encounter problems. No personal profiles
+            are built; we do not use these cookies for advertising.
+          </p>
+
+          <h3 className={`text-lg font-medium mb-2 mt-4 ${h}`}>Advertising</h3>
+          <p className="mb-3">
+            Third-party cookies set by Google AdSense and its partners. These may be
+            used to measure ad performance and, if you consent, to show you personalized
+            ads based on your browsing activity. If you decline advertising cookies, we
+            will ask Google to serve non-personalized ads instead.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>3. Cookies we set</h2>
+          <div className="overflow-x-auto">
+            <table className={`w-full text-sm border ${tableBorder} border-collapse`}>
+              <thead className={tableHeadBg}>
+                <tr>
+                  <th className={`text-left px-3 py-2 border ${tableBorder} ${h}`}>Name</th>
+                  <th className={`text-left px-3 py-2 border ${tableBorder} ${h}`}>Category</th>
+                  <th className={`text-left px-3 py-2 border ${tableBorder} ${h}`}>Purpose</th>
+                  <th className={`text-left px-3 py-2 border ${tableBorder} ${h}`}>Duration</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>session</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Essential</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Keeps you signed in (HttpOnly).</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Session / 30 days</td>
+                </tr>
+                <tr>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>fr_session_id</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Analytics</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Anonymous identifier used to deduplicate page views.</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Persistent (localStorage)</td>
+                </tr>
+                <tr>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>fr_cookie_consent</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Essential</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Stores your cookie consent choices.</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Persistent (localStorage)</td>
+                </tr>
+                <tr>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>darkMode</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Essential</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Remembers your light/dark theme preference.</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Persistent (localStorage)</td>
+                </tr>
+                <tr>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>__gads, __gpi, IDE</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Advertising</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Set by Google AdSense to measure ad performance and, with consent, to personalize ads.</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Up to 13 months</td>
+                </tr>
+                <tr>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Stripe (e.g. __stripe_mid)</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Essential</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>Set only on payment pages to prevent fraud during checkout.</td>
+                  <td className={`px-3 py-2 border ${tableBorder}`}>1 year</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>4. Third-party cookies</h2>
+          <p className="mb-3">
+            The following third parties may set cookies on our site. Each is governed by
+            its own privacy policy:
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>
+              <strong>Google AdSense</strong> — ad serving and measurement.{' '}
+              <a
+                href="https://policies.google.com/technologies/ads"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`underline ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+              >
+                Google privacy &amp; ads policy
+              </a>
+            </li>
+            <li>
+              <strong>Stripe</strong> — fraud prevention on payment pages.{' '}
+              <a
+                href="https://stripe.com/cookies-policy/legal"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`underline ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+              >
+                Stripe cookie policy
+              </a>
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>5. How to control cookies</h2>
+          <p className="mb-3">
+            You can change your choices at any time:
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>
+              Use our preference center:{' '}
+              <button
+                type="button"
+                onClick={openCookiePreferences}
+                className={`underline ${isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'}`}
+              >
+                Open cookie preferences
+              </button>
+            </li>
+            <li>Adjust your browser settings to block or delete cookies. Note that
+              blocking essential cookies will prevent sign-in from working.</li>
+            <li>
+              Opt out of personalized advertising across the web at{' '}
+              <a
+                href="https://adssettings.google.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`underline ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+              >
+                adssettings.google.com
+              </a>
+              {' '}and{' '}
+              <a
+                href="https://www.aboutads.info/choices/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`underline ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+              >
+                aboutads.info/choices
+              </a>
+              .
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>6. Do Not Track</h2>
+          <p>
+            Some browsers send a "Do Not Track" (DNT) signal. There is no industry
+            consensus on how to interpret DNT, so we do not respond to DNT signals.
+            You can instead use the cookie preferences above, which achieve the same
+            result.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>7. Changes to this policy</h2>
+          <p>
+            We may update this Cookie Policy when our practices change. We will post
+            the updated policy here with a revised "Last updated" date.
+          </p>
+        </section>
+
+        <section className={`border-t pt-6 ${border}`}>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact Us</h2>
+          <p>
+            Questions about this Cookie Policy? Email{' '}
+            <span className="font-medium">privacy@filmroomfantasy.com</span>.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DMCAView.tsx
+++ b/src/components/DMCAView.tsx
@@ -1,0 +1,106 @@
+interface DMCAViewProps {
+  isDarkMode: boolean;
+}
+
+export function DMCAView({ isDarkMode }: DMCAViewProps) {
+  const h = isDarkMode ? 'text-white' : 'text-slate-900';
+  const p = isDarkMode ? 'text-slate-300' : 'text-slate-600';
+  const s = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const border = isDarkMode ? 'border-slate-800' : 'border-slate-200';
+  const codeBg = isDarkMode ? 'bg-slate-800' : 'bg-slate-100';
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className={`text-3xl font-bold mb-2 ${h}`}>DMCA &amp; Copyright Policy</h1>
+      <p className={`text-sm mb-8 ${s}`}>Last updated: April 16, 2026</p>
+
+      <div className={`space-y-8 ${p}`}>
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>1. Our commitment</h2>
+          <p>
+            FilmRoom Fantasy respects the intellectual property rights of others and
+            expects our users to do the same. In accordance with the Digital Millennium
+            Copyright Act of 1998 ("DMCA"), we will respond expeditiously to valid
+            claims of copyright infringement regarding material hosted on
+            filmroomfantasy.com.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>2. Reporting copyright infringement</h2>
+          <p className="mb-3">
+            If you believe that material on FilmRoom infringes your copyright, please
+            send a written notice to our Designated Agent that includes the following:
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>A physical or electronic signature of the copyright owner or a person authorized to act on their behalf.</li>
+            <li>Identification of the copyrighted work claimed to have been infringed.</li>
+            <li>Identification of the material that is claimed to be infringing, with a URL or sufficient detail to permit us to locate it.</li>
+            <li>Your contact information (address, telephone number, and email address).</li>
+            <li>A statement that you have a good faith belief that the use of the material is not authorized by the copyright owner, its agent, or the law.</li>
+            <li>A statement, made under penalty of perjury, that the information in the notice is accurate and that you are the copyright owner or authorized to act on the owner's behalf.</li>
+          </ul>
+          <p className="mt-3">
+            Incomplete notices may not be actionable. Misrepresentations in a DMCA
+            notice may subject you to liability for damages, including costs and
+            attorney's fees (17 U.S.C. § 512(f)).
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>3. Designated agent</h2>
+          <div className={`${codeBg} rounded-lg p-4 text-sm ${p}`}>
+            <div><strong>FilmRoom Fantasy — DMCA Agent</strong></div>
+            <div>Email: <span className="font-medium">dmca@filmroomfantasy.com</span></div>
+            <div>Subject line: "DMCA Takedown Notice"</div>
+          </div>
+          <p className="mt-3">
+            Please use email for the fastest response. Postal mail may also be used but
+            will be considerably slower; contact us at the email above to request a
+            mailing address.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>4. Counter-notification</h2>
+          <p className="mb-3">
+            If you believe your content was removed by mistake or misidentification, you
+            may submit a counter-notification containing:
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>Your physical or electronic signature.</li>
+            <li>Identification of the material that was removed and the location where it appeared before removal.</li>
+            <li>A statement, under penalty of perjury, that you have a good faith belief the material was removed as a result of mistake or misidentification.</li>
+            <li>Your name, address, telephone number, and a statement that you consent to the jurisdiction of the federal district court for the judicial district in which you reside (or any judicial district in which FilmRoom may be found if you reside outside the United States), and that you will accept service of process from the person who filed the original DMCA notice.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>5. Repeat infringer policy</h2>
+          <p>
+            It is our policy, in appropriate circumstances and at our discretion, to
+            suspend or terminate accounts of users who are deemed to be repeat
+            infringers.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>6. Trademarks and other rights</h2>
+          <p>
+            For trademark, right-of-publicity, or other non-copyright claims, please
+            email <span className="font-medium">support@filmroomfantasy.com</span> with
+            a detailed description of the issue and the specific URL(s) involved.
+          </p>
+        </section>
+
+        <section className={`border-t pt-6 ${border}`}>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
+          <p>
+            General copyright questions:{' '}
+            <span className="font-medium">dmca@filmroomfantasy.com</span>.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DisclaimerView.tsx
+++ b/src/components/DisclaimerView.tsx
@@ -1,0 +1,114 @@
+interface DisclaimerViewProps {
+  isDarkMode: boolean;
+}
+
+export function DisclaimerView({ isDarkMode }: DisclaimerViewProps) {
+  const h = isDarkMode ? 'text-white' : 'text-slate-900';
+  const p = isDarkMode ? 'text-slate-300' : 'text-slate-600';
+  const s = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const border = isDarkMode ? 'border-slate-800' : 'border-slate-200';
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className={`text-3xl font-bold mb-2 ${h}`}>Disclaimer</h1>
+      <p className={`text-sm mb-8 ${s}`}>Last updated: April 16, 2026</p>
+
+      <div className={`space-y-8 ${p}`}>
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>1. Informational purposes only</h2>
+          <p>
+            All content on FilmRoom Fantasy — including player rankings, projections,
+            trade grades, waiver recommendations, playoff odds, and articles — is
+            provided for informational and entertainment purposes only. It is not
+            intended as, and should not be construed as, professional advice of any
+            kind.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>2. Not gambling or betting advice</h2>
+          <p>
+            FilmRoom is a fantasy football analysis tool. We do not offer gambling or
+            sports-betting advice, do not accept wagers, and do not facilitate payouts
+            of any kind. Any decisions you make on third-party platforms (including
+            daily fantasy sports, sportsbooks, or prop-betting services) are your own.
+            If you or someone you know has a gambling problem, call 1-800-GAMBLER or
+            visit{' '}
+            <a
+              href="https://www.ncpgambling.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`underline ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+            >
+              ncpgambling.org
+            </a>
+            .
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>3. No guarantees of accuracy</h2>
+          <p>
+            Our projections are generated from Vegas betting lines, publicly available
+            NFL statistics, and proprietary models. Fantasy football is inherently
+            unpredictable — injuries, weather, coaching decisions, and in-game
+            circumstances can change outcomes. We do not guarantee the accuracy,
+            completeness, or timeliness of any projection, ranking, or analysis, and
+            we make no promises about fantasy football results.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>4. AI-generated content</h2>
+          <p>
+            Some features (including the Trade Analyzer and counter-offer suggestions)
+            use artificial intelligence and machine-learning models. AI output may
+            contain inaccuracies, biases, or errors and should not be relied upon as a
+            sole basis for any decision. Always apply your own judgment.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>5. Third-party trademarks</h2>
+          <p>
+            NFL team names, logos, player names, and related marks are the property of
+            their respective owners. References to players, teams, or leagues on
+            FilmRoom are for identification and commentary purposes only. FilmRoom is
+            not affiliated with, endorsed by, or sponsored by the NFL, any NFL team,
+            or any fantasy football platform (Sleeper, ESPN, Yahoo, or otherwise).
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>6. External links</h2>
+          <p>
+            Our site may contain links to third-party websites. We do not control and
+            are not responsible for the content, accuracy, or privacy practices of any
+            linked site. Use of external sites is at your own risk.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>7. No liability</h2>
+          <p>
+            FilmRoom, its owners, employees, and affiliates accept no liability for
+            any loss (including loss of winnings, league fees, or entry fees) arising
+            from your use of the site. See our{' '}
+            <a href="/terms" className={`underline ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}>
+              Terms of Service
+            </a>
+            {' '}for the full disclaimer of warranties and limitation of liability.
+          </p>
+        </section>
+
+        <section className={`border-t pt-6 ${border}`}>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
+          <p>
+            Questions? Email{' '}
+            <span className="font-medium">support@filmroomfantasy.com</span>.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DoNotSellView.tsx
+++ b/src/components/DoNotSellView.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { openCookiePreferences } from './CookieConsentBanner';
+import { rejectAll, getConsent } from '../services/consent';
+
+interface DoNotSellViewProps {
+  isDarkMode: boolean;
+}
+
+export function DoNotSellView({ isDarkMode }: DoNotSellViewProps) {
+  const h = isDarkMode ? 'text-white' : 'text-slate-900';
+  const p = isDarkMode ? 'text-slate-300' : 'text-slate-600';
+  const s = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const border = isDarkMode ? 'border-slate-800' : 'border-slate-200';
+  const cardBg = isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-slate-50 border-slate-200';
+
+  const current = getConsent();
+  const [optedOut, setOptedOut] = useState(
+    current !== null && current.advertising === false && current.analytics === false
+  );
+
+  const handleOptOut = () => {
+    rejectAll();
+    setOptedOut(true);
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className={`text-3xl font-bold mb-2 ${h}`}>Do Not Sell or Share My Personal Information</h1>
+      <p className={`text-sm mb-8 ${s}`}>Last updated: April 16, 2026</p>
+
+      <div className={`space-y-8 ${p}`}>
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Your California privacy rights</h2>
+          <p>
+            Under the California Consumer Privacy Act (CCPA) as amended by the CPRA,
+            California residents have the right to opt out of the "sale" or "sharing"
+            of their personal information. Under these laws, the use of third-party
+            advertising cookies (including Google AdSense) to show you personalized
+            ads can qualify as "sharing" even when no money changes hands.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>What we do</h2>
+          <p className="mb-3">
+            We do not sell personal information in the traditional sense. However, we
+            may share limited data (such as cookie identifiers and IP address) with
+            Google AdSense and other advertising partners so they can serve relevant
+            ads, which may be considered "sharing" under California law.
+          </p>
+          <p>
+            We also honor the Global Privacy Control (GPC) browser signal as a valid
+            opt-out request when transmitted by your browser.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Opt out now</h2>
+          <div className={`rounded-xl border p-6 ${cardBg}`}>
+            {optedOut ? (
+              <div>
+                <p className={`mb-2 font-semibold ${h}`}>You're opted out.</p>
+                <p className="text-sm">
+                  Personalized advertising and analytics cookies are disabled for this
+                  browser. You can fine-tune your preferences at any time using the
+                  button below.
+                </p>
+              </div>
+            ) : (
+              <div>
+                <p className={`mb-4 ${p}`}>
+                  Clicking the button below will disable analytics and advertising
+                  cookies for this browser. You will still see ads, but they will not
+                  be personalized.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleOptOut}
+                  className="px-5 py-2.5 rounded-lg bg-blue-600 text-white font-semibold text-sm hover:bg-blue-700 transition-colors"
+                >
+                  Opt out of sale / sharing
+                </button>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={openCookiePreferences}
+              className={`mt-4 text-sm underline ${isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'}`}
+            >
+              Open cookie preferences
+            </button>
+          </div>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Other rights you have</h2>
+          <p className="mb-3">California residents also have the right to:</p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>Know what personal information we collect, use, and disclose about you.</li>
+            <li>Request a copy of your personal information.</li>
+            <li>Request deletion of your personal information, subject to certain exceptions.</li>
+            <li>Correct inaccurate personal information.</li>
+            <li>Limit the use and disclosure of sensitive personal information.</li>
+            <li>Not be discriminated against for exercising any of these rights.</li>
+          </ul>
+          <p className="mt-3">
+            To exercise these rights, email{' '}
+            <span className="font-medium">privacy@filmroomfantasy.com</span> from the
+            email address associated with your account. We may need to verify your
+            identity before fulfilling the request.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Authorized agents</h2>
+          <p>
+            You may designate an authorized agent to submit a request on your behalf.
+            We will require written proof of the agent's authority and may contact you
+            directly to verify the request.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>For residents of other states</h2>
+          <p>
+            Similar rights may be available to residents of Colorado, Connecticut,
+            Virginia, Utah, and other U.S. states with comprehensive privacy laws. We
+            honor opt-out requests from residents of any U.S. state.
+          </p>
+        </section>
+
+        <section className={`border-t pt-6 ${border}`}>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
+          <p>
+            Privacy requests:{' '}
+            <span className="font-medium">privacy@filmroomfantasy.com</span>.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { openCookiePreferences } from './CookieConsentBanner';
 
 interface LandingPageProps {
   onNavigate: (view: string) => void;
@@ -144,7 +145,11 @@ const LANDING_CSS = `
 .lp .bottom-cta{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:48px;text-align:center;margin:0 0 40px}
 .lp .bottom-cta h2{font-size:28px;margin:0 0 8px;font-weight:800;color:var(--text-bright);letter-spacing:-.02em}
 .lp .bottom-cta p{color:var(--muted);margin:0 0 20px;font-size:14px}
-.lp footer{border-top:1px solid var(--border);padding:24px 0;color:var(--muted);font-size:12px;text-align:center}
+.lp footer{border-top:1px solid var(--border);padding:28px 0;color:var(--muted);font-size:12px;text-align:center}
+.lp .footer-links{display:flex;flex-wrap:wrap;justify-content:center;gap:8px 16px;margin-bottom:12px}
+.lp .footer-links a,.lp .footer-links button{color:var(--muted);cursor:pointer;font-size:12px;transition:color .12s;background:none;border:none;padding:0;font-family:inherit}
+.lp .footer-links a:hover,.lp .footer-links button:hover{color:var(--text)}
+.lp .footer-copy{color:var(--muted);font-size:12px}
 .lp .finder-row{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;border-radius:8px;background:var(--bg);border:1px solid var(--border);margin-bottom:6px;font-size:12px}
 .lp .finder-row:hover{border-color:var(--blue-border)}
 .lp .finder-players{display:flex;align-items:center;gap:6px;flex:1;flex-wrap:wrap}
@@ -549,7 +554,21 @@ export function LandingPage({ onNavigate }: LandingPageProps) {
       </section>
 
       <footer>
-        <div className="container">&copy; 2026 FilmRoom &mdash; Film-based fantasy football analysis &amp; management.</div>
+        <div className="container">
+          <nav className="footer-links" aria-label="Footer">
+            <a onClick={nav('Privacy')}>Privacy Policy</a>
+            <a onClick={nav('Terms')}>Terms of Service</a>
+            <a onClick={nav('CookiePolicy')}>Cookie Policy</a>
+            <a onClick={nav('AcceptableUse')}>Acceptable Use</a>
+            <a onClick={nav('Disclaimer')}>Disclaimer</a>
+            <a onClick={nav('Refunds')}>Refunds</a>
+            <a onClick={nav('DMCA')}>DMCA</a>
+            <a onClick={nav('Accessibility')}>Accessibility</a>
+            <a onClick={nav('DoNotSell')}>Do Not Sell / Share</a>
+            <button type="button" onClick={() => openCookiePreferences()}>Cookie preferences</button>
+          </nav>
+          <div className="footer-copy">&copy; {new Date().getFullYear()} FilmRoom &mdash; Fantasy football analysis &amp; management. Not affiliated with the NFL or any fantasy platform.</div>
+        </div>
       </footer>
     </div>
   );

--- a/src/components/RefundPolicyView.tsx
+++ b/src/components/RefundPolicyView.tsx
@@ -1,0 +1,121 @@
+interface RefundPolicyViewProps {
+  isDarkMode: boolean;
+}
+
+export function RefundPolicyView({ isDarkMode }: RefundPolicyViewProps) {
+  const h = isDarkMode ? 'text-white' : 'text-slate-900';
+  const p = isDarkMode ? 'text-slate-300' : 'text-slate-600';
+  const s = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const border = isDarkMode ? 'border-slate-800' : 'border-slate-200';
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className={`text-3xl font-bold mb-2 ${h}`}>Refund &amp; Cancellation Policy</h1>
+      <p className={`text-sm mb-8 ${s}`}>Last updated: April 16, 2026</p>
+
+      <div className={`space-y-8 ${p}`}>
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>1. Subscription plans</h2>
+          <p>
+            FilmRoom Fantasy offers a free plan and two paid subscription tiers (Pro
+            and Elite) billed monthly through Stripe. This policy explains how billing,
+            cancellations, and refunds work.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>2. Free trials</h2>
+          <p>
+            If you start a free trial of a paid plan, we will not charge your payment
+            method until the trial period ends. You may cancel at any time during the
+            trial to avoid being charged.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>3. Recurring billing</h2>
+          <p>
+            Paid subscriptions renew automatically each month at the then-current price
+            until cancelled. We send a receipt to your email address after each
+            successful charge.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>4. Cancellation</h2>
+          <p className="mb-3">
+            You can cancel your subscription at any time from{' '}
+            <strong>Settings → Subscription</strong>. When you cancel:
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>Your paid features remain active through the end of the current billing period.</li>
+            <li>You will not be billed again.</li>
+            <li>Your account automatically returns to the Free plan at the end of the period.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>5. Refunds</h2>
+          <p className="mb-3">
+            Because subscriptions can be cancelled at any time and service continues
+            through the billing period you already paid for, monthly subscriptions are
+            generally non-refundable.
+          </p>
+          <p className="mb-3">
+            We may issue a full or partial refund at our discretion in the following
+            situations:
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>Duplicate or accidental charges.</li>
+            <li>A billing error or technical issue attributable to FilmRoom that prevented you from using the service.</li>
+            <li>You were charged for a renewal immediately after cancelling (notify us within 7 days).</li>
+            <li>Where required by applicable consumer protection law.</li>
+          </ul>
+          <p className="mt-3">
+            To request a refund, email{' '}
+            <span className="font-medium">billing@filmroomfantasy.com</span> from the
+            email address on your account and include the date and amount of the charge.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>6. Chargebacks</h2>
+          <p>
+            If you believe a charge is incorrect, please contact us first — most issues
+            can be resolved quickly. Initiating a chargeback without contacting us may
+            result in suspension of your account while the dispute is investigated.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>7. Price changes</h2>
+          <p>
+            We may change subscription prices from time to time. Any price change will
+            be communicated at least 14 days in advance and will take effect on your
+            next billing cycle. If you do not agree with the new price, you can cancel
+            before it takes effect.
+          </p>
+        </section>
+
+        <section>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>8. EU / UK consumer rights</h2>
+          <p>
+            If you are a consumer in the EU or UK, you have a 14-day right of
+            withdrawal from the date of your initial paid subscription, provided you
+            have not substantially used the service. You expressly request that service
+            begins immediately upon subscribing, which may affect the withdrawal right
+            for services already provided. Contact us to exercise this right.
+          </p>
+        </section>
+
+        <section className={`border-t pt-6 ${border}`}>
+          <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
+          <p>
+            Billing questions:{' '}
+            <span className="font-medium">billing@filmroomfantasy.com</span>.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -102,6 +102,34 @@ const ROUTE_SEO: Record<string, { title: string; description: string }> = {
     title: 'Terms of Service | FilmRoom',
     description: 'FilmRoom Fantasy terms of service. Read the terms and conditions governing your use of our fantasy football analysis platform.',
   },
+  CookiePolicy: {
+    title: 'Cookie Policy | FilmRoom',
+    description: 'Learn about the cookies FilmRoom Fantasy uses, how we use them, and how to control your preferences.',
+  },
+  DMCA: {
+    title: 'DMCA & Copyright Policy | FilmRoom',
+    description: 'How to report copyright infringement on FilmRoom Fantasy and our process for handling DMCA takedown notices.',
+  },
+  Refunds: {
+    title: 'Refund & Cancellation Policy | FilmRoom',
+    description: 'How FilmRoom Fantasy subscription billing, cancellations, and refunds work.',
+  },
+  DoNotSell: {
+    title: 'Do Not Sell or Share My Personal Information | FilmRoom',
+    description: 'California and state privacy rights. Opt out of the sale or sharing of your personal information on FilmRoom Fantasy.',
+  },
+  Disclaimer: {
+    title: 'Disclaimer | FilmRoom',
+    description: 'FilmRoom Fantasy disclaimer. Our rankings, projections, and analysis are for informational purposes only.',
+  },
+  Accessibility: {
+    title: 'Accessibility Statement | FilmRoom',
+    description: "FilmRoom Fantasy's commitment to accessibility and our progress toward WCAG 2.1 AA conformance.",
+  },
+  AcceptableUse: {
+    title: 'Acceptable Use Policy | FilmRoom',
+    description: 'The rules for using FilmRoom Fantasy. Prohibited activities and enforcement.',
+  },
 };
 
 // View name to URL path mapping
@@ -129,6 +157,13 @@ const VIEW_TO_PATH: Record<string, string> = {
   Admin: '/admin',
   Privacy: '/privacy',
   Terms: '/terms',
+  CookiePolicy: '/cookies',
+  DMCA: '/dmca',
+  Refunds: '/refunds',
+  DoNotSell: '/do-not-sell',
+  Disclaimer: '/disclaimer',
+  Accessibility: '/accessibility',
+  AcceptableUse: '/acceptable-use',
 };
 
 export function SEO({ title, description, path, type = 'website', image, noindex, jsonLd }: SEOProps) {

--- a/src/components/TermsOfServiceView.tsx
+++ b/src/components/TermsOfServiceView.tsx
@@ -80,7 +80,16 @@ export function TermsOfServiceView({ isDarkMode }: TermsOfServiceViewProps) {
 
         <section>
           <h2 className={`text-xl font-semibold mb-3 ${h}`}>6. Acceptable Use</h2>
-          <p className="mb-3">You agree not to:</p>
+          <p className="mb-3">
+            Your use of FilmRoom is governed by our{' '}
+            <a
+              href="/acceptable-use"
+              className={`underline ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}
+            >
+              Acceptable Use Policy
+            </a>
+            , which is incorporated into these Terms. In summary, you agree not to:
+          </p>
           <ul className="list-disc list-inside space-y-2">
             <li>Use FilmRoom for any unlawful purpose or in violation of any applicable laws</li>
             <li>Attempt to gain unauthorized access to our systems, other accounts, or data</li>
@@ -89,6 +98,9 @@ export function TermsOfServiceView({ isDarkMode }: TermsOfServiceViewProps) {
             <li>Resell, redistribute, or commercially exploit our content, projections, or analysis without written consent</li>
             <li>Upload malicious code, viruses, or any harmful content</li>
           </ul>
+          <p className="mt-3">
+            See the full <a href="/acceptable-use" className={`underline ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}>Acceptable Use Policy</a> for the complete list of prohibited activities and enforcement details.
+          </p>
         </section>
 
         <section>

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,4 +1,5 @@
 import { api } from './api';
+import { isAllowed } from './consent';
 
 // Generate or retrieve a persistent anonymous session ID
 function getSessionId(): string {
@@ -31,6 +32,9 @@ function getBrowser(): string {
 let lastTrackedPath = '';
 
 export function trackPageView(path: string): void {
+  // Respect user consent — skip analytics entirely if not granted
+  if (!isAllowed('analytics')) return;
+
   // Deduplicate rapid-fire calls for the same path
   if (path === lastTrackedPath) return;
   lastTrackedPath = path;

--- a/src/services/consent.ts
+++ b/src/services/consent.ts
@@ -1,0 +1,142 @@
+/**
+ * Cookie consent management.
+ *
+ * Tracks user consent for three categories of cookies/technologies:
+ *   - essential: always on (session, auth, CSRF, dark-mode preference)
+ *   - analytics: first-party page-view analytics
+ *   - advertising: Google AdSense + personalized advertising cookies
+ *
+ * Consent is stored in localStorage under `fr_cookie_consent`. A CustomEvent
+ * named `fr:consent-change` is dispatched on the window whenever consent is
+ * updated so subscribers (AdUnit, analytics) can react immediately.
+ *
+ * We treat "no stored value" as "no decision yet" and keep non-essential
+ * cookies disabled until the user makes a choice (GDPR/ePrivacy compliant).
+ */
+
+export type ConsentCategory = 'essential' | 'analytics' | 'advertising';
+
+export interface ConsentState {
+  essential: true; // always true; included for type completeness
+  analytics: boolean;
+  advertising: boolean;
+  /** ISO timestamp of when the user made this decision. */
+  decidedAt: string | null;
+  /** Schema version — bump if we materially change the categories. */
+  version: number;
+}
+
+const STORAGE_KEY = 'fr_cookie_consent';
+const EVENT_NAME = 'fr:consent-change';
+const CURRENT_VERSION = 1;
+
+const DEFAULT_PENDING: ConsentState = {
+  essential: true,
+  analytics: false,
+  advertising: false,
+  decidedAt: null,
+  version: CURRENT_VERSION,
+};
+
+function readStorage(): ConsentState | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ConsentState>;
+    if (parsed.version !== CURRENT_VERSION) return null;
+    return {
+      essential: true,
+      analytics: !!parsed.analytics,
+      advertising: !!parsed.advertising,
+      decidedAt: typeof parsed.decidedAt === 'string' ? parsed.decidedAt : null,
+      version: CURRENT_VERSION,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(state: ConsentState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage unavailable — in-memory only (banner will reappear next visit)
+  }
+}
+
+/** Get the current consent state. If no decision has been made, returns null. */
+export function getConsent(): ConsentState | null {
+  return readStorage();
+}
+
+/** Whether the user has made an explicit consent decision yet. */
+export function hasDecided(): boolean {
+  const state = readStorage();
+  return state !== null && state.decidedAt !== null;
+}
+
+/** Whether a specific category is allowed. Essential is always true. */
+export function isAllowed(category: ConsentCategory): boolean {
+  if (category === 'essential') return true;
+  const state = readStorage();
+  if (!state) return false;
+  return state[category] === true;
+}
+
+/** Set consent for all categories at once and notify subscribers. */
+export function setConsent(next: { analytics: boolean; advertising: boolean }): void {
+  const state: ConsentState = {
+    essential: true,
+    analytics: !!next.analytics,
+    advertising: !!next.advertising,
+    decidedAt: new Date().toISOString(),
+    version: CURRENT_VERSION,
+  };
+  writeStorage(state);
+  try {
+    window.dispatchEvent(new CustomEvent<ConsentState>(EVENT_NAME, { detail: state }));
+  } catch {
+    // CustomEvent unavailable (old browser) — subscribers will pick up on next read
+  }
+}
+
+/** Accept everything. */
+export function acceptAll(): void {
+  setConsent({ analytics: true, advertising: true });
+}
+
+/** Reject everything non-essential. */
+export function rejectAll(): void {
+  setConsent({ analytics: false, advertising: false });
+}
+
+/** Clear the stored decision (used by "Manage preferences" to reopen the banner). */
+export function resetConsent(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+  try {
+    window.dispatchEvent(new CustomEvent<ConsentState>(EVENT_NAME, { detail: DEFAULT_PENDING }));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Subscribe to consent changes. The callback is invoked immediately with the
+ * current state, and again whenever consent is updated. Returns an unsubscribe
+ * function.
+ */
+export function onConsentChange(cb: (state: ConsentState) => void): () => void {
+  const handler = (e: Event) => {
+    const detail = (e as CustomEvent<ConsentState>).detail;
+    if (detail) cb(detail);
+    else cb(readStorage() ?? DEFAULT_PENDING);
+  };
+  window.addEventListener(EVENT_NAME, handler);
+  // Invoke once with current state so subscribers don't need to read twice
+  cb(readStorage() ?? DEFAULT_PENDING);
+  return () => window.removeEventListener(EVENT_NAME, handler);
+}


### PR DESCRIPTION
Adds the full suite of data-compliance surfaces the site was missing:

New pages (all lazy-loaded, SEO-indexed with static HTML):
- /cookies          Cookie Policy
- /dmca             DMCA & Copyright Policy
- /refunds          Refund & Cancellation Policy
- /do-not-sell      CCPA/CPRA opt-out with in-page action
- /disclaimer       Informational-purposes-only notice
- /accessibility    WCAG 2.1 AA commitment
- /acceptable-use   Standalone AUP (also referenced from ToS)

Cookie consent:
- services/consent.ts manages user choice across essential / analytics / advertising categories with event dispatch.
- CookieConsentBanner renders on first visit with accept / reject / manage-preferences options; can be reopened from any footer via openCookiePreferences().
- analytics.trackPageView is gated on analytics consent.
- AdUnit waits for a consent decision before loading AdSense and signals requestNonPersonalizedAds=1 when advertising cookies are rejected (Google-recommended GDPR/CCPA path).

Global footer:
- AppFooter component surfaces all compliance links plus a Cookie preferences button on every in-app page.
- LandingPage footer extended with the same links.