### PR TITLE
Fix mobile sidebar swallowing taps on nav items

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -144,7 +144,7 @@ export function Sidebar({ activeView, onViewChange, isDarkMode, isAuthenticated 
         />
       )}
 
-      <aside className={`w-64 border-r z-50 flex flex-col ${mobileOpen ? 'sidebar-open' : 'sidebar-responsive'} ${isDarkMode ? 'bg-slate-950 border-slate-700' : 'bg-white border-slate-200'}`}>
+      <aside className={`w-64 border-r z-mobile-sidebar flex flex-col ${mobileOpen ? 'sidebar-open' : 'sidebar-responsive'} ${isDarkMode ? 'bg-slate-950 border-slate-700' : 'bg-white border-slate-200'}`}>
         {/* Logo */}
         <div className={`h-14 sm:h-16 flex items-center px-6 border-b flex-shrink-0 ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
           <button

--- a/src/index.css
+++ b/src/index.css
@@ -2542,10 +2542,15 @@ html {
 /* Explicit z-index layers for the cookie banner, mobile backdrop, and the
    mobile-open sidebar. Only .z-50 is present in the compiled Tailwind bundle,
    so we define the other tiers here to keep stacking predictable:
-     banner   (70) < backdrop (75) < mobile-open sidebar (80). */
+     banner   (70) < backdrop (75) < mobile-open sidebar (80).
+   The sidebar needs its own class (not Tailwind's .z-50) so the mobile
+   backdrop at z-75 never ends up on top of it and swallowing taps. */
 .z-cookie-banner {
   z-index: 70;
 }
 .z-mobile-backdrop {
   z-index: 75;
+}
+.z-mobile-sidebar {
+  z-index: 80;
 }


### PR DESCRIPTION
## Summary

On mobile, the sidebar would render when you tapped the hamburger, but tapping nav items inside it did nothing — the sidebar just closed without navigating.

Root cause: the `<aside>` had Tailwind's `z-50` utility alongside the unlayered `.sidebar-open { z-index: 80 }`. Tailwind's `.z-50` lives in `@layer utilities` while our sidebar class is unlayered, so per the cascade the sidebar should be at 80 and above the `.z-mobile-backdrop` at 75. When that resolution didn't hold, the backdrop ended up on top of the sidebar and its `onClick={onMobileClose}` intercepted every tap — which fires before the button click, so the sidebar closed and navigation never happened.

Fix: drop `z-50` from the aside and add a dedicated unlayered `.z-mobile-sidebar { z-index: 80 }` class, matching the same tier as `.z-mobile-backdrop` (75) and `.z-cookie-banner` (70). Same layer, explicit integers, sidebar unambiguously on top.

- `src/components/Sidebar.tsx`: aside uses `z-mobile-sidebar` instead of `z-50`
- `src/index.css`: add `.z-mobile-sidebar` at `z-index: 80`

## Test plan

- [ ] On mobile viewport (<768px), tap hamburger — sidebar opens
- [ ] Tap a nav item (Home, Player Rankings, Trade Analyzer, etc.) — view changes AND sidebar closes
- [ ] Tap outside the sidebar (on the backdrop) — sidebar closes without navigating
- [ ] Tap a collapsible group header (Rankings/League/Tools) — group expands/collapses, sidebar stays open
- [ ] Cookie banner still renders below the sidebar on mobile (sidebar covers it when open)
- [ ] Desktop (≥768px) — sidebar is a static column, no behavioral change
