### PR TITLE
Patch missing table-cell + responsive visibility utilities

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -961,3 +961,75 @@ html {
 /* Disabled cursor helpers used on buttons */
 .disabled\:cursor-not-allowed:disabled { cursor: not-allowed; }
 .disabled\:opacity-50:disabled         { opacity: 0.5; }
+
+/* -- Table display + responsive visibility utilities --
+ * Missing from the compiled bundle, caused PlayerTable columns
+ * (POSITION/STATS/+-/OUTCOME/TREND) to be hidden at every viewport.
+ */
+.table         { display: table; }
+.table-cell    { display: table-cell; }
+.table-row     { display: table-row; }
+.table-header-group { display: table-header-group; }
+.table-row-group    { display: table-row-group; }
+.inline-flex   { display: inline-flex; }
+
+/* Responsive display variants */
+@media (min-width: 640px) {
+  .sm\:table-cell { display: table-cell; }
+  .sm\:block      { display: block; }
+  .sm\:inline     { display: inline; }
+  .sm\:hidden     { display: none; }
+  .sm\:flex       { display: flex; }
+  .sm\:w-auto     { width: auto; }
+  .sm\:w-16       { width: 4rem; }
+  .sm\:w-36       { width: 9rem; }
+  .sm\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .sm\:px-3       { padding-left: 0.75rem; padding-right: 0.75rem; }
+  .sm\:px-4       { padding-left: 1rem; padding-right: 1rem; }
+  .sm\:px-6       { padding-left: 1.5rem; padding-right: 1.5rem; }
+  .sm\:py-1       { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+  .sm\:py-1\.5    { padding-top: 0.375rem; padding-bottom: 0.375rem; }
+  .sm\:py-4       { padding-top: 1rem; padding-bottom: 1rem; }
+  .sm\:p-4        { padding: 1rem; }
+  .sm\:p-6        { padding: 1.5rem; }
+  .sm\:gap-3      { gap: 0.75rem; }
+  .sm\:mt-4       { margin-top: 1rem; }
+  .sm\:w-12       { width: 3rem; }
+  .sm\:h-12       { height: 3rem; }
+  .sm\:text-base  { font-size: 1rem; line-height: 1.5rem; }
+  .sm\:text-sm    { font-size: 0.875rem; line-height: 1.25rem; }
+  .sm\:text-lg    { font-size: 1.125rem; line-height: 1.75rem; }
+  .sm\:text-3xl   { font-size: 1.875rem; line-height: 2.25rem; }
+}
+@media (min-width: 768px) {
+  .md\:table-cell { display: table-cell; }
+  .md\:block      { display: block; }
+  .md\:inline     { display: inline; }
+  .md\:hidden     { display: none; }
+  .md\:flex       { display: flex; }
+  .md\:px-6       { padding-left: 1.5rem; padding-right: 1.5rem; }
+  .md\:py-4       { padding-top: 1rem; padding-bottom: 1rem; }
+  .md\:p-6        { padding: 1.5rem; }
+  .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .md\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+@media (min-width: 1024px) {
+  .lg\:table-cell { display: table-cell; }
+  .lg\:block      { display: block; }
+  .lg\:hidden     { display: none; }
+  .lg\:flex       { display: flex; }
+  .lg\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+
+/* Tabular nums for numeric columns */
+.tabular-nums { font-variant-numeric: tabular-nums; }
+
+/* Misc utilities referenced by PlayerTable/RosterBoardPanel */
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
+.placeholder-slate-500::placeholder { color: #64748b; }
+.placeholder-slate-400::placeholder { color: #94a3b8; }


### PR DESCRIPTION
Diagnosed from the live Player Rankings screenshot — only RK, PLAYER, and PTS columns rendered; POSITION, STATS, +/-, OUTCOME, and TREND were all permanently hidden regardless of viewport.

Root cause: the pre-compiled src/index.css was missing .table-cell and every responsive variant of it (.sm:table-cell, .md:table-cell, .lg:table-cell) plus sibling sm/md/lg display / padding / sizing utilities that PlayerTable.tsx relies on.

Append the missing utilities to globals.css:
- Table displays: .table, .table-cell, .table-row, .table-header-group, .table-row-group
- .inline-flex (used in many pill/badge layouts)
- sm: variants: table-cell, block, inline, hidden, flex, w-auto, w-16, w-36, w-12, h-12, grid-cols-3, px-3/4/6, py-1/1.5/4, p-4/6, gap-3, mt-4, text-base/sm/lg/3xl
- md: variants: table-cell, block, inline, hidden, flex, px-6, py-4, p-6, grid-cols-2/3/4
- lg: variants: table-cell, block, hidden, flex, grid-cols-4
- .tabular-nums for numeric columns
- .sr-only accessibility helper
- .placeholder-slate-400 / .placeholder-slate-500

Verified: after rebuild, .sm\:table-cell and .md\:table-cell are in the built CSS bundle.