### PR TITLE
Harden security headers and 404 sensitive probe paths

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>404 Not Found</title>
+<meta name="robots" content="noindex">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+<body>
+<h1>404 Not Found</h1>
+<p>The requested resource was not found on this server.</p>
+</body>
+</html>

--- a/public/_headers
+++ b/public/_headers
@@ -15,4 +15,11 @@
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin
+  # HSTS rollout plan: max-age=300 -> 86400 -> 31536000, then add
+  # includeSubDomains, then preload. Do NOT jump straight to one year
+  # or add includeSubDomains/preload without verifying every subdomain
+  # serves HTTPS correctly first.
+  Strict-Transport-Security: max-age=300
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src https://fonts.gstatic.com; connect-src 'self' https://filmroom-api.earle2001.workers.dev; img-src 'self' data: https:; frame-src https://googleads.g.doubleclick.net
   Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src https://fonts.gstatic.com; connect-src 'self' https://filmroom-api.earle2001.workers.dev; img-src 'self' data: https:; frame-src https://googleads.g.doubleclick.net

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,28 @@
+# Allow /.well-known/* through (ACME cert validation, security.txt, etc.).
+# This MUST come before the dotfile denylist below so it wins first-match.
+/.well-known/*    /.well-known/:splat    200
+
+# Deny known-sensitive paths with a real 404 instead of the SPA shell.
+# Dotfiles (.env, .git/*, .htaccess, .aws/*, etc.)
+/.*    /404.html    404
+# WordPress probes
+/wp-admin    /404.html    404
+/wp-admin/*    /404.html    404
+/wp-login.php    /404.html    404
+/wp-content    /404.html    404
+/wp-content/*    /404.html    404
+/wp-includes    /404.html    404
+/wp-includes/*    /404.html    404
+# Admin surfaces
+/admin    /404.html    404
+/admin/*    /404.html    404
+# Server info leaks
+/server-info    /404.html    404
+/server-status    /404.html    404
+# Debug endpoints (API itself lives on a separate Worker)
+/api/debug    /404.html    404
+/api/debug/*    /404.html    404
+
 /assets/*    /assets/:splat    200
 /favicon.ico    /favicon.ico    200
 /favicon-32.png    /favicon-32.png    200


### PR DESCRIPTION
## Summary

Addresses four security-scan findings on filmroomfantasy.com. All changes are in the Cloudflare Pages static-site config (no Worker / app code touched).

### Files touched

- **`public/_headers`** — header additions for the `/*` block
- **`public/_redirects`** — 404 denylist prepended before the SPA fallback
- **`public/404.html`** — new, minimal `noindex` 404 body used by the denylist rules

### Changes

1. **HSTS (missing → enabled, short TTL)**
   Added `Strict-Transport-Security: max-age=300`. No `includeSubDomains`, no `preload` — this is the first step of a deliberate phased rollout. A comment next to the header documents the ramp: `300 → 86400 → 31536000`, then add `includeSubDomains`, then `preload`, each as a separate follow-up PR after verification.

2. **CSP (report-only → enforcing)**
   Renamed the existing `Content-Security-Policy-Report-Only` to `Content-Security-Policy`. Directives unchanged. A parallel `Content-Security-Policy-Report-Only` with the same policy was kept so violation reports continue to flow after enforcement is on.

3. **Permissions-Policy (missing → added)**
   `camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()`.

4. **Real 404s for sensitive paths**
   `public/_redirects` now returns `404 /404.html` for:
   - `/.*` — all dotfiles (`/.env`, `/.git/config`, `/.htaccess`, `/.aws/*`, …)
   - `/wp-admin`, `/wp-admin/*`, `/wp-login.php`, `/wp-content`, `/wp-content/*`, `/wp-includes`, `/wp-includes/*`
   - `/admin`, `/admin/*`
   - `/server-info`, `/server-status`
   - `/api/debug`, `/api/debug/*`

   **Ordering note:** `/.well-known/*` is placed *above* the dotfile rule so cert validation / protocol endpoints pass through (first-match-wins). Existing asset passthroughs and the `/*  /index.html  200` SPA fallback remain at the bottom. `/robots.txt` and `/sitemap.xml` are real static files and are served before `_redirects` is evaluated.

## Test plan

- [ ] After Pages deploys the branch (preview URL), run:
  - `curl -sI https://<preview>/ | grep -iE 'strict-transport|content-security-policy|permissions-policy'` → all three headers present, CSP enforcing (not `-Report-Only` only)
  - `curl -sI https://<preview>/.env` → `HTTP/2 404`
  - `curl -sI https://<preview>/wp-admin` → `HTTP/2 404`
  - `curl -sI https://<preview>/.well-known/foo` → not a denylist 404 (200 or default fallback)
  - `curl -sI https://<preview>/robots.txt` → `HTTP/2 200`
- [ ] Load the site and check browser console for new CSP violations (the report-only mode was silent; enforcement may surface something previously only logged).
- [ ] After merging, repeat the curls against `https://filmroomfantasy.com`.

https://claude.ai/code/session_01JuQavgHpwdbnVcXwNN76ki