### PR TITLE
Loosen footer link spacing

### DIFF
--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -57,7 +57,7 @@ export function AppFooter({ isDarkMode, onNavigate }: AppFooterProps) {
       <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6">
         <nav
           aria-label="Footer"
-          className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-xs"
+          className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3 text-xs"
         >
           {LEGAL_LINKS.map((link) => (
             <a

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -146,7 +146,7 @@ const LANDING_CSS = `
 .lp .bottom-cta h2{font-size:28px;margin:0 0 8px;font-weight:800;color:var(--text-bright);letter-spacing:-.02em}
 .lp .bottom-cta p{color:var(--muted);margin:0 0 20px;font-size:14px}
 .lp footer{border-top:1px solid var(--border);padding:28px 0;color:var(--muted);font-size:12px;text-align:center}
-.lp .footer-links{display:flex;flex-wrap:wrap;justify-content:center;gap:8px 16px;margin-bottom:12px}
+.lp .footer-links{display:flex;flex-wrap:wrap;justify-content:center;gap:12px 24px;margin-bottom:16px}
 .lp .footer-links a,.lp .footer-links button{color:var(--muted);cursor:pointer;font-size:12px;transition:color .12s;background:none;border:none;padding:0;font-family:inherit}
 .lp .footer-links a:hover,.lp .footer-links button:hover{color:var(--text)}
 .lp .footer-copy{color:var(--muted);font-size:12px}


### PR DESCRIPTION
## Summary
- Widened horizontal and vertical gap between legal/privacy links in the in-app footer (`AppFooter.tsx`) from `gap-x-4 gap-y-2` to `gap-x-6 gap-y-3`.
- Matched the landing page footer (`LandingPage.tsx`) by bumping `.footer-links` gap from `8px 16px` to `12px 24px` and increasing bottom margin.

## Test plan
- [ ] Visually confirm in-app footer links (Privacy Policy, Terms, Cookie Policy, etc.) have more breathing room.
- [ ] Visually confirm landing page footer links are no longer bunched.
- [ ] Check wrap behavior on narrow viewports.

https://claude.ai/code/session_01BdF6jAKeLENVUuoaAVCBGW