### PR TITLE
Fix /home 404 on refresh from ambiguous dotfile redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -3,8 +3,32 @@
 /.well-known/*    /.well-known/:splat    200
 
 # Deny known-sensitive paths with a real 404 instead of the SPA shell.
-# Dotfiles (.env, .git/*, .htaccess, .aws/*, etc.)
-/.*    /404.html    404
+# Dotfiles — enumerated explicitly rather than using a `/.*` catch-all,
+# which some matchers greedy-compile into `^/.*$` and end up swallowing
+# SPA routes like `/home` (BUG: home refresh returned 404).
+/.env    /404.html    404
+/.env.*    /404.html    404
+/.env/*    /404.html    404
+/.git    /404.html    404
+/.git/*    /404.html    404
+/.gitignore    /404.html    404
+/.gitattributes    /404.html    404
+/.htaccess    /404.html    404
+/.htpasswd    /404.html    404
+/.aws    /404.html    404
+/.aws/*    /404.html    404
+/.ssh    /404.html    404
+/.ssh/*    /404.html    404
+/.svn    /404.html    404
+/.svn/*    /404.html    404
+/.hg    /404.html    404
+/.hg/*    /404.html    404
+/.DS_Store    /404.html    404
+/.npmrc    /404.html    404
+/.vscode    /404.html    404
+/.vscode/*    /404.html    404
+/.idea    /404.html    404
+/.idea/*    /404.html    404
 # WordPress probes
 /wp-admin    /404.html    404
 /wp-admin/*    /404.html    404


### PR DESCRIPTION
## Summary

- Refreshing `/home` (and other non-prerendered SPA routes) returned a 404 instead of the SPA shell.
- Root cause: the dotfile denylist in `public/_redirects` used a single `/.*    /404.html    404` catch-all. Depending on how the splat is compiled, that pattern can match every path starting with `/` — so it was swallowing SPA routes before they could reach the `/*    /index.html    200` fallback. Prerendered routes like `/player-rankings` still worked because Cloudflare Pages served their static `index.html` before ever consulting `_redirects`.
- Replaced the single catch-all with explicit dotfile patterns (`/.env`, `/.env.*`, `/.git`, `/.git/*`, `/.htaccess`, `/.aws/*`, `/.ssh/*`, `/.DS_Store`, etc.) so the intent is unambiguous and SPA routes keep reaching the fallback.

## Test plan

- [x] Simulated the Cloudflare Pages splat → regex compilation against the new rule set: `/home`, `/team`, `/matchup`, `/waivers`, `/settings`, `/profile` all route to `/* → /index.html (200)`; `/.env`, `/.env.production`, `/.git/config`, `/.aws/credentials`, `/.ssh/id_rsa`, `/.htaccess`, `/.DS_Store` all return `/404.html (404)`; `/.well-known/acme-challenge/xyz` still passes through; `/board → /player-rankings (301)` still works.
- [ ] Deploy preview and hard-refresh `/home` in an incognito window (should render the SPA shell, not 404).
- [ ] Probe `/.env`, `/.git/HEAD`, `/wp-admin` on the preview and confirm each still returns a real 404.

https://claude.ai/code/session_012xhwUPgniosZDBor3Wgi1q