### PR TITLE
Fix login 405 in production: auto-detect API origin

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,35 @@
 // Base API configuration and utilities
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+// Resolve the API origin in this priority order:
+//   1. VITE_API_URL — explicit override (CI sets this to the worker URL).
+//   2. Hostname auto-detect — if we're on a known production host, point at
+//      the deployed worker. This is the safety net: if the build env var ever
+//      goes missing (Vite only inherits VITE_* from .env files, not always
+//      from process.env, depending on version/config), we still route to the
+//      worker instead of falling through to the same-origin Pages site (which
+//      returns 404/405 for /api/*).
+//   3. '/api' — local dev only, served via the Vite proxy in vite.config.ts.
+const PROD_API_URL = 'https://filmroom-api.earle2001.workers.dev/api';
+const PROD_HOSTS = new Set([
+  'filmroomfantasy.com',
+  'www.filmroomfantasy.com',
+  'filmroom.app',
+  'www.filmroom.app',
+]);
+
+function resolveApiBaseUrl(): string {
+  const envUrl = import.meta.env.VITE_API_URL;
+  if (envUrl) return envUrl;
+  if (typeof window !== 'undefined') {
+    const host = window.location.hostname;
+    if (PROD_HOSTS.has(host) || host.endsWith('.filmroomfantasy.pages.dev')) {
+      return PROD_API_URL;
+    }
+  }
+  return '/api';
+}
+
+const API_BASE_URL = resolveApiBaseUrl();
 
 // Origin of the API server. In dev API_BASE_URL is the relative '/api', so
 // this resolves to the same origin as the page (Vite proxy). In prod it's


### PR DESCRIPTION
## Summary

- Login was failing in production with the generic *"An error occurred"* message because `POST https://filmroomfantasy.com/api/auth/login` returned **405** (Pages doesn't host the Worker) and `GET /api/auth/me` returned **404**. The deployed bundle (`/assets/index-13YK_KOg.js`) hardcoded `"/api"` as the API base URL — zero references to `filmroom-api.earle2001.workers.dev`.
- Root cause: even though CI sets `VITE_API_URL` on the build step, Vite 6 didn't bake it into the build. There's no `.env.production` in the repo (only `.env.production.example`), and Vite's behavior around inheriting `process.env.VITE_*` without a `.env` file is inconsistent.
- Fix: replace the brittle single-line fallback in `src/services/api.ts` with a 3-tier resolver:
  1. `VITE_API_URL` if set (CI override still wins).
  2. Hostname auto-detect — if we're on `filmroomfantasy.com`, `filmroom.app`, or any `*.filmroomfantasy.pages.dev` preview, return the worker URL.
  3. `/api` only as a last resort (local dev via Vite proxy).
- Verified locally: `npx vite build` succeeds and the resulting `build/assets/index-*.js` contains both `"/api"` (dev) and `filmroom-api.earle2001.workers.dev/api` (prod). At runtime the right one is chosen by `window.location.hostname`.

## Test plan

- [ ] Wait for CI deploy on merge.
- [ ] Hit https://filmroomfantasy.com/login and submit valid credentials → expect successful login (no 405).
- [ ] DevTools → Network: `POST /auth/login` should target `https://filmroom-api.earle2001.workers.dev/api/auth/login` and return **200** with a JSON body containing `{ token, user }`.
- [ ] `GET /auth/me` should return **200** (or **401** if logged out) — never 404.
- [ ] Verify a Pages preview deploy (e.g. `*.filmroomfantasy.pages.dev`) also routes to the worker.
- [ ] Local dev (`npm run dev`) still uses the Vite proxy at `/api` → confirm by logging in against a local `wrangler dev` worker on `:8787`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)