### PR TITLE
Tighten pricing CTA gap and fix footer Cookie preferences sizing

### DIFF
--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -100,7 +100,7 @@ export function AppFooter({ isDarkMode, onNavigate }: AppFooterProps) {
           <button
             type="button"
             onClick={openCookiePreferences}
-            className={`${linkClass} transition-colors`}
+            className={`${linkClass} text-xs font-normal transition-colors`}
           >
             Cookie preferences
           </button>

--- a/src/components/PricingView.tsx
+++ b/src/components/PricingView.tsx
@@ -369,7 +369,7 @@ export function PricingView({ isDarkMode, userTier = 'free', isAuthenticated = f
         </div>
 
         {/* Bottom CTA */}
-        <div className={`mt-20 text-center py-12 rounded-xl border ${isDarkMode ? 'bg-slate-900 border-slate-800' : 'bg-slate-50 border-slate-200'}`}>
+        <div className={`mt-8 text-center py-12 rounded-xl border ${isDarkMode ? 'bg-slate-900 border-slate-800' : 'bg-slate-50 border-slate-200'}`}>
           <p className={`text-lg font-semibold mb-6 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
             Ready to level up your fantasy game?
           </p>


### PR DESCRIPTION
## Summary
Two follow-ups to the previous spacing fixes:

1. **PricingView bottom CTA gap** — `mt-20` (80px) gave the card a page-level separation from the FAQ list above it, which felt jarring next to the 24px `space-y-6` rhythm between FAQ items. Drop to `mt-8` (32px) so the CTA visually belongs to the same section as the FAQs.

2. **Footer "Cookie preferences" font size** — the button was rendering larger and bolder than its sibling `<a>` links. Cause: the base typography rule in `globals.css` applies `font-size: var(--text-base)` and `font-weight: 500` to `<button>` elements, and the `text-xs` class on the parent `<nav>` doesn't propagate (it's a class on the parent, not a `font-size` on the button itself, so `font: inherit` from preflight doesn't help). Add `text-xs font-normal` directly to the button so it matches the other footer links.

## Test plan
- [ ] Visit `/pricing` — the gap between "What happens if I cancel?" and the bottom CTA card should now feel like it belongs to the same FAQ section, not a separate one
- [ ] Confirm the CTA card itself still has visible interior padding (py-12 ⇒ 48px top/bottom)
- [ ] Visit any page with the footer — "Cookie preferences" should be the same font size and weight as "Privacy Policy", "Terms of Service", etc.
- [ ] Confirm both dark and light modes look correct

https://claude.ai/code/session_014v6cQowcdpQ5fg6DhqKYJz

---
_Generated by [Claude Code](https://claude.ai/code/session_014v6cQowcdpQ5fg6DhqKYJz)_