### PR TITLE
Stop 404'ing /admin so refresh works

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -37,9 +37,6 @@
 /wp-content/*    /404.html    404
 /wp-includes    /404.html    404
 /wp-includes/*    /404.html    404
-# Admin surfaces
-/admin    /404.html    404
-/admin/*    /404.html    404
 # Server info leaks
 /server-info    /404.html    404
 /server-status    /404.html    404


### PR DESCRIPTION
## Why

Refreshing the admin page returns a 404. `public/_redirects` has explicit deny rules for `/admin` and `/admin/*` that send those paths to `/404.html` before the SPA catch-all can serve `index.html`.

```
# Admin surfaces
/admin    /404.html    404
/admin/*    /404.html    404
```

Those were anti-scanner theatre. Real auth is enforced both server-side (`adminAuthMiddleware` on `/analytics/admin/*` and `/admin/*` API routes) and client-side (the React admin view checks the user's role), so a probe hitting `/admin` just sees the SPA login screen — there's no attack surface to hide.

## What changed

Removed the two `/admin*` deny rules from `public/_redirects` so the SPA catch-all (`/* /index.html 200`) handles refreshes. The other sensitive-path rules (dotfiles, WordPress, server-info, debug) are unchanged.

## Test plan

- [ ] Deploy and visit `/admin` directly in the browser — should load the admin view (or login if not authenticated), not 404
- [ ] Confirm `/admin/users`, `/admin/articles`, etc. all refresh cleanly
- [ ] Confirm `/.env`, `/wp-admin`, `/server-info` still 404 as expected

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2XoWVvSiFcQVRyckopYMH)_