### PR TITLE
Pin Content-Type on /ads.txt for AdSense verification

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -10,6 +10,16 @@
   X-Robots-Tag: all
   Cache-Control: public, max-age=3600
 
+# Google AdSense fetches this file from the root domain. It must respond
+# 200 with Content-Type text/plain; crawlers don't execute CSP so the
+# security headers from /* below are harmless, but we pin Content-Type and
+# short-circuit any robot/cache restrictions here to avoid "ads.txt not
+# found" reports in the AdSense console.
+/ads.txt
+  Content-Type: text/plain; charset=utf-8
+  X-Robots-Tag: all
+  Cache-Control: public, max-age=3600
+
 /*
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY


### PR DESCRIPTION
## Summary
- Google's ads.txt crawler was reporting "not found" for `filmroomfantasy.com/ads.txt`. The file itself exists at `public/ads.txt` with the correct content (`google.com, pub-6355054767351119, DIRECT, f08c47fec0942fa0`) and is already excluded from the Pages Functions router in `public/_routes.json`, so the file was being served — but without explicit headers.
- `public/_headers` had dedicated blocks for `/robots.txt` and `/sitemap.xml` but `/ads.txt` fell through to the global `/*` block, which adds CSP/HSTS/Permissions-Policy and `X-Content-Type-Options: nosniff` with no explicit `Content-Type`. With `nosniff` in effect, any edge-level Content-Type drift can make AdSense's fetcher reject the file.
- Add an explicit `/ads.txt` block mirroring the robots.txt/sitemap.xml pattern: `Content-Type: text/plain; charset=utf-8`, `X-Robots-Tag: all`, `Cache-Control: public, max-age=3600`.

## Test plan
- [x] `npm run build` produces `build/ads.txt` with the expected single-line content.
- [x] `build/_headers` contains the new `/ads.txt` block ahead of the `/*` block.
- [ ] After deploy, `curl -I https://filmroomfantasy.com/ads.txt` returns `200` with `Content-Type: text/plain; charset=utf-8`.
- [ ] Re-run the AdSense ads.txt check from the AdSense console once Cloudflare edge cache has flushed (can take up to an hour).

https://claude.ai/code/session_01JvTaZuzp7wRqtzBKhzL15y