### PR TITLE
Persist league selection across reloads

### DIFF
--- a/src/context/LeagueContext.tsx
+++ b/src/context/LeagueContext.tsx
@@ -192,7 +192,7 @@ const LeagueContext = createContext<LeagueContextType | undefined>(undefined);
 
 export function LeagueProvider({ children }: { children: ReactNode }) {
   const { user, isAuthenticated } = useAuth();
-  const { leagues } = useLeaguesContext();
+  const { leagues, isLoading: leaguesLoading } = useLeaguesContext();
 
   // State
   const [selectedLeagueId, setSelectedLeagueIdState] = useState<string | null>(() => {
@@ -231,8 +231,11 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
   const [allMatchupsLoading, setAllMatchupsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Auto-select league: validate persisted selection or fall back to first league
+  // Auto-select league: validate persisted selection or fall back to first league.
+  // Skip while leagues are still loading so we don't clobber the persisted id
+  // before the fetch resolves.
   useEffect(() => {
+    if (leaguesLoading) return;
     if (leagues.length > 0) {
       if (!selectedLeagueId || !leagues.some(l => l.id === selectedLeagueId)) {
         setSelectedLeagueId(leagues[0].id);
@@ -246,7 +249,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
       setMatchup(null);
       setStandings([]);
     }
-  }, [leagues, selectedLeagueId, setSelectedLeagueId]);
+  }, [leagues, leaguesLoading, selectedLeagueId, setSelectedLeagueId]);
 
   // Reset viewedTeamId when league changes (so we can set it to the user's team)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Switching leagues already wrote the selected id to `localStorage`, but the auto-select effect in `LeagueContext` ran before the leagues fetch resolved. On every reload it hit the empty-list branch and called `setSelectedLeagueId(null)`, wiping the persisted id before falling back to `leagues[0]`.
- Pull `isLoading` from `LeaguesContext` and early-return from the effect while leagues are still loading. The id read from `localStorage` now survives until we can validate it against the fetched list.

## Test plan
- [ ] Select a non-default league, hard-reload the app, confirm the same league stays selected.
- [ ] Select a league that no longer exists (e.g. disconnected), reload, confirm fallback to the first available league.
- [ ] Log out / log back in with zero leagues, confirm state clears cleanly.

https://claude.ai/code/session_01Xxmi2XSW9FvtNRQLKF5Pd4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xxmi2XSW9FvtNRQLKF5Pd4)_