### PR TITLE
Consolidate contact emails to support@filmroomfantasy.com

### DIFF
--- a/src/components/AcceptableUseView.tsx
+++ b/src/components/AcceptableUseView.tsx
@@ -69,7 +69,7 @@ export function AcceptableUseView({ isDarkMode }: AcceptableUseViewProps) {
           <h2 className={`text-xl font-semibold mb-3 ${h}`}>5. Reporting abuse</h2>
           <p>
             To report a violation of this AUP, email{' '}
-            <span className="font-medium">abuse@filmroomfantasy.com</span> with as
+            <span className="font-medium">support@filmroomfantasy.com</span> with as
             much detail as you can provide (URLs, timestamps, screenshots).
           </p>
         </section>
@@ -87,7 +87,7 @@ export function AcceptableUseView({ isDarkMode }: AcceptableUseViewProps) {
           <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
           <p>
             Abuse reports:{' '}
-            <span className="font-medium">abuse@filmroomfantasy.com</span>.
+            <span className="font-medium">support@filmroomfantasy.com</span>.
           </p>
         </section>
       </div>

--- a/src/components/AccessibilityView.tsx
+++ b/src/components/AccessibilityView.tsx
@@ -67,7 +67,7 @@ export function AccessibilityView({ isDarkMode }: AccessibilityViewProps) {
           <p>
             If you experience any difficulty accessing content on our site, or if you
             have suggestions for improving accessibility, please contact us at{' '}
-            <span className="font-medium">accessibility@filmroomfantasy.com</span>.
+            <span className="font-medium">support@filmroomfantasy.com</span>.
             We aim to respond within 5 business days. When possible, please include:
           </p>
           <ul className="list-disc list-inside space-y-2 mt-3">
@@ -90,7 +90,7 @@ export function AccessibilityView({ isDarkMode }: AccessibilityViewProps) {
           <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
           <p>
             Accessibility contact:{' '}
-            <span className="font-medium">accessibility@filmroomfantasy.com</span>.
+            <span className="font-medium">support@filmroomfantasy.com</span>.
           </p>
         </section>
       </div>

--- a/src/components/CookiePolicyView.tsx
+++ b/src/components/CookiePolicyView.tsx
@@ -205,7 +205,7 @@ export function CookiePolicyView({ isDarkMode }: CookiePolicyViewProps) {
           <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact Us</h2>
           <p>
             Questions about this Cookie Policy? Email{' '}
-            <span className="font-medium">privacy@filmroomfantasy.com</span>.
+            <span className="font-medium">support@filmroomfantasy.com</span>.
           </p>
         </section>
       </div>

--- a/src/components/DMCAView.tsx
+++ b/src/components/DMCAView.tsx
@@ -51,7 +51,7 @@ export function DMCAView({ isDarkMode }: DMCAViewProps) {
           <h2 className={`text-xl font-semibold mb-3 ${h}`}>3. Designated agent</h2>
           <div className={`${codeBg} rounded-lg p-4 text-sm ${p}`}>
             <div><strong>FilmRoom Fantasy — DMCA Agent</strong></div>
-            <div>Email: <span className="font-medium">dmca@filmroomfantasy.com</span></div>
+            <div>Email: <span className="font-medium">support@filmroomfantasy.com</span></div>
             <div>Subject line: "DMCA Takedown Notice"</div>
           </div>
           <p className="mt-3">
@@ -97,7 +97,7 @@ export function DMCAView({ isDarkMode }: DMCAViewProps) {
           <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
           <p>
             General copyright questions:{' '}
-            <span className="font-medium">dmca@filmroomfantasy.com</span>.
+            <span className="font-medium">support@filmroomfantasy.com</span>.
           </p>
         </section>
       </div>

--- a/src/components/DoNotSellView.tsx
+++ b/src/components/DoNotSellView.tsx
@@ -105,7 +105,7 @@ export function DoNotSellView({ isDarkMode }: DoNotSellViewProps) {
           </ul>
           <p className="mt-3">
             To exercise these rights, email{' '}
-            <span className="font-medium">privacy@filmroomfantasy.com</span> from the
+            <span className="font-medium">support@filmroomfantasy.com</span> from the
             email address associated with your account. We may need to verify your
             identity before fulfilling the request.
           </p>
@@ -133,7 +133,7 @@ export function DoNotSellView({ isDarkMode }: DoNotSellViewProps) {
           <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
           <p>
             Privacy requests:{' '}
-            <span className="font-medium">privacy@filmroomfantasy.com</span>.
+            <span className="font-medium">support@filmroomfantasy.com</span>.
           </p>
         </section>
       </div>

--- a/src/components/RefundPolicyView.tsx
+++ b/src/components/RefundPolicyView.tsx
@@ -73,7 +73,7 @@ export function RefundPolicyView({ isDarkMode }: RefundPolicyViewProps) {
           </ul>
           <p className="mt-3">
             To request a refund, email{' '}
-            <span className="font-medium">billing@filmroomfantasy.com</span> from the
+            <span className="font-medium">support@filmroomfantasy.com</span> from the
             email address on your account and include the date and amount of the charge.
           </p>
         </section>
@@ -112,7 +112,7 @@ export function RefundPolicyView({ isDarkMode }: RefundPolicyViewProps) {
           <h2 className={`text-xl font-semibold mb-3 ${h}`}>Contact</h2>
           <p>
             Billing questions:{' '}
-            <span className="font-medium">billing@filmroomfantasy.com</span>.
+            <span className="font-medium">support@filmroomfantasy.com</span>.
           </p>
         </section>
       </div>


### PR DESCRIPTION
## Summary
Consolidates every user-facing contact email in the legal/policy views to `support@filmroomfantasy.com`:

| File | Was |
|---|---|
| `RefundPolicyView.tsx` | `billing@` |
| `AcceptableUseView.tsx` | `abuse@` |
| `CookiePolicyView.tsx` | `privacy@` |
| `DoNotSellView.tsx` | `privacy@` |
| `DMCAView.tsx` | `dmca@` |
| `AccessibilityView.tsx` | `accessibility@` |

## Not touched
`noreply@filmroomfantasy.com` in `server/src/routes/auth.ts` and `server/src/routes/feedback.ts` — that's the "From" header on outgoing transactional emails (password resets, feedback notifications), which is a separate concern. If you want those flipped to `support@` too, say the word.

## Test plan
- [ ] Visit /refunds, /acceptable-use, /cookies, /do-not-sell, /dmca, /accessibility and confirm every contact address reads `support@filmroomfantasy.com`.

https://claude.ai/code/session_01BdF6jAKeLENVUuoaAVCBGW