### PR TITLE
Restore SPA catch-all to stop user-facing 404s on valid routes

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -60,25 +60,17 @@
 /apple-touch-icon.png    /apple-touch-icon.png    200
 /board    /player-rankings    301
 
-# SPA-only routes without a prerendered directory — serve the app shell so
-# client-side routing can take over. Keep this list in sync with the SPA
-# router at src/App.tsx (VIEW_TO_PATH). Any path omitted here falls through
-# to the 404 catch-all at the bottom.
-/home             /index.html    200
-/team             /index.html    200
-/matchup          /index.html    200
-/settings         /index.html    200
-/profile          /index.html    200
-/all-players      /index.html    200
-/login            /index.html    200
-/register         /index.html    200
-/research         /index.html    200
-/draft-rankings   /index.html    200
-/league-analyzer  /index.html    200
-
-# Real 404 for unknown routes (replaces the previous /* -> /index.html 200
-# SPA fallback, which was a soft-404 anti-pattern: unknown URLs returned
-# HTTP 200 with the app shell). Prerendered routes (/player-rankings,
-# /trade-analyzer, /articles/<slug>, legal pages, etc.) are served directly
-# by Cloudflare Pages from <route>/index.html and never reach this rule.
-/*    /404.html    404
+# SPA catch-all: serve the app shell for any path that hasn't already been
+# matched by a sensitive-path 404 above or by a prerendered static file.
+# React handles routing client-side, and the NotFound view is noindex'd for
+# genuinely unknown paths.
+#
+# The previous iteration tried `/* -> /404.html 404` plus an explicit
+# whitelist of SPA routes (commit d6dc7b1), relying on Cloudflare Pages to
+# prefer prerendered `<route>/index.html` over the splat. That produced
+# user-facing 404s whenever (a) the puppeteer prerender silently skipped a
+# route — the CI script only fails on total prerender failure — or (b) a
+# valid SPA path (including new article slugs) wasn't in the whitelist.
+# The soft-404 tradeoff is acceptable because NotFound is noindex'd; a
+# real user hitting a broken page is much worse than a crawler signal.
+/*    /index.html    200


### PR DESCRIPTION
## Summary

Users were hitting 404s on valid pages (not just `/admin`). Root cause: commit d6dc7b1 replaced the final `/* -> /index.html 200` with `/* -> /404.html 404` plus a hand-maintained whitelist of SPA-only routes. It assumed Cloudflare Pages would serve prerendered `<route>/index.html` static files before the splat redirect fires — so the "real" pages wouldn't hit the 404 rule.

That assumption was too fragile in practice:

- **Partial prerender failures ship silently.** Commit 40de332 deliberately relaxed `scripts/prerender.js` to exit non-zero only on *total* prerender failure, so any route the puppeteer step skips (network flake, timeout) deploys with no `<route>/index.html` and falls through to the hard 404.
- **Whitelist drift.** Any valid SPA path missing from the explicit list — new article slugs, any deep-linked view added to `VIEW_TO_PATH` without also updating `_redirects` — 404s even though the React router could handle it fine.

## Fix

Restore `/*  /index.html  200` as the final rule in `public/_redirects`. The sensitive-path denylist above it (dotfiles, `/wp-*`, `/admin`, `/server-info`, `/api/debug`) is untouched and still returns a real 404, because exact-match rules come before the splat under first-match semantics.

The soft-404 tradeoff for genuinely unknown paths is acceptable: the in-app `NotFound` view is already `noindex`'d, which is the signal crawlers actually weight. A real user hitting a broken page is a far worse failure mode than a marginal SEO signal on paths that weren't going to be indexed anyway.

## Test plan

- [ ] Deploy to Cloudflare Pages and confirm previously-404ing valid routes (e.g. `/home`, `/team`, article slugs) now load the SPA
- [ ] Confirm sensitive probes still 404: `/.env`, `/wp-admin`, `/admin`, `/server-status`, `/api/debug`
- [ ] Confirm prerendered pages (`/trade-analyzer`, `/pricing`, legal pages) still serve their prerendered HTML with full meta tags (static asset match beats `/*` splat)
- [ ] Confirm truly unknown paths render the in-app NotFound view

https://claude.ai/code/session_01HPi437iqBJb89R2GST2KXM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPi437iqBJb89R2GST2KXM)_