### PR TITLE
Unblock /admin SPA route in _redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -37,9 +37,6 @@
 /wp-content/*    /404.html    404
 /wp-includes    /404.html    404
 /wp-includes/*    /404.html    404
-# Admin surfaces
-/admin    /404.html    404
-/admin/*    /404.html    404
 # Server info leaks
 /server-info    /404.html    404
 /server-status    /404.html    404
@@ -75,6 +72,8 @@
 /research         /index.html    200
 /draft-rankings   /index.html    200
 /league-analyzer  /index.html    200
+/admin            /index.html    200
+/admin/*          /index.html    200
 
 # Real 404 for unknown routes (replaces the previous /* -> /index.html 200
 # SPA fallback, which was a soft-404 anti-pattern: unknown URLs returned


### PR DESCRIPTION
## Summary

Follow-up to #202. `/admin` is a real SPA route (`src/App.tsx` `VIEW_TO_PATH` → lazy-loaded `AdminView`, sidebar-gated on `isAdmin`) but the denylist I added in #202 was returning `404.html` for it, so admin users saw a 404 page instead of the admin view.

### Change

`public/_redirects`:
- Remove `/admin` and `/admin/*` from the sensitive-path denylist.
- Add `/admin` and `/admin/*` to the SPA-only allowlist (alongside `/home`, `/team`, `/settings`, etc.) so client-side routing takes over.

Other admin-shaped paths are unaffected:
- `/admin/stats`, `/admin/set-tier`, `/admin/bulk-set-tier`, `/articles/admin/*`, `/analytics/admin/*` are API calls to `filmroom-api.earle2001.workers.dev`. They never hit Pages `_redirects`.
- WordPress, dotfile, `/server-info`, `/server-status`, and `/api/debug` denylist entries all remain in place.

### Impact scope

In practice this only affected admin accounts — the sidebar link to `/admin` is only rendered when `isAdmin` is true (`src/components/Sidebar.tsx:78`), and nothing else in the UI links a non-admin to `/admin`.

## Test plan

- [ ] After Pages deploys, as an admin: navigate to `/admin` via sidebar → app shell loads, AdminView renders.
- [ ] Hard-refresh on `/admin` → still loads (no 404).
- [ ] `curl -sI https://filmroomfantasy.com/admin` → `HTTP/2 200`.
- [ ] `curl -sI https://filmroomfantasy.com/wp-admin` → `HTTP/2 404` (denylist still enforcing).
- [ ] `curl -sI https://filmroomfantasy.com/.env` → `HTTP/2 404`.
- [ ] Security headers (HSTS, CSP, Permissions-Policy) from #202 still present on `/`.

https://claude.ai/code/session_01JuQavgHpwdbnVcXwNN76ki

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuQavgHpwdbnVcXwNN76ki)_