### PR TITLE
Don't show sync prompt on injury alerts when league is synced

### DIFF
--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -732,7 +732,7 @@ export function HomeView({ onPlayerClick, onViewChange, onGameSelect, isDarkMode
             )}
           </div>
           <div>
-            {roster.length === 0 ? (
+            {roster.length === 0 && !league ? (
               <div className={`p-6 text-center text-sm ${mutedCls}`}>Sync a league to see alerts</div>
             ) : injuredRosterPlayers.length === 0 ? (
               <div className={`p-6 text-center text-sm ${mutedCls}`}>No injuries on your roster</div>


### PR DESCRIPTION
Previously the injury alerts panel checked only roster length, so a synced league with an empty roster showed "Sync a league to see alerts". Now it only shows that message when no league is synced.