### PR TITLE
Distinguish incoming rookies from last year's rookies in trade analyzer

### DIFF
--- a/server/src/services/playerTenure.ts
+++ b/server/src/services/playerTenure.ts
@@ -1,0 +1,161 @@
+/**
+ * playerTenure — infer a player's NFL tenure (draft class + rookie status)
+ * from the signals we already have: Sleeper's `yearsExp` counter and whether
+ * the player shows up in our weekly-stats table for the current / previous
+ * NFL season.
+ *
+ * The trade analyzer used to surface only raw `yearsExp` to the AI. That's
+ * Sleeper's years-of-experience counter, which ticks over on the NFL
+ * calendar (typically around camp). During the offseason window between
+ * seasons, Sleeper may still have last year's rookies at `yearsExp = 0`
+ * — identical to an incoming rookie who hasn't played yet. The AI had no
+ * way to tell "drafted last April and played a full rookie year" apart
+ * from "drafted this April and has never taken an NFL snap."
+ *
+ * Cross-referencing with our own weekly-stats table disambiguates them:
+ * if the player has stats in the previous NFL season, they clearly aren't
+ * an incoming rookie, regardless of what `yearsExp` says.
+ */
+
+export type RookieStatus =
+  | 'incoming-rookie' // no NFL games in our data, yearsExp ≤ 0 — likely just drafted or not yet active
+  | 'rookie-active'   // playing their rookie year right now (current-season stats, no prior)
+  | 'sophomore'       // rookies from last year — played the previous season, at most one
+  | 'veteran'         // 2+ NFL seasons of stats or yearsExp ≥ 2
+  | 'unknown';        // insufficient signal
+
+export interface PlayerTenureInfo {
+  /** NFL season the player was drafted / first active, best-effort. null when unknown. */
+  draftClass: number | null;
+  rookieStatus: RookieStatus;
+  /** Human-readable label safe to surface in the analyzer prompt. */
+  tenureLabel: string;
+}
+
+export interface InferPlayerTenureArgs {
+  yearsExp: number | null | undefined;
+  /** True if the player has any usage/snaps in our current-season stats table. */
+  playedInCurrentSeason: boolean;
+  /** True if the player has any usage/snaps in our previous-season stats table. */
+  playedInPreviousSeason: boolean;
+  /** The NFL season year the trade context is anchored to (e.g., 2026). */
+  seasonYear: number;
+  /** 'offseason' | 'preseason' | 'regular' | 'playoffs' — governs interpretation. */
+  seasonPhase: 'offseason' | 'preseason' | 'regular' | 'playoffs';
+}
+
+/**
+ * Compute a tenure label from the available signals. Stats presence is
+ * preferred over `yearsExp` because stats don't lie — if a player has
+ * 2025 weekly stats, they played in 2025, regardless of how Sleeper
+ * currently reports years_exp.
+ */
+export function inferPlayerTenure(args: InferPlayerTenureArgs): PlayerTenureInfo {
+  const { yearsExp, playedInCurrentSeason, playedInPreviousSeason, seasonYear, seasonPhase } =
+    args;
+  const exp = typeof yearsExp === 'number' ? yearsExp : null;
+
+  // The "anchor year" is the most recent season where stats would exist.
+  // In offseason/preseason, that's the season that JUST finished
+  // (seasonYear - 1 when seasonYear is the upcoming season). In regular
+  // season/playoffs, it's the current season.
+  const isOffseasonish = seasonPhase === 'offseason' || seasonPhase === 'preseason';
+  const lastPlayedSeason = isOffseasonish ? seasonYear - 1 : seasonYear;
+
+  // Played in the previous NFL season → not an incoming rookie, period.
+  if (playedInPreviousSeason) {
+    // If they ALSO played the current/most-recent season but not further back
+    // AND yearsExp suggests only 1–2 years, call them a sophomore. Otherwise
+    // default to veteran.
+    if ((exp == null || exp <= 2) && playedInCurrentSeason) {
+      // "Sophomore" — played their rookie year in (lastPlayedSeason - 1).
+      const draftClass = lastPlayedSeason - 1;
+      return {
+        draftClass,
+        rookieStatus: 'sophomore',
+        tenureLabel: `Sophomore — NFL debut ${draftClass} (played rookie year last season, NOT an incoming rookie)`,
+      };
+    }
+    // Otherwise we have prior-season presence but can't cleanly label.
+    // Fall through to the yearsExp-based veteran label below.
+  }
+
+  // Has stats this season but NOT last season → likely rookie year in progress,
+  // OR a practice-squad elevation / late-career callup. yearsExp disambiguates.
+  if (playedInCurrentSeason && !playedInPreviousSeason) {
+    if (exp != null && exp <= 0) {
+      return {
+        draftClass: lastPlayedSeason,
+        rookieStatus: 'rookie-active',
+        tenureLabel: `Rookie — NFL debut ${lastPlayedSeason} (currently in their first NFL season)`,
+      };
+    }
+    // yearsExp ≥ 1 but no prior-season stats — veteran with a quiet prior year.
+    // Fall through.
+  }
+
+  // No stats anywhere + yearsExp ≤ 0 → incoming rookie (or inactive).
+  if (!playedInCurrentSeason && !playedInPreviousSeason) {
+    if (exp == null || exp <= 0) {
+      // In the offseason window, yearsExp = 0 most commonly means
+      // "incoming draft class or undrafted rookie" — but we flag
+      // the uncertainty honestly.
+      return {
+        draftClass: isOffseasonish ? seasonYear : lastPlayedSeason,
+        rookieStatus: 'incoming-rookie',
+        tenureLabel:
+          `Incoming rookie — no NFL games in our data` +
+          (isOffseasonish ? ` (likely ${seasonYear} draft class or undrafted rookie)` : ''),
+      };
+    }
+    // yearsExp ≥ 1 but no stats in our DB → veteran we don't have data for.
+    // Fall through.
+  }
+
+  // Fallback: use yearsExp for a coarse veteran label.
+  if (exp == null) {
+    return { draftClass: null, rookieStatus: 'unknown', tenureLabel: 'Tenure unknown' };
+  }
+
+  if (exp <= 0) {
+    // yearsExp says rookie but we have no stats anywhere — still incoming-ish.
+    return {
+      draftClass: isOffseasonish ? seasonYear : lastPlayedSeason,
+      rookieStatus: 'incoming-rookie',
+      tenureLabel: `Incoming rookie — yearsExp 0, no NFL stats in our data`,
+    };
+  }
+
+  if (exp === 1) {
+    // yearsExp=1 means one NFL season in the books. That's a sophomore.
+    const draftClass = lastPlayedSeason - (playedInPreviousSeason ? 1 : 0);
+    return {
+      draftClass,
+      rookieStatus: 'sophomore',
+      tenureLabel: `Sophomore — NFL debut ${draftClass} (2nd NFL season, NOT an incoming rookie)`,
+    };
+  }
+
+  // Veteran path.
+  const draftClass = lastPlayedSeason - exp;
+  return {
+    draftClass,
+    rookieStatus: 'veteran',
+    tenureLabel: `Veteran — NFL debut ${draftClass} (${exp + 1}${ordinalSuffix(exp + 1)} NFL season)`,
+  };
+}
+
+function ordinalSuffix(n: number): string {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return 'th';
+  switch (n % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+}

--- a/server/src/services/tradeAnalyzer.ts
+++ b/server/src/services/tradeAnalyzer.ts
@@ -243,10 +243,18 @@ Instead of applying fixed weights, ASK YOURSELF:
 DATA YOU WILL RECEIVE:
 A structured TRADE CONTEXT block containing authoritative facts from our live database:
 - Per-player: identity, recent volume (last 4 games), next-week projection, Vegas market signals (team implied totals, player props), next 4-week schedule, playoff weeks (15-17).
+- Per-player: a "Tenure:" line giving an authoritative NFL-tenure label (e.g., "Incoming rookie", "Rookie — NFL debut 2025", "Sophomore — NFL debut 2024", "Veteran — NFL debut 2019").
 - If available: YOUR TEAM record, standing, roster breakdown by position.
 - Data availability flags so you know when facts are missing (offseason, no vegas yet, etc.).
 
 USE THE CONTEXT AS GROUND TRUTH. If the context has no projection for a player, say so rather than guessing. If the user has no connected league, analyze without the user-context reasoning but make it clear you're evaluating the trade generically.
+
+ROOKIE vs. LAST YEAR'S ROOKIE — READ CAREFULLY:
+- The "Tenure:" line is the ONLY authoritative source on draft class and rookie status. Trust it over any "Exp Xy" / "Experience: X years" bio field, which comes from Sleeper and lags the NFL calendar during the offseason.
+- "Incoming rookie" means the player has never played an NFL game in our data — treat them as an unproven prospect from the incoming draft class.
+- "Sophomore — NFL debut YYYY" means the player already played a full rookie season in YYYY. They are NOT an incoming rookie. Evaluate them based on their rookie-year performance, not as a blank-slate prospect.
+- If a named player in the trade has no entry in the TRADE CONTEXT block at all, that usually means they're an incoming draft-class rookie who isn't in our catalog yet (our data ingests from Sleeper, which adds the new NFL draft class a few weeks after the draft). Treat them as an incoming rookie in that case.
+- Never conflate "incoming rookie" with "last year's rookie" — they have very different dynasty values. If the user's stated leagueType is Dynasty or Keeper, this distinction is load-bearing.
 
 League format: ${leagueLabel}${strategyNote}
 

--- a/server/src/services/tradeContext.ts
+++ b/server/src/services/tradeContext.ts
@@ -19,6 +19,7 @@ import { eq, and, desc, inArray, gte } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import * as schema from '../db/schema';
 import { chunkedInArrayFetch, DEFAULT_ID_CHUNK } from '../utils/chunked';
+import { inferPlayerTenure, type PlayerTenureInfo } from './playerTenure';
 
 type DB = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -59,6 +60,12 @@ export interface PlayerFacts {
     injuryBodyPart: string | null;
     depthChartOrder: number | null;
     byeWeek: number | null;
+    /**
+     * Server-computed tenure label. The AI should trust this over
+     * `yearsExp` alone — `yearsExp` lags the NFL calendar in offseason
+     * and can't distinguish an incoming rookie from last year's rookie.
+     */
+    tenure: PlayerTenureInfo;
   };
 
   /** Recent game-level volume (last 4 played games in the current season) */
@@ -253,6 +260,37 @@ export async function buildTradeContext({
     statsByPlayer.set(s.playerId, arr);
   }
 
+  // 2a. Fetch previous-season stats so we can distinguish "incoming rookie"
+  //     (no NFL games in our data) from "last year's rookie" (has prior-season
+  //     stats). Raw Sleeper yearsExp can't tell these apart during offseason.
+  const previousSeasonYear = seasonYear - 1;
+  const prevWeeklyStats = await chunkedInArrayFetch(playerIds, ID_CHUNK, (chunk) =>
+    db.query.playerWeeklyStats.findMany({
+      where: and(
+        inArray(schema.playerWeeklyStats.playerId, chunk),
+        eq(schema.playerWeeklyStats.seasonYear, previousSeasonYear)
+      ),
+      columns: {
+        playerId: true,
+        offSnaps: true,
+        passAttempts: true,
+        rushAttempts: true,
+        receptions: true,
+        targets: true,
+      },
+    })
+  );
+  const playedPrevSeasonByPlayer = new Set<string>();
+  for (const s of prevWeeklyStats) {
+    const hasActivity =
+      Number(s.offSnaps ?? 0) > 0 ||
+      Number(s.passAttempts ?? 0) > 0 ||
+      Number(s.rushAttempts ?? 0) > 0 ||
+      Number(s.receptions ?? 0) > 0 ||
+      Number(s.targets ?? 0) > 0;
+    if (hasActivity) playedPrevSeasonByPlayer.add(s.playerId);
+  }
+
   // 2b. Fetch recent news for these players (last 7 days, chunked)
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
   const recentNewsRows = await chunkedInArrayFetch(playerIds, ID_CHUNK, (chunk) =>
@@ -411,6 +449,10 @@ export async function buildTradeContext({
     propsByName.set(pr.playerName.toLowerCase(), nameMap);
   }
 
+  // Compute season phase up-front so player-tenure inference sees the
+  // same value the TradeContext will ultimately report.
+  const seasonPhaseForCtx = computeSeasonPhase(currentWeek, weeklyStats.length > 0);
+
   // 7. Build PlayerFacts[]
   const playerFacts: PlayerFacts[] = players.map((p) => {
     const stats = statsByPlayer.get(p.id) || [];
@@ -425,6 +467,22 @@ export async function buildTradeContext({
         Number(s.targets ?? 0) > 0;
       return off > 0 || activity;
     });
+
+    // DEF entries aren't rookies — skip the heuristic for them.
+    const tenure =
+      p.position === 'DEF'
+        ? {
+            draftClass: null,
+            rookieStatus: 'veteran' as const,
+            tenureLabel: 'Team defense',
+          }
+        : inferPlayerTenure({
+            yearsExp: p.yearsExp,
+            playedInCurrentSeason: played.length > 0,
+            playedInPreviousSeason: playedPrevSeasonByPlayer.has(p.id),
+            seasonYear,
+            seasonPhase: seasonPhaseForCtx,
+          });
 
     const recentVolume: PlayerFacts['recentVolume'] =
       played.length > 0
@@ -573,6 +631,7 @@ export async function buildTradeContext({
         injuryBodyPart: p.injuryBodyPart,
         depthChartOrder: p.depthChartOrder,
         byeWeek: p.byeWeek,
+        tenure,
       },
       recentVolume,
       projection,
@@ -604,7 +663,7 @@ export async function buildTradeContext({
     generatedAt: new Date().toISOString(),
     seasonYear,
     currentWeek,
-    seasonPhase: computeSeasonPhase(currentWeek, weeklyStats.length > 0),
+    seasonPhase: seasonPhaseForCtx,
     leagueSettings,
     players: playerFacts,
     userContext,
@@ -765,6 +824,9 @@ export function formatTradeContextForPrompt(ctx: TradeContext): string {
       bio.push(`Depth #${p.identity.depthChartOrder}`);
     if (p.identity.byeWeek != null) bio.push(`Bye W${p.identity.byeWeek}`);
     if (bio.length) lines.push(`  ${bio.join(' | ')}`);
+    // Authoritative tenure label — use this, not raw yearsExp, to
+    // distinguish incoming rookies from last year's rookies.
+    lines.push(`  Tenure: ${p.identity.tenure.tenureLabel}`);
     if (p.identity.status !== 'active') {
       lines.push(
         `  Injury: ${p.identity.status.toUpperCase()}` +

--- a/server/src/services/tradePlayerEnrichment.ts
+++ b/server/src/services/tradePlayerEnrichment.ts
@@ -20,6 +20,7 @@
 import { eq, and, desc, inArray } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import * as schema from '../db/schema';
+import { inferPlayerTenure, type PlayerTenureInfo } from './playerTenure';
 
 type DB = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -31,6 +32,11 @@ export interface EnrichedPlayerData {
   nflTeam: string;
   age: number | null;
   yearsExp: number | null;
+  /**
+   * Server-computed NFL tenure (draft class, rookie-vs-sophomore disambiguation).
+   * The analyzer prompt trusts this label over `yearsExp` alone.
+   */
+  tenure: PlayerTenureInfo;
   status: string;
   injuryNote: string | null;
   injuryBodyPart: string | null;
@@ -107,14 +113,32 @@ export async function fetchPlayerData(
 
   const playerIds = matchedPlayers.map((p) => p.id);
   const currentYear = new Date().getFullYear();
+  const previousYear = currentYear - 1;
 
-  const [weeklyStats, projections, news] = await Promise.all([
+  const [weeklyStats, prevWeeklyStats, projections, news] = await Promise.all([
     db.query.playerWeeklyStats.findMany({
       where: and(
         inArray(schema.playerWeeklyStats.playerId, playerIds),
         eq(schema.playerWeeklyStats.seasonYear, currentYear)
       ),
       orderBy: [desc(schema.playerWeeklyStats.week)],
+    }),
+    // Prior-season activity — used only to tell "incoming rookie" apart
+    // from "last year's rookie" since Sleeper's yearsExp can't do that
+    // reliably during offseason.
+    db.query.playerWeeklyStats.findMany({
+      where: and(
+        inArray(schema.playerWeeklyStats.playerId, playerIds),
+        eq(schema.playerWeeklyStats.seasonYear, previousYear)
+      ),
+      columns: {
+        playerId: true,
+        offSnaps: true,
+        passAttempts: true,
+        rushAttempts: true,
+        receptions: true,
+        targets: true,
+      },
     }),
     db.query.playerProjections.findMany({
       where: and(
@@ -130,6 +154,24 @@ export async function fetchPlayerData(
       limit: playerIds.length * 3,
     }),
   ]);
+
+  const playedPrevByPlayer = new Set<string>();
+  for (const s of prevWeeklyStats) {
+    const active =
+      Number(s.offSnaps ?? 0) > 0 ||
+      Number(s.passAttempts ?? 0) > 0 ||
+      Number(s.rushAttempts ?? 0) > 0 ||
+      Number(s.receptions ?? 0) > 0 ||
+      Number(s.targets ?? 0) > 0;
+    if (active) playedPrevByPlayer.add(s.playerId);
+  }
+
+  // In-season stats don't flow into this module's "current year"
+  // window until games start; treat Jan–Jul as offseason for tenure
+  // purposes (same rubric as tradeContext.computeSeasonPhase).
+  const monthNow = new Date().getUTCMonth();
+  const seasonPhaseForTenure: 'offseason' | 'preseason' | 'regular' | 'playoffs' =
+    monthNow >= 1 && monthNow <= 6 ? 'offseason' : monthNow === 7 ? 'preseason' : 'regular';
 
   const statsByPlayer = new Map<string, typeof weeklyStats>();
   for (const s of weeklyStats) {
@@ -251,12 +293,24 @@ export async function fetchPlayerData(
       opponent: s.opponent,
     }));
 
+    const tenure: PlayerTenureInfo =
+      player.position === 'DEF'
+        ? { draftClass: null, rookieStatus: 'veteran', tenureLabel: 'Team defense' }
+        : inferPlayerTenure({
+            yearsExp: player.yearsExp,
+            playedInCurrentSeason: (seasonStats?.gamesPlayed ?? 0) > 0,
+            playedInPreviousSeason: playedPrevByPlayer.has(player.id),
+            seasonYear: currentYear,
+            seasonPhase: seasonPhaseForTenure,
+          });
+
     result.set(player.name.toLowerCase(), {
       name: player.name,
       position: player.position,
       nflTeam: player.team,
       age: player.age,
       yearsExp: player.yearsExp,
+      tenure,
       status: player.status,
       injuryNote: player.injuryNote,
       injuryBodyPart: player.injuryBodyPart,
@@ -300,6 +354,9 @@ export function formatPlayerDataBlock(data: EnrichedPlayerData): string {
   if (data.depthChartOrder) bioDetails.push(`Depth chart: #${data.depthChartOrder}`);
   if (data.byeWeek) bioDetails.push(`Bye: Week ${data.byeWeek}`);
   if (bioDetails.length > 0) lines.push(bioDetails.join(' | '));
+  // Authoritative tenure label — trust over `yearsExp` alone to tell
+  // incoming rookies apart from last year's rookies.
+  lines.push(`Tenure: ${data.tenure.tenureLabel}`);
 
   if (data.status !== 'active') {
     const injury = [data.status.toUpperCase()];


### PR DESCRIPTION
## Summary

- Adds a server-side `playerTenure` helper that cross-references Sleeper's `yearsExp` with prior-season weekly-stats presence to emit an authoritative tenure label (e.g. `Incoming rookie`, `Rookie — NFL debut 2025`, `Sophomore — NFL debut 2024`, `Veteran — NFL debut 2019`).
- Wires the label through `tradeContext.ts` and `tradePlayerEnrichment.ts` so it reaches the prompt for both the manual `/analyze` route and the Trade Finder's verification pass.
- Updates the analyzer system prompt to trust the `Tenure:` line over raw `yearsExp`, and to treat players missing from the catalog entirely as likely incoming draft-class rookies (Sleeper hasn't added them yet).

## Why

The trade analyzer surfaced only Sleeper's `yearsExp` counter to the AI. That value ticks on the NFL calendar and lags during the offseason — so an incoming draft-class rookie and a player who already completed their rookie year can both look like `yearsExp = 0`. The AI had no signal to tell them apart, which broke dynasty trade evaluations where the distinction is load-bearing.

Prior-season weekly-stats presence is a signal that doesn't lie: if a player has 2025 game logs, they clearly aren't an incoming 2026 rookie.

## Scope

- No schema change. Everything computed from data we already ingest.
- DEF entries are labeled `Team defense` and skip the heuristic.
- One small ancillary change: `computeSeasonPhase` now runs once and is reused for both tenure inference and the returned context (no behavior change).

## Test plan

- [ ] Typecheck passes (`npm run typecheck:server`) — done locally.
- [ ] Manual trade analyzer: submit a dynasty trade containing a 2025-draft-class player and confirm the analyzer no longer describes them as an "incoming rookie."
- [ ] Manual trade analyzer: submit a trade naming a player not in our catalog (proxy for an incoming 2026 draftee) and confirm the AI treats them as an incoming rookie rather than guessing based on `yearsExp`.
- [ ] Trade Finder: verify suggested dynasty trades evaluate rookie-vs-sophomore assets consistently with the manual analyzer.

https://claude.ai/code/session_01Dii6xxRMTHiNjzKXPSC8FS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dii6xxRMTHiNjzKXPSC8FS)_