### PR TITLE
Fix getDefaultSeason ReferenceError in AllPlayersView

### DIFF
--- a/src/components/AllPlayersView.tsx
+++ b/src/components/AllPlayersView.tsx
@@ -4,7 +4,7 @@ import { Player } from '../App';
 import { useLeagueContext } from '../context/LeagueContext';
 import api from '../services/api';
 import { useOdds } from '../hooks/useOdds';
-import { type APIPlayer, convertAPIPlayerToPlayer, getEffectiveSeason, scoringToFormat, NFL_WEEKS } from '../utils/playerUtils';
+import { type APIPlayer, convertAPIPlayerToPlayer, getDefaultSeason, getEffectiveSeason, scoringToFormat, NFL_WEEKS } from '../utils/playerUtils';
 
 const ALL_PLAYERS_PAGE_SIZE = 350;
 


### PR DESCRIPTION
## Summary
- `AllPlayersView.tsx` called `getDefaultSeason()` (line 129) but never imported it, so clicking "View more players" crashed with `getDefaultSeason is not defined`.
- Added `getDefaultSeason` to the existing import from `../utils/playerUtils`.

## Test plan
- [ ] Open the app, click "View more players" from the board and waivers entry points — page renders without runtime error.
- [ ] Odds load for the current week.

https://claude.ai/code/session_01Q6AYVATkdFawFAkZPK7tTY