### PR TITLE
Widen pricing CTA padding and gap to FAQ list

### DIFF
--- a/src/components/PricingView.tsx
+++ b/src/components/PricingView.tsx
@@ -369,7 +369,7 @@ export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = f
         </div>
 
         {/* Bottom CTA */}
-        <div className={`mt-12 text-center py-12 rounded-xl border ${isDarkMode ? 'bg-slate-900 border-slate-800' : 'bg-slate-50 border-slate-200'}`}>
+        <div className={`mt-20 text-center py-12 rounded-xl border ${isDarkMode ? 'bg-slate-900 border-slate-800' : 'bg-slate-50 border-slate-200'}`}>
           <p className={`text-lg font-semibold mb-6 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
             Ready to level up your fantasy game?
           </p>
@@ -383,7 +383,7 @@ export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = f
                 window.location.href = '/login';
               }
             }}
-            className="bg-blue-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-blue-700 transition-all inline-flex items-center gap-3"
+            className="bg-blue-600 text-white px-10 py-3 rounded-lg font-semibold hover:bg-blue-700 transition-all inline-flex items-center gap-3"
           >
             <CreditCard className="w-5 h-5" />
             {isAuthenticated ? 'Start with Pro' : 'Sign Up Free'}


### PR DESCRIPTION
## Summary
Follow-up to #217. The previous adjustment over-tightened the bottom CTA: the FAQ box and "Ready to level up your fantasy game?" card ended up flush against each other, and `px-8` left the "Start with Pro" / "Sign Up Free" label hugging the right edge of the button.

- Restores `mt-20` (80px) above the bottom CTA card so it's clearly separated from the last FAQ ("What happens if I cancel?")
- Bumps the button's horizontal padding from `px-8` to `px-10` so the icon + label have visible breathing room inside the rounded background

## Test plan
- [ ] Visit `/pricing` while signed in — the "Start with Pro" label should sit comfortably between both rounded edges of the blue button
- [ ] Visit `/pricing` while signed out — same check for the "Sign Up Free" label
- [ ] Confirm the gap between the last FAQ box and the bottom CTA card is clearly visible (not flush)
- [ ] Sanity-check dark and light modes

https://claude.ai/code/session_014v6cQowcdpQ5fg6DhqKYJz

---
_Generated by [Claude Code](https://claude.ai/code/session_014v6cQowcdpQ5fg6DhqKYJz)_