### PR TITLE
Use real CSS rules for cookie-banner/sidebar stacking

### DIFF
--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -91,7 +91,7 @@ export function CookieConsentBanner({ isDarkMode, onNavigate, offsetForSidebar =
       role="dialog"
       aria-labelledby="cookie-banner-title"
       aria-describedby="cookie-banner-description"
-      className={`fixed right-0 bottom-0 left-0 z-[70] ${offsetForSidebar ? 'md:left-64' : ''} ${bg} border-t ${border} shadow-2xl`}
+      className={`fixed right-0 bottom-0 z-cookie-banner ${offsetForSidebar ? 'cookie-banner-sidebar-offset' : 'left-0'} ${bg} border-t ${border} shadow-2xl`}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6 py-4 sm:py-5">
         {!showPreferences ? (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -139,7 +139,7 @@ export function Sidebar({ activeView, onViewChange, isDarkMode, isAuthenticated 
       {/* Mobile backdrop */}
       {mobileOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 md:hidden"
+          className="fixed inset-0 bg-black/50 z-mobile-backdrop md:hidden"
           onClick={onMobileClose}
         />
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -2515,7 +2515,8 @@ html {
   top: 0;
   bottom: 0;
   left: 0;
-  z-index: 50;
+  /* Above the cookie consent banner (z-[70]) so it covers it on mobile. */
+  z-index: 80;
 }
 
 /* Mobile-only element (e.g., hamburger menu button) */
@@ -2526,4 +2527,25 @@ html {
   .mobile-only {
     display: none;
   }
+}
+
+/* Cookie banner: full width on mobile, offset by sidebar (w-64 = 16rem) on md+ */
+.cookie-banner-sidebar-offset {
+  left: 0;
+}
+@media (min-width: 768px) {
+  .cookie-banner-sidebar-offset {
+    left: 16rem;
+  }
+}
+
+/* Explicit z-index layers for the cookie banner, mobile backdrop, and the
+   mobile-open sidebar. Only .z-50 is present in the compiled Tailwind bundle,
+   so we define the other tiers here to keep stacking predictable:
+     banner   (70) < backdrop (75) < mobile-open sidebar (80). */
+.z-cookie-banner {
+  z-index: 70;
+}
+.z-mobile-backdrop {
+  z-index: 75;
 }


### PR DESCRIPTION
The previous offset attempt used md:left-64, but src/index.css is a pre-compiled Tailwind v4 bundle that does not include that class, so the class was a no-op and the banner still phased through the sidebar on desktop. Same issue for the z-40 backdrop and z-[70] banner — only .z-50 exists in the compiled CSS, leaving everything else at z-index auto.

Define concrete CSS rules in index.css for the banner's sidebar offset (left: 16rem at md+) and for explicit z-index tiers, then switch the components to use those classes. The mobile-open sidebar now sits above the banner (z-index 80), and the backdrop above the banner but under the sidebar.