### PR TITLE
Add standalone player profile page at /players/:slug-:id

### DIFF
--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -923,11 +923,18 @@ playerRoutes.get('/stats/available-years', optionalAuthMiddleware, async (c) => 
 // Get player details
 playerRoutes.get('/:id', optionalAuthMiddleware, async (c) => {
   const db = c.get('db');
-  const playerId = c.req.param('id');
+  const idParam = c.req.param('id');
 
   try {
+    // Resolve playerId — accept either our internal id or the Sleeper externalId
+    // (numeric). Mirrors the resolution behavior of /:id/stats and the other
+    // sibling routes so /players/:slug-:externalId profile URLs work.
+    const lookupColumn = /^\d+$/.test(idParam)
+      ? schema.nflPlayers.externalId
+      : schema.nflPlayers.id;
+
     const player = await db.query.nflPlayers.findFirst({
-      where: eq(schema.nflPlayers.id, playerId),
+      where: eq(lookupColumn, idParam),
       with: {
         news: {
           orderBy: desc(schema.playerNews.publishedAt),
@@ -1153,12 +1160,19 @@ playerRoutes.get('/:id/stats', optionalAuthMiddleware, async (c) => {
 // Get player projections
 playerRoutes.get('/:id/projections', optionalAuthMiddleware, async (c) => {
   const db = c.get('db');
-  const playerId = c.req.param('id');
+  let playerId = c.req.param('id');
   const week = c.req.query('week');
   const season = parseInt(c.req.query('season') || String(new Date().getFullYear()));
   const scoringFormat = c.req.query('format') || 'ppr';
 
   try {
+    if (/^\d+$/.test(playerId)) {
+      const player = await db.query.nflPlayers.findFirst({
+        where: eq(schema.nflPlayers.externalId, playerId),
+      });
+      if (player) playerId = player.id;
+    }
+
     const conditions = [
       eq(schema.playerProjections.playerId, playerId),
       eq(schema.playerProjections.seasonYear, season),
@@ -1184,9 +1198,16 @@ playerRoutes.get('/:id/projections', optionalAuthMiddleware, async (c) => {
 // Get player news + articles linked to this player
 playerRoutes.get('/:id/news', optionalAuthMiddleware, async (c) => {
   const db = c.get('db');
-  const playerId = c.req.param('id');
+  let playerId = c.req.param('id');
 
   try {
+    if (/^\d+$/.test(playerId)) {
+      const player = await db.query.nflPlayers.findFirst({
+        where: eq(schema.nflPlayers.externalId, playerId),
+      });
+      if (player) playerId = player.id;
+    }
+
     // Fetch player news and linked articles in parallel
     const [newsItems, articleLinks] = await Promise.all([
       db.query.playerNews.findMany({
@@ -1238,7 +1259,7 @@ playerRoutes.get('/:id/news', optionalAuthMiddleware, async (c) => {
 // Get player prop lines for a specific week
 playerRoutes.get('/:id/props', optionalAuthMiddleware, async (c) => {
   const db = c.get('db');
-  const playerId = c.req.param('id');
+  const idParam = c.req.param('id');
   const week = parseInt(c.req.query('week') || '1', 10);
   const season = parseInt(c.req.query('season') || '2025', 10);
 
@@ -1247,14 +1268,19 @@ playerRoutes.get('/:id/props', optionalAuthMiddleware, async (c) => {
   }
 
   try {
-    // Get player info
+    // Get player info — accept either internal id or Sleeper externalId
+    const lookupColumn = /^\d+$/.test(idParam)
+      ? schema.nflPlayers.externalId
+      : schema.nflPlayers.id;
     const player = await db.query.nflPlayers.findFirst({
-      where: eq(schema.nflPlayers.id, playerId),
+      where: eq(lookupColumn, idParam),
     });
 
     if (!player) {
       return c.json({ error: 'Player not found' }, 404);
     }
+
+    const playerId = player.id;
 
     // Name matching between Sleeper and The Odds API is inconsistent —
     // Sleeper strips "Jr." suffixes and some punctuation, sportsbooks don't.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ const DisclaimerView = lazyWithReload(() => import('./components/DisclaimerView'
 const AccessibilityView = lazyWithReload(() => import('./components/AccessibilityView').then(m => ({ default: m.AccessibilityView })));
 const AcceptableUseView = lazyWithReload(() => import('./components/AcceptableUseView').then(m => ({ default: m.AcceptableUseView })));
 const DraftRankingsView = lazyWithReload(() => import('./components/DraftRankingsView').then(m => ({ default: m.DraftRankingsView })));
+const PlayerProfileView = lazyWithReload(() => import('./components/PlayerProfileView').then(m => ({ default: m.PlayerProfileView })));
 import { LoginView } from './components/LoginView';
 import { RegisterView } from './components/RegisterView';
 import { ForgotPasswordView, ResetPasswordView } from './components/ForgotPasswordView';
@@ -71,6 +72,7 @@ import { LeaguesProvider, useLeaguesContext } from './context/LeaguesContext';
 import { trackPageView } from './services/analytics';
 import { trackSignUp } from './services/tracking';
 import { authService } from './services/auth';
+import { buildPlayerProfilePath, parsePlayerProfilePath } from './utils/slug';
 
 // Page transition wrapper component
 function PageTransition({ children, viewKey }: { children: React.ReactNode; viewKey: string }) {
@@ -212,6 +214,7 @@ const VIEW_TO_PATH: Record<string, string> = {
   Admin: '/admin',
   Articles: '/articles',
   ArticleDetail: '/articles', // handled with slug in URL
+  PlayerProfile: '/players', // handled with slug-id in URL
   Privacy: '/privacy',
   Terms: '/terms',
   CookiePolicy: '/cookies',
@@ -238,6 +241,9 @@ function getViewFromURL(): string {
   if (path.startsWith('/articles/') && path.length > '/articles/'.length) return 'ArticleDetail';
   if (path === '/articles') return 'Articles';
 
+  // Handle player profile routes (/players/{slug}-{id})
+  if (path.startsWith('/players/') && parsePlayerProfilePath(path)) return 'PlayerProfile';
+
   const view = PATH_TO_VIEW[path] ?? 'NotFound';
   // /register is handled within the Login view via authView state
   if (view === 'Register') return 'Login';
@@ -251,6 +257,11 @@ function getArticleSlugFromURL(): string | null {
     return path.slice('/articles/'.length);
   }
   return null;
+}
+
+/** Extract player profile id + slug from URL (/players/{slug}-{id}) */
+function getPlayerProfileFromURL(): { slug: string; id: string } | null {
+  return parsePlayerProfilePath(window.location.pathname);
 }
 
 // Main App content component that uses auth context
@@ -271,9 +282,10 @@ function AppContent() {
     }
   }, [league?.id, league?.currentWeek]);
   // Initialize activeView from URL so direct navigation works
-  const [activeView, setActiveView] = useState<'Landing' | 'Board' | 'Team' | 'Matchup' | 'Waivers' | 'Home' | 'GameSlate' | 'Trends' | 'Research' | 'Playoffs' | 'Settings' | 'Profile' | 'Login' | 'AllPlayers' | 'Pricing' | 'TradeAnalyzer' | 'DraftRankings' | 'LeagueAnalyzer' | 'Admin' | 'Articles' | 'ArticleDetail' | 'Privacy' | 'Terms' | 'CookiePolicy' | 'DMCA' | 'Refunds' | 'DoNotSell' | 'Disclaimer' | 'Accessibility' | 'AcceptableUse' | 'NotFound'>(() => getViewFromURL() as any);
+  const [activeView, setActiveView] = useState<'Landing' | 'Board' | 'Team' | 'Matchup' | 'Waivers' | 'Home' | 'GameSlate' | 'Trends' | 'Research' | 'Playoffs' | 'Settings' | 'Profile' | 'Login' | 'AllPlayers' | 'Pricing' | 'TradeAnalyzer' | 'DraftRankings' | 'LeagueAnalyzer' | 'Admin' | 'Articles' | 'ArticleDetail' | 'PlayerProfile' | 'Privacy' | 'Terms' | 'CookiePolicy' | 'DMCA' | 'Refunds' | 'DoNotSell' | 'Disclaimer' | 'Accessibility' | 'AcceptableUse' | 'NotFound'>(() => getViewFromURL() as any);
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
   const [articleSlug, setArticleSlug] = useState<string | null>(() => getArticleSlugFromURL());
+  const [playerProfile, setPlayerProfile] = useState<{ slug: string; id: string } | null>(() => getPlayerProfileFromURL());
   // Local dark mode state for unauthenticated users (initialized from localStorage)
   const [localDarkMode, setLocalDarkMode] = useState<boolean>(() => {
     try {
@@ -313,6 +325,8 @@ function AppContent() {
     let targetPath: string;
     if (activeView === 'ArticleDetail' && articleSlug) {
       targetPath = `/articles/${articleSlug}`;
+    } else if (activeView === 'PlayerProfile' && playerProfile) {
+      targetPath = `/players/${playerProfile.slug}-${playerProfile.id}`;
     } else {
       targetPath = VIEW_TO_PATH[activeView] || '/player-rankings';
     }
@@ -320,7 +334,7 @@ function AppContent() {
       window.history.pushState({ view: activeView }, '', targetPath);
     }
     trackPageView(targetPath);
-  }, [activeView, articleSlug]);
+  }, [activeView, articleSlug, playerProfile]);
 
   // Handle browser back/forward buttons (popstate) so routing stays in sync
   useEffect(() => {
@@ -328,6 +342,7 @@ function AppContent() {
       const view = getViewFromURL();
       setActiveView(view as any);
       setArticleSlug(getArticleSlugFromURL());
+      setPlayerProfile(getPlayerProfileFromURL());
     };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
@@ -416,6 +431,37 @@ function AppContent() {
 
   const handlePlayerClick = useCallback((player: Player) => {
     setSelectedPlayer(player);
+  }, []);
+
+  /** Navigate to the standalone player profile page (closes modal if open). */
+  const handleOpenPlayerProfile = useCallback((p: { id: string; name: string }) => {
+    setSelectedPlayer(null);
+    const path = buildPlayerProfilePath(p.name, p.id);
+    const parsed = parsePlayerProfilePath(path);
+    if (parsed) {
+      setPlayerProfile(parsed);
+      setActiveView('PlayerProfile');
+    }
+  }, []);
+
+  /** Reopen the modal as a quick-look from the standalone profile page. */
+  const handleQuickLookFromProfile = useCallback((p: { id: string; name: string; team: string; position: 'QB' | 'RB' | 'WR' | 'TE' | 'K' | 'DEF'; headshotUrl?: string | null }) => {
+    setSelectedPlayer({
+      id: p.id,
+      rank: 0,
+      name: p.name,
+      team: p.team,
+      position: p.position as Player['position'],
+      keyLine: '',
+      projectedPoints: 0,
+      weekChange: 0,
+      headshotUrl: p.headshotUrl ?? null,
+    });
+  }, []);
+
+  const handleBackFromPlayerProfile = useCallback(() => {
+    setPlayerProfile(null);
+    setActiveView('Board');
   }, []);
 
   const handleLogin = useCallback(async (email: string, password: string) => {
@@ -778,6 +824,18 @@ function AppContent() {
                   onNavigate={(view) => setActiveView(view as any)}
                 />
               </Suspense>
+            ) : activeView === 'PlayerProfile' && playerProfile ? (
+              <Suspense fallback={suspenseFallback}>
+                <PlayerProfileView
+                  playerId={playerProfile.id}
+                  isDarkMode={isDarkMode}
+                  seasonYear={league?.seasonYear}
+                  currentWeek={currentWeek}
+                  scoringFormat={league?.scoringFormat}
+                  onBack={handleBackFromPlayerProfile}
+                  onOpenQuickLook={handleQuickLookFromProfile}
+                />
+              </Suspense>
             ) : activeView === 'Privacy' ? (
               <Suspense fallback={suspenseFallback}><PrivacyPolicyView isDarkMode={isDarkMode} /></Suspense>
             ) : activeView === 'Terms' ? (
@@ -864,6 +922,7 @@ function AppContent() {
           seasonYear={league?.seasonYear}
           currentWeek={currentWeek}
           scoringFormat={league?.scoringFormat}
+          onViewFullProfile={handleOpenPlayerProfile}
         />
       )}
 

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -19,6 +19,8 @@ interface PlayerCardProps {
   currentWeek?: number;
   /** League scoring format. Defaults to 'ppr'. */
   scoringFormat?: string;
+  /** Optional handler — when set, the modal shows a "View full profile" CTA that navigates to the standalone player page. */
+  onViewFullProfile?: (player: { id: string; name: string }) => void;
 }
 
 interface APIWeeklyStat {
@@ -75,7 +77,7 @@ const statText = (isDarkMode: boolean) => isDarkMode ? 'text-slate-300' : 'text-
 const statMuted = (isDarkMode: boolean) => isDarkMode ? 'text-slate-400' : 'text-slate-700';
 const colBorder = (isDarkMode: boolean) => isDarkMode ? 'border-r border-slate-600' : 'border-r border-slate-200';
 
-export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeasonYear, currentWeek: propsCurrentWeek, scoringFormat: propsScoringFormat }: PlayerCardProps) {
+export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeasonYear, currentWeek: propsCurrentWeek, scoringFormat: propsScoringFormat, onViewFullProfile }: PlayerCardProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [activeTab, setActiveTab] = useState<'props' | 'breakdown' | 'history'>('props');
 
@@ -342,12 +344,22 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
             <span className={isDarkMode ? 'text-slate-600' : 'text-slate-400'}>/</span>
             <span className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Player Card</span>
           </button>
-          <button
-            onClick={handleClose}
-            className={`w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${isDarkMode ? 'bg-slate-800 hover:bg-slate-700' : 'bg-white hover:bg-slate-100 border border-slate-200'}`}
-          >
-            <X className={`w-4 h-4 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`} />
-          </button>
+          <div className="flex items-center gap-2">
+            {onViewFullProfile && (
+              <button
+                onClick={() => onViewFullProfile({ id: player.id, name: player.name })}
+                className={`text-xs font-semibold px-2.5 py-1.5 rounded-lg transition-colors ${isDarkMode ? 'bg-blue-600/20 text-blue-300 hover:bg-blue-600/30 border border-blue-700/40' : 'bg-blue-50 text-blue-700 hover:bg-blue-100 border border-blue-200'}`}
+              >
+                View full profile →
+              </button>
+            )}
+            <button
+              onClick={handleClose}
+              className={`w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${isDarkMode ? 'bg-slate-800 hover:bg-slate-700' : 'bg-white hover:bg-slate-100 border border-slate-200'}`}
+            >
+              <X className={`w-4 h-4 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`} />
+            </button>
+          </div>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/src/components/PlayerProfileView.tsx
+++ b/src/components/PlayerProfileView.tsx
@@ -1,0 +1,654 @@
+import { useEffect, useState, useMemo, type CSSProperties } from 'react';
+import { ArrowLeft, Calendar, Clock, TrendingUp, Sparkles } from 'lucide-react';
+import api from '../services/api';
+import { playerService } from '../services';
+import type { PlayerNews, MatchupGradeResponse, Player as ApiPlayer } from '../services/players';
+import { PlayerAvatar } from './PlayerAvatar';
+import { NewsSnippet } from './NewsSnippet';
+import { SEO, getPlayerProfileSEOProps } from './SEO';
+import { buildPlayerProfilePath } from '../utils/slug';
+
+interface PlayerProfileViewProps {
+  playerId: string;
+  isDarkMode: boolean;
+  seasonYear?: number;
+  currentWeek?: number;
+  scoringFormat?: string;
+  onBack: () => void;
+  onOpenQuickLook?: (player: { id: string; name: string; team: string; position: ApiPlayer['position']; headshotUrl?: string | null }) => void;
+}
+
+interface APIWeeklyStat {
+  week: number;
+  seasonYear: number;
+  opponent?: string | null;
+  passYards?: number;
+  passTDs?: number;
+  passInterceptions?: number;
+  passAttempts?: number;
+  passCompletions?: number;
+  rushYards?: number;
+  rushTDs?: number;
+  rushAttempts?: number;
+  receptions?: number;
+  receivingYards?: number;
+  receivingTDs?: number;
+  targets?: number;
+  fgMade?: number;
+  fgAttempts?: number;
+  xpMade?: number;
+  xpAttempts?: number;
+  sacks?: number;
+  defInterceptions?: number;
+  fumblesRecovered?: number;
+  defenseTDs?: number;
+  pointsAllowed?: number;
+  fantasyPointsPPR?: number;
+  fantasyPointsHalf?: number;
+  fantasyPointsStd?: number;
+  snapPct?: number | null;
+}
+
+interface PlayerDetail extends ApiPlayer {
+  height?: string;
+  weight?: number;
+  college?: string;
+  depthChartOrder?: number;
+}
+
+function formatTimeAgo(dateString: string | Date): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return 'Yesterday';
+  return `${diffDays}d ago`;
+}
+
+function getMatchupGradeLabel(grade: string | null | undefined): string {
+  if (!grade) return '—';
+  if (grade.startsWith('A')) return 'Elite';
+  if (grade.startsWith('B')) return 'Good';
+  if (grade.startsWith('C')) return 'Average';
+  return 'Tough';
+}
+
+function getGradeStyle(grade: string | null | undefined, isDarkMode: boolean): CSSProperties {
+  if (!grade) return { color: isDarkMode ? '#64748b' : '#94a3b8', backgroundColor: isDarkMode ? 'rgba(30,41,59,0.6)' : '#f1f5f9', borderColor: isDarkMode ? '#475569' : '#e2e8f0' };
+  if (grade.startsWith('A')) return { color: isDarkMode ? '#34d399' : '#059669', backgroundColor: isDarkMode ? 'rgba(16,185,129,0.25)' : '#d1fae5', borderColor: isDarkMode ? 'rgba(16,185,129,0.4)' : '#6ee7b7' };
+  if (grade.startsWith('B')) return { color: isDarkMode ? '#60a5fa' : '#2563eb', backgroundColor: isDarkMode ? 'rgba(59,130,246,0.25)' : '#dbeafe', borderColor: isDarkMode ? 'rgba(59,130,246,0.4)' : '#93c5fd' };
+  if (grade.startsWith('C')) return { color: isDarkMode ? '#fbbf24' : '#d97706', backgroundColor: isDarkMode ? 'rgba(245,158,11,0.25)' : '#fef3c7', borderColor: isDarkMode ? 'rgba(245,158,11,0.4)' : '#fcd34d' };
+  return { color: isDarkMode ? '#fb7185' : '#e11d48', backgroundColor: isDarkMode ? 'rgba(244,63,94,0.25)' : '#ffe4e6', borderColor: isDarkMode ? 'rgba(244,63,94,0.4)' : '#fda4af' };
+}
+
+function statusPillClasses(status: string): string {
+  if (status === 'injured_reserve' || status === 'out') return 'bg-red-500/20 text-red-400';
+  if (status === 'questionable') return 'bg-yellow-500/20 text-yellow-400';
+  if (status === 'doubtful') return 'bg-orange-500/20 text-orange-400';
+  return 'bg-slate-500/20 text-slate-400';
+}
+
+function statusLabel(status: string): string {
+  if (status === 'injured_reserve') return 'IR';
+  return status.toUpperCase();
+}
+
+export function PlayerProfileView({
+  playerId,
+  isDarkMode,
+  seasonYear,
+  currentWeek,
+  scoringFormat,
+  onBack,
+  onOpenQuickLook,
+}: PlayerProfileViewProps) {
+  const [player, setPlayer] = useState<PlayerDetail | null>(null);
+  const [playerLoading, setPlayerLoading] = useState(true);
+  const [playerError, setPlayerError] = useState<string | null>(null);
+
+  const [weeklyStats, setWeeklyStats] = useState<APIWeeklyStat[] | null>(null);
+  const [seasonTotals, setSeasonTotals] = useState<{ games?: number; gamesPlayed?: number; fantasyPointsPPR?: number; fantasyPointsHalf?: number; fantasyPointsStd?: number } | null>(null);
+  const [averagePoints, setAveragePoints] = useState<{ ppr: number | null; half: number | null; std: number | null }>({ ppr: null, half: null, std: null });
+  const [statsLoading, setStatsLoading] = useState(true);
+
+  const [news, setNews] = useState<PlayerNews[]>([]);
+  const [newsLoading, setNewsLoading] = useState(true);
+
+  const [matchupData, setMatchupData] = useState<MatchupGradeResponse | null>(null);
+  const [matchupLoading, setMatchupLoading] = useState(true);
+
+  const [propsData, setPropsData] = useState<any>(null);
+  const [propsLoading, setPropsLoading] = useState(true);
+
+  const week = currentWeek ?? 1;
+  const season = seasonYear ?? new Date().getFullYear();
+
+  const normalizedFormat = scoringFormat === 'half_ppr' ? 'half_ppr' : scoringFormat === 'standard' ? 'standard' : 'ppr';
+  const scoringLabel = normalizedFormat === 'half_ppr' ? 'Half PPR' : normalizedFormat === 'standard' ? 'Standard' : 'PPR';
+
+  const getFantasyPoints = (s: APIWeeklyStat): number => {
+    if (normalizedFormat === 'half_ppr') return s.fantasyPointsHalf ?? s.fantasyPointsPPR ?? 0;
+    if (normalizedFormat === 'standard') return s.fantasyPointsStd ?? s.fantasyPointsPPR ?? 0;
+    return s.fantasyPointsPPR ?? 0;
+  };
+
+  const currentAverage = normalizedFormat === 'half_ppr' ? averagePoints.half : normalizedFormat === 'standard' ? averagePoints.std : averagePoints.ppr;
+  const seasonTotal = normalizedFormat === 'half_ppr' ? seasonTotals?.fantasyPointsHalf : normalizedFormat === 'standard' ? seasonTotals?.fantasyPointsStd : seasonTotals?.fantasyPointsPPR;
+
+  // Load player details
+  useEffect(() => {
+    if (!playerId) return;
+    let cancelled = false;
+    setPlayerLoading(true);
+    setPlayerError(null);
+    api.get<{ player: PlayerDetail }>(`/players/${playerId}`)
+      .then((res) => { if (!cancelled) { setPlayer(res.player); setPlayerLoading(false); } })
+      .catch((err) => {
+        if (!cancelled) {
+          setPlayer(null);
+          setPlayerLoading(false);
+          setPlayerError(err instanceof Error ? err.message : 'Player not found');
+        }
+      });
+    return () => { cancelled = true; };
+  }, [playerId]);
+
+  // Load season stats
+  useEffect(() => {
+    if (!playerId) return;
+    let cancelled = false;
+    setStatsLoading(true);
+    api.get<{
+      weeklyStats: APIWeeklyStat[];
+      seasonTotals?: { games?: number; gamesPlayed?: number; fantasyPointsPPR?: number; fantasyPointsHalf?: number; fantasyPointsStd?: number };
+      averagePointsPPR?: number;
+      averagePointsHalf?: number;
+      averagePointsStd?: number;
+    }>(`/players/${playerId}/stats?season=${season}`)
+      .then((res) => {
+        if (cancelled) return;
+        setWeeklyStats(res?.weeklyStats?.length ? res.weeklyStats : null);
+        setSeasonTotals(res?.seasonTotals ?? null);
+        setAveragePoints({
+          ppr: res?.averagePointsPPR ?? null,
+          half: res?.averagePointsHalf ?? null,
+          std: res?.averagePointsStd ?? null,
+        });
+        setStatsLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setWeeklyStats(null);
+        setSeasonTotals(null);
+        setAveragePoints({ ppr: null, half: null, std: null });
+        setStatsLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [playerId, season]);
+
+  // Load news
+  useEffect(() => {
+    if (!playerId) return;
+    let cancelled = false;
+    setNewsLoading(true);
+    setNews([]);
+    playerService.getPlayerNews(playerId)
+      .then((res) => { if (!cancelled) { setNews(res.news); setNewsLoading(false); } })
+      .catch(() => { if (!cancelled) { setNews([]); setNewsLoading(false); } });
+    return () => { cancelled = true; };
+  }, [playerId]);
+
+  // Load matchup grade
+  useEffect(() => {
+    if (!playerId) return;
+    let cancelled = false;
+    setMatchupLoading(true);
+    playerService.getMatchupGrade(playerId, { season, week })
+      .then((res) => { if (!cancelled) setMatchupData(res); })
+      .catch(() => { if (!cancelled) setMatchupData(null); })
+      .finally(() => { if (!cancelled) setMatchupLoading(false); });
+    return () => { cancelled = true; };
+  }, [playerId, season, week]);
+
+  // Load props
+  useEffect(() => {
+    if (!playerId) return;
+    let cancelled = false;
+    setPropsLoading(true);
+    api.get<any>(`/players/${playerId}/props?week=${week}&season=${season}`)
+      .then((res) => { if (!cancelled) { setPropsData(res); setPropsLoading(false); } })
+      .catch(() => { if (!cancelled) { setPropsData(null); setPropsLoading(false); } });
+    return () => { cancelled = true; };
+  }, [playerId, week, season]);
+
+  const bestWeek = useMemo(() => {
+    if (!weeklyStats?.length) return null;
+    return weeklyStats.reduce<{ week: number; pts: number } | null>((best, s) => {
+      const pts = getFantasyPoints(s);
+      if (!best || pts > best.pts) return { week: s.week, pts };
+      return best;
+    }, null);
+  }, [weeklyStats, normalizedFormat]);
+
+  // Loading state
+  if (playerLoading) {
+    return (
+      <div className="max-w-6xl mx-auto py-12 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  // Error state
+  if (!player) {
+    return (
+      <div className="max-w-3xl mx-auto py-12 text-center">
+        <h1 className={`text-2xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Player not found</h1>
+        <p className={`mb-6 ${isDarkMode ? 'text-slate-400' : 'text-slate-600'}`}>
+          {playerError ?? "We couldn't find this player profile."}
+        </p>
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-4 py-2 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700"
+        >
+          Back to rankings
+        </button>
+      </div>
+    );
+  }
+
+  const grade = matchupData?.grade ?? '';
+  const position = player.position;
+
+  const heroBg = isDarkMode
+    ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 border-slate-800'
+    : 'bg-gradient-to-br from-slate-50 via-white to-slate-100 border-slate-200';
+
+  const cardBg = isDarkMode
+    ? 'bg-slate-900 border-slate-800'
+    : 'bg-white border-slate-200';
+
+  const sectionTitle = `text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`;
+  const muted = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const headingColor = isDarkMode ? 'text-white' : 'text-slate-900';
+  const bodyColor = isDarkMode ? 'text-slate-300' : 'text-slate-700';
+
+  // Prefer the short, shareable Sleeper externalId in the canonical URL when
+  // available; fall back to the internal id. Both resolve on the backend.
+  const canonicalId = player.externalId ?? player.id;
+  const profilePath = buildPlayerProfilePath(player.name, canonicalId);
+  const playerSeo = getPlayerProfileSEOProps(player, profilePath);
+
+  return (
+    <div className="max-w-6xl mx-auto pb-12">
+      <SEO {...playerSeo} />
+      {/* Breadcrumb / back */}
+      <nav className="mb-4 flex items-center gap-2 text-sm">
+        <button
+          type="button"
+          onClick={onBack}
+          className={`flex items-center gap-1.5 transition-colors group ${muted} hover:${isDarkMode ? 'text-white' : 'text-slate-900'}`}
+        >
+          <ArrowLeft className="w-4 h-4 group-hover:-translate-x-0.5 transition-transform" />
+          <span>Back</span>
+        </button>
+        <span className={isDarkMode ? 'text-slate-700' : 'text-slate-300'}>/</span>
+        <span className={muted}>Players</span>
+        <span className={isDarkMode ? 'text-slate-700' : 'text-slate-300'}>/</span>
+        <span className={isDarkMode ? 'text-slate-200' : 'text-slate-700'}>{player.name}</span>
+      </nav>
+
+      {/* Hero */}
+      <header className={`rounded-2xl border p-6 sm:p-8 ${heroBg}`}>
+        <div className="flex flex-col sm:flex-row gap-6 items-start">
+          <div className={`w-28 h-32 sm:w-32 sm:h-36 rounded-xl overflow-hidden border flex-shrink-0 flex items-center justify-center ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-100 border-slate-200'}`}>
+            <PlayerAvatar
+              name={player.name}
+              headshotUrl={player.headshotUrl}
+              className="w-full h-full object-contain"
+              fallbackClassName="text-3xl font-bold"
+              isDarkMode={isDarkMode}
+            />
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-3 flex-wrap mb-2">
+              <h1 className={`text-3xl sm:text-4xl font-bold ${headingColor}`}>{player.name}</h1>
+              {player.status && player.status !== 'active' && (
+                <span className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded ${statusPillClasses(player.status)}`}>
+                  {statusLabel(player.status)}
+                </span>
+              )}
+            </div>
+            <div className={`flex items-center gap-2 text-sm flex-wrap mb-4 ${bodyColor}`}>
+              <span className="font-semibold">{player.team}</span>
+              <span className={muted}>•</span>
+              <span className="font-semibold">{position}</span>
+              {player.jerseyNumber != null && (
+                <>
+                  <span className={muted}>•</span>
+                  <span>#{player.jerseyNumber}</span>
+                </>
+              )}
+              {player.byeWeek != null && (
+                <>
+                  <span className={muted}>•</span>
+                  <span className="flex items-center gap-1"><Calendar className="w-3.5 h-3.5" />Bye Week {player.byeWeek}</span>
+                </>
+              )}
+            </div>
+
+            {/* Bio strip */}
+            <div className={`flex items-center gap-x-4 gap-y-1 flex-wrap text-xs ${muted}`}>
+              {player.age != null && <span><span className={`font-semibold ${bodyColor}`}>{player.age}</span> yrs</span>}
+              {player.height && <span><span className={`font-semibold ${bodyColor}`}>{player.height}</span></span>}
+              {player.weight != null && <span><span className={`font-semibold ${bodyColor}`}>{player.weight}</span> lbs</span>}
+              {player.college && <span><span className={`font-semibold ${bodyColor}`}>{player.college}</span></span>}
+              {player.yearsExp != null && <span><span className={`font-semibold ${bodyColor}`}>{player.yearsExp}</span> yrs exp</span>}
+            </div>
+
+            {player.injuryNote && (
+              <div className={`mt-4 text-sm rounded-lg border px-3 py-2 ${isDarkMode ? 'bg-red-950/30 border-red-900/50 text-red-200' : 'bg-red-50 border-red-200 text-red-800'}`}>
+                <span className="font-semibold">{player.injuryBodyPart ? `${player.injuryBodyPart}: ` : 'Injury: '}</span>
+                {player.injuryNote}
+              </div>
+            )}
+          </div>
+
+          {grade && !matchupLoading && (
+            <div className="flex flex-col items-end gap-1 shrink-0">
+              <span className="text-xs font-medium px-3 py-2 rounded-lg border" style={getGradeStyle(grade, isDarkMode)}>
+                {matchupData?.opponent ? `vs ${matchupData.opponent} ` : 'Matchup '}{grade}
+              </span>
+              <span className={`text-[10px] uppercase tracking-wide ${muted}`}>{getMatchupGradeLabel(grade)} matchup</span>
+            </div>
+          )}
+        </div>
+      </header>
+
+      {/* Quick stats strip */}
+      <section className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard label={`${scoringLabel} Pts`} value={seasonTotal != null ? seasonTotal.toFixed(1) : '—'} loading={statsLoading} isDarkMode={isDarkMode} />
+        <StatCard label="Games" value={(seasonTotals?.gamesPlayed ?? seasonTotals?.games)?.toString() ?? '—'} loading={statsLoading} isDarkMode={isDarkMode} />
+        <StatCard label="PPG" value={currentAverage != null ? currentAverage.toFixed(1) : '—'} loading={statsLoading} isDarkMode={isDarkMode} />
+        <StatCard label="Best Week" value={bestWeek ? `Wk ${bestWeek.week} · ${bestWeek.pts.toFixed(1)}` : '—'} loading={statsLoading} isDarkMode={isDarkMode} />
+      </section>
+
+      <div className="mt-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left/main column */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* AI Take placeholder — wired in pass 2 */}
+          <section className={`rounded-2xl border p-5 ${cardBg}`} aria-labelledby="ai-take-heading">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <Sparkles className={`w-4 h-4 ${isDarkMode ? 'text-purple-400' : 'text-purple-600'}`} />
+                <h2 id="ai-take-heading" className={`text-sm font-semibold ${headingColor}`}>FilmRoom AI Take</h2>
+              </div>
+              <span className={`text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border ${isDarkMode ? 'border-purple-900/50 text-purple-300 bg-purple-950/30' : 'border-purple-200 text-purple-700 bg-purple-50'}`}>
+                Coming soon
+              </span>
+            </div>
+            <p className={`text-sm leading-relaxed ${bodyColor}`}>
+              AI-generated weekly analysis covering recent form, upcoming matchup, role/usage trends, and start/sit guidance — landing here next.
+            </p>
+          </section>
+
+          {/* Weekly stats table */}
+          <section className={`rounded-2xl border overflow-hidden ${cardBg}`} aria-labelledby="weekly-stats-heading">
+            <div className={`px-5 py-4 border-b flex items-center justify-between ${isDarkMode ? 'border-slate-800' : 'border-slate-200'}`}>
+              <div>
+                <h2 id="weekly-stats-heading" className={`text-sm font-semibold ${headingColor}`}>{season} Weekly Stats</h2>
+                <p className={`text-xs ${muted}`}>{scoringLabel} scoring</p>
+              </div>
+            </div>
+            {statsLoading ? (
+              <div className="p-6 space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className={`animate-pulse rounded h-8 ${isDarkMode ? 'bg-slate-800' : 'bg-slate-100'}`} />
+                ))}
+              </div>
+            ) : !weeklyStats?.length ? (
+              <p className={`p-6 text-sm ${muted}`}>No game stats for {season} yet.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <WeeklyStatsTable
+                  stats={weeklyStats}
+                  position={position}
+                  getFantasyPoints={getFantasyPoints}
+                  isDarkMode={isDarkMode}
+                />
+              </div>
+            )}
+          </section>
+
+          {/* Vegas props */}
+          <section className={`rounded-2xl border p-5 ${cardBg}`} aria-labelledby="props-heading">
+            <h2 id="props-heading" className={`text-sm font-semibold mb-3 ${headingColor}`}>Vegas Props · Week {week}</h2>
+            {propsLoading ? (
+              <div className={`animate-pulse h-12 rounded ${isDarkMode ? 'bg-slate-800' : 'bg-slate-100'}`} />
+            ) : !propsData?.props || Object.keys(propsData.props).length === 0 ? (
+              <p className={`text-sm ${muted}`}>No prop lines posted for this week.</p>
+            ) : (
+              <PropsList propsData={propsData} isDarkMode={isDarkMode} />
+            )}
+            {propsData?.isFallback && propsData?.season && (
+              <p className={`text-xs mt-3 ${muted}`}>Showing {propsData.season} lines (last available season).</p>
+            )}
+          </section>
+        </div>
+
+        {/* Right/side column */}
+        <aside className="space-y-6">
+          {/* Matchup grade detail */}
+          <section className={`rounded-2xl border p-5 ${cardBg}`} aria-labelledby="matchup-heading">
+            <div className="flex items-center gap-2 mb-3">
+              <TrendingUp className={`w-4 h-4 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`} />
+              <h2 id="matchup-heading" className={`text-sm font-semibold ${headingColor}`}>Matchup Grade</h2>
+            </div>
+            {matchupLoading ? (
+              <div className={`animate-pulse h-16 rounded ${isDarkMode ? 'bg-slate-800' : 'bg-slate-100'}`} />
+            ) : !grade ? (
+              <p className={`text-sm ${muted}`}>No matchup data for this week.</p>
+            ) : (
+              <>
+                <div className="flex items-center gap-3 mb-3">
+                  <span className="text-3xl font-bold px-3 py-1 rounded-lg border" style={getGradeStyle(grade, isDarkMode)}>{grade}</span>
+                  <div>
+                    <div className={`text-sm font-semibold ${headingColor}`}>{getMatchupGradeLabel(grade)}</div>
+                    {matchupData?.opponent && <div className={`text-xs ${muted}`}>vs {matchupData.opponent} · Week {matchupData.week ?? week}</div>}
+                  </div>
+                </div>
+                {matchupData?.message && <p className={`text-sm leading-relaxed ${bodyColor}`}>{matchupData.message}</p>}
+              </>
+            )}
+          </section>
+
+          {/* News */}
+          <section className={`rounded-2xl border p-5 ${cardBg}`} aria-labelledby="news-heading">
+            <h2 id="news-heading" className={sectionTitle + ' mb-3'}>Latest News</h2>
+            {newsLoading ? (
+              <div className="space-y-3">
+                {[1, 2].map((i) => (
+                  <div key={i} className={`animate-pulse rounded-lg h-14 ${isDarkMode ? 'bg-slate-800' : 'bg-slate-100'}`} />
+                ))}
+              </div>
+            ) : news.length === 0 ? (
+              <p className={`text-sm ${muted}`}>No recent news.</p>
+            ) : (
+              <ul className="space-y-3">
+                {news.slice(0, 5).map((item, i) => (
+                  <li key={item.id ?? i} className="flex flex-col gap-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className={`text-[11px] font-medium ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}>{item.source ?? 'News'}</span>
+                      <span className={`text-[11px] flex items-center gap-1 ${muted}`}>
+                        <Clock className="w-3 h-3" />{formatTimeAgo(item.publishedAt)}
+                      </span>
+                    </div>
+                    <p className={`text-sm leading-relaxed ${bodyColor}`}>
+                      {(item as any).isArticle && item.sourceUrl ? (
+                        <a href={item.sourceUrl} className="hover:underline font-medium">{item.headline}</a>
+                      ) : (
+                        <NewsSnippet item={item} />
+                      )}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* Open quick-look (modal) */}
+          {onOpenQuickLook && player && (
+            <button
+              type="button"
+              onClick={() => onOpenQuickLook({ id: player.id, name: player.name, team: player.team, position: player.position, headshotUrl: player.headshotUrl })}
+              className={`w-full px-4 py-2.5 rounded-lg text-sm font-semibold border transition-colors ${isDarkMode ? 'border-slate-700 text-slate-200 hover:bg-slate-800' : 'border-slate-300 text-slate-700 hover:bg-slate-50'}`}
+            >
+              Open quick-look modal
+            </button>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value, loading, isDarkMode }: { label: string; value: string; loading: boolean; isDarkMode: boolean }) {
+  return (
+    <div className={`rounded-xl border p-4 ${isDarkMode ? 'bg-slate-900 border-slate-800' : 'bg-white border-slate-200'}`}>
+      <div className={`text-[10px] uppercase tracking-wide ${isDarkMode ? 'text-slate-500' : 'text-slate-500'}`}>{label}</div>
+      {loading ? (
+        <div className={`mt-1 animate-pulse h-7 w-16 rounded ${isDarkMode ? 'bg-slate-800' : 'bg-slate-100'}`} />
+      ) : (
+        <div className={`mt-1 text-xl font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{value}</div>
+      )}
+    </div>
+  );
+}
+
+function WeeklyStatsTable({
+  stats,
+  position,
+  getFantasyPoints,
+  isDarkMode,
+}: {
+  stats: APIWeeklyStat[];
+  position: ApiPlayer['position'];
+  getFantasyPoints: (s: APIWeeklyStat) => number;
+  isDarkMode: boolean;
+}) {
+  const headerCls = `text-left text-[10px] uppercase tracking-wide font-semibold px-3 py-2 ${isDarkMode ? 'text-slate-400 bg-slate-950' : 'text-slate-500 bg-slate-50'}`;
+  const cellCls = `px-3 py-2 text-sm ${isDarkMode ? 'text-slate-200' : 'text-slate-800'}`;
+  const rowBorder = isDarkMode ? 'border-slate-800' : 'border-slate-200';
+
+  const cols = useMemo(() => {
+    const base = [
+      { key: 'week', label: 'Wk' },
+      { key: 'opp', label: 'OPP' },
+      { key: 'fpts', label: 'FPTS' },
+    ];
+    if (position === 'QB') return [...base, { key: 'cmpAtt', label: 'CMP/ATT' }, { key: 'passYds', label: 'PASS YDS' }, { key: 'passTd', label: 'PASS TD' }, { key: 'int', label: 'INT' }, { key: 'rushYds', label: 'RUSH YDS' }, { key: 'rushTd', label: 'RUSH TD' }];
+    if (position === 'WR' || position === 'TE') return [...base, { key: 'tgt', label: 'TGT' }, { key: 'rec', label: 'REC' }, { key: 'recYds', label: 'REC YDS' }, { key: 'recTd', label: 'REC TD' }, { key: 'rushYds', label: 'RUSH YDS' }];
+    if (position === 'RB') return [...base, { key: 'rushAtt', label: 'CAR' }, { key: 'rushYds', label: 'RUSH YDS' }, { key: 'rushTd', label: 'RUSH TD' }, { key: 'tgt', label: 'TGT' }, { key: 'rec', label: 'REC' }, { key: 'recYds', label: 'REC YDS' }];
+    if (position === 'K') return [...base, { key: 'fg', label: 'FG' }, { key: 'xp', label: 'XP' }];
+    if (position === 'DEF') return [...base, { key: 'sack', label: 'SACK' }, { key: 'int', label: 'INT' }, { key: 'fr', label: 'FR' }, { key: 'td', label: 'TD' }, { key: 'pa', label: 'PA' }];
+    return base;
+  }, [position]);
+
+  const renderCell = (s: APIWeeklyStat, key: string): string => {
+    if (key === 'week') return String(s.week);
+    if (key === 'opp') return s.opponent ?? '—';
+    if (key === 'fpts') return getFantasyPoints(s).toFixed(1);
+    if (key === 'cmpAtt') return `${s.passCompletions ?? 0}/${s.passAttempts ?? 0}`;
+    if (key === 'passYds') return String(s.passYards ?? 0);
+    if (key === 'passTd') return String(s.passTDs ?? 0);
+    if (key === 'int') return String(s.passInterceptions ?? s.defInterceptions ?? 0);
+    if (key === 'rushYds') return String(s.rushYards ?? 0);
+    if (key === 'rushTd') return String(s.rushTDs ?? 0);
+    if (key === 'rushAtt') return String(s.rushAttempts ?? 0);
+    if (key === 'tgt') return String(s.targets ?? 0);
+    if (key === 'rec') return String(s.receptions ?? 0);
+    if (key === 'recYds') return String(s.receivingYards ?? 0);
+    if (key === 'recTd') return String(s.receivingTDs ?? 0);
+    if (key === 'fg') return `${s.fgMade ?? 0}/${s.fgAttempts ?? 0}`;
+    if (key === 'xp') return `${s.xpMade ?? 0}/${s.xpAttempts ?? 0}`;
+    if (key === 'sack') return String(s.sacks ?? 0);
+    if (key === 'fr') return String(s.fumblesRecovered ?? 0);
+    if (key === 'td') return String(s.defenseTDs ?? 0);
+    if (key === 'pa') return String(s.pointsAllowed ?? 0);
+    return '—';
+  };
+
+  return (
+    <table className="min-w-full">
+      <thead>
+        <tr>
+          {cols.map((c) => (
+            <th key={c.key} scope="col" className={headerCls}>{c.label}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {stats.map((s, i) => (
+          <tr key={`${s.seasonYear}-${s.week}-${i}`} className={`border-t ${rowBorder}`}>
+            {cols.map((c) => (
+              <td key={c.key} className={cellCls}>{renderCell(s, c.key)}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function PropsList({ propsData, isDarkMode }: { propsData: any; isDarkMode: boolean }) {
+  const MARKET_LABELS: Record<string, string> = {
+    passyds: 'Passing Yards',
+    rushyds: 'Rushing Yards',
+    receptionyds: 'Receiving Yards',
+    passtds: 'Passing TDs',
+    rushtds: 'Rushing TDs',
+    receptions: 'Receptions',
+    anytimetd: 'Anytime TD',
+  };
+  const ACTUAL_KEYS: Record<string, string> = {
+    passyds: 'passYds',
+    rushyds: 'rushYds',
+    receptionyds: 'recYds',
+    passtds: 'passTds',
+    rushtds: 'rushTds',
+    receptions: 'recs',
+    anytimetd: 'scoredTd',
+  };
+
+  const props = propsData?.props ?? {};
+  const actual = propsData?.actual ?? {};
+  const markets = Object.keys(props);
+
+  return (
+    <ul className="space-y-2">
+      {markets.map((market) => {
+        const p = props[market];
+        const actualVal = actual[ACTUAL_KEYS[market]];
+        const label = MARKET_LABELS[market] ?? market;
+        return (
+          <li key={market} className={`flex items-center justify-between text-sm rounded-lg border px-3 py-2 ${isDarkMode ? 'border-slate-800 bg-slate-950/30' : 'border-slate-200 bg-slate-50'}`}>
+            <span className={isDarkMode ? 'text-slate-200' : 'text-slate-800'}>{label}</span>
+            <span className={`flex items-center gap-3 ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}>
+              <span className="font-semibold">{p?.line ?? '—'}</span>
+              {actualVal != null && (
+                <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-500'}`}>actual: {String(actualVal)}</span>
+              )}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/PlayerProfileView.tsx
+++ b/src/components/PlayerProfileView.tsx
@@ -293,7 +293,7 @@ export function PlayerProfileView({
         <button
           type="button"
           onClick={onBack}
-          className={`flex items-center gap-1.5 transition-colors group ${muted} hover:${isDarkMode ? 'text-white' : 'text-slate-900'}`}
+          className={`flex items-center gap-1.5 transition-colors group ${muted} ${isDarkMode ? 'hover:text-white' : 'hover:text-slate-900'}`}
         >
           <ArrowLeft className="w-4 h-4 group-hover:-translate-x-0.5 transition-transform" />
           <span>Back</span>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -94,6 +94,10 @@ const ROUTE_SEO: Record<string, { title: string; description: string }> = {
     title: 'Fantasy Football Articles & Guides | FilmRoom',
     description: 'Expert fantasy football strategy guides, rankings analysis, waiver wire tips, and beginner resources.',
   },
+  PlayerProfile: {
+    title: 'NFL Player Profile | FilmRoom',
+    description: 'NFL player profile with weekly fantasy football stats, projections, matchup analysis, Vegas props, and the latest news.',
+  },
   Privacy: {
     title: 'Privacy Policy | FilmRoom',
     description: 'FilmRoom Fantasy privacy policy. Learn how we collect, use, and protect your personal information and league data.',
@@ -439,4 +443,56 @@ export function getSEOPropsForView(view: string, authView?: string): SEOProps {
   }
 
   return props;
+}
+
+/** Build per-player SEO props for the standalone profile page. */
+export function getPlayerProfileSEOProps(player: {
+  name: string;
+  team?: string;
+  position?: string;
+  headshotUrl?: string | null;
+  byeWeek?: number;
+}, profilePath: string): SEOProps {
+  const { name, team, position, headshotUrl } = player;
+  const positionFull: Record<string, string> = {
+    QB: 'Quarterback',
+    RB: 'Running Back',
+    WR: 'Wide Receiver',
+    TE: 'Tight End',
+    K: 'Kicker',
+    DEF: 'Defense',
+  };
+  const posLabel = position ? (positionFull[position] ?? position) : 'Player';
+  const teamLabel = team ?? 'NFL';
+  const title = `${name} Fantasy Stats, Projections & News (${teamLabel} ${position ?? ''}) | FilmRoom`.replace(/\s+/g, ' ').trim();
+  const description = `${name}, ${teamLabel} ${posLabel}. Weekly fantasy football stats, projections, matchup grade, Vegas props, and the latest news on FilmRoom.`;
+
+  return {
+    title,
+    description,
+    path: profilePath,
+    type: 'profile',
+    image: headshotUrl ?? undefined,
+    jsonLd: [
+      {
+        '@context': 'https://schema.org',
+        '@type': 'Person',
+        'name': name,
+        'jobTitle': posLabel,
+        ...(team ? { 'affiliation': { '@type': 'SportsTeam', 'name': team } } : {}),
+        'memberOf': { '@type': 'SportsOrganization', 'name': 'National Football League', 'url': 'https://www.nfl.com' },
+        ...(headshotUrl ? { 'image': headshotUrl } : {}),
+        'url': `${BASE_URL}${profilePath}`,
+      },
+      {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        'itemListElement': [
+          { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': BASE_URL },
+          { '@type': 'ListItem', 'position': 2, 'name': 'Player Rankings', 'item': `${BASE_URL}/player-rankings` },
+          { '@type': 'ListItem', 'position': 3, 'name': name, 'item': `${BASE_URL}${profilePath}` },
+        ],
+      },
+    ],
+  };
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Home, LayoutDashboard, TrendingUp, Settings, Swords, Users as UsersIcon, ListPlus, CalendarRange, Trophy, CreditCard, BookOpen, ArrowLeftRight, ShieldCheck, Medal, BarChart3, FileText, ChevronDown, ChartNoAxesCombined, Shield, Wrench } from 'lucide-react';
 import { LeagueManager } from './LeagueManager';
 
-type SidebarView = 'Board' | 'Team' | 'Matchup' | 'Waivers' | 'Home' | 'GameSlate' | 'Trends' | 'Research' | 'Playoffs' | 'DraftRankings' | 'TradeAnalyzer' | 'LeagueAnalyzer' | 'Settings' | 'Pricing' | 'Admin' | 'Articles' | 'ArticleDetail';
+type SidebarView = 'Board' | 'Team' | 'Matchup' | 'Waivers' | 'Home' | 'GameSlate' | 'Trends' | 'Research' | 'Playoffs' | 'DraftRankings' | 'TradeAnalyzer' | 'LeagueAnalyzer' | 'Settings' | 'Pricing' | 'Admin' | 'Articles' | 'ArticleDetail' | 'PlayerProfile';
 
 interface MenuItem {
   icon: React.ComponentType<{ className?: string }>;

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -13,12 +13,29 @@ export function buildPlayerProfilePath(name: string, id: string): string {
   return `/players/${slugify(name)}-${id}`;
 }
 
+// Player ids in this app are either:
+//   - a numeric Sleeper externalId (e.g. "6803"), or
+//   - a UUID v4 from generateId() (e.g. "e72f0bdc-2987-4d0c-9e31-4f8c6abc8f13").
+// UUIDs contain hyphens, so naive lastIndexOf('-') splitting truncates them.
+// We detect a trailing UUID first, then fall back to splitting on the last
+// hyphen for short numeric ids.
+const TRAILING_UUID = /-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/;
+
 export function parsePlayerProfilePath(pathname: string): { slug: string; id: string } | null {
   const path = pathname.toLowerCase().replace(/\/+$/, '');
   if (!path.startsWith('/players/')) return null;
   const tail = path.slice('/players/'.length);
   if (!tail) return null;
+
+  const uuid = tail.match(TRAILING_UUID);
+  if (uuid) {
+    const slug = tail.slice(0, tail.length - uuid[0].length);
+    if (!slug) return null;
+    return { slug, id: uuid[1] };
+  }
+
   const lastDash = tail.lastIndexOf('-');
   if (lastDash <= 0 || lastDash === tail.length - 1) return null;
   return { slug: tail.slice(0, lastDash), id: tail.slice(lastDash + 1) };
 }
+

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,24 @@
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+export function buildPlayerProfilePath(name: string, id: string): string {
+  return `/players/${slugify(name)}-${id}`;
+}
+
+export function parsePlayerProfilePath(pathname: string): { slug: string; id: string } | null {
+  const path = pathname.toLowerCase().replace(/\/+$/, '');
+  if (!path.startsWith('/players/')) return null;
+  const tail = path.slice('/players/'.length);
+  if (!tail) return null;
+  const lastDash = tail.lastIndexOf('-');
+  if (lastDash <= 0 || lastDash === tail.length - 1) return null;
+  return { slug: tail.slice(0, lastDash), id: tail.slice(lastDash + 1) };
+}


### PR DESCRIPTION
## Summary
Adds a standalone, indexable player profile page at `/players/:slug-:id` (e.g. `/players/josh-allen-6803`). Foundation for the SEO work in the backlog and the next pass of AI player analysis.

## What's new

**New route + page** (`src/components/PlayerProfileView.tsx`)
- Hero with large headshot, name, team/position/jersey/bye/age/height/weight/college/exp + injury banner
- Season summary cards: total fantasy points (per league scoring), games, PPG, best week
- Weekly game log table (position-aware columns: QB / RB / WR-TE / K / DEF)
- Matchup grade panel with letter grade, label, opponent, and explanation
- Vegas props strip for the current week (line vs actual)
- Latest news (5 most recent)
- "FilmRoom AI Take" placeholder section — wires up in pass 2

**Routing** (`src/App.tsx`, `src/utils/slug.ts`, `src/components/Sidebar.tsx`)
- Custom pathname router gets a `PlayerProfile` view, parsed with `parsePlayerProfilePath()` (splits on the last `-` so hyphenated names work)
- `popstate` + URL pushState plumbing kept consistent with the existing article-detail pattern
- Lazy-loaded chunk: 17.53 kB / 5.23 kB gzipped

**Modal ↔ page handoff** (`src/components/PlayerCard.tsx`)
- New optional `onViewFullProfile` prop adds a **View full profile →** CTA in the modal header
- The standalone page exposes a reciprocal **Open quick-look modal** button so deep-dive tabs (props, breakdown, history) stay one click away

**Backend** (`server/src/routes/players.ts`)
- `GET /players/:id`, `/:id/projections`, `/:id/news`, `/:id/props` now resolve a numeric `:id` against Sleeper `externalId` in addition to the internal id (matching `/:id/stats` and `/:id/matchup-grade` which already did this)
- Lets canonical URLs use the short, shareable Sleeper id

**SEO** (`src/components/SEO.tsx`)
- New `getPlayerProfileSEOProps(player, path)` emits per-player `<title>` (`{Name} Fantasy Stats, Projections & News ({TEAM} {POS}) | FilmRoom`), description, canonical, OG image (headshot), and JSON-LD: `Person` with `jobTitle` (position), `affiliation` (team), `memberOf: NFL` + a 3-step `BreadcrumbList`
- Generic `PlayerProfile` fallback added to `ROUTE_SEO`
- Profile page renders its own `<SEO>` after the player loads, so Helmet overrides the generic tags with the player-specific ones

## Deferred to follow-up
- **Sitemap inclusion** of per-player URLs — needs a build-time data source for the player list (current sitemap.xml is static)
- **Static HTML pre-rendering** per player in `scripts/generate-static-pages.js` — same dependency
- **AI take section** — placeholder is in place, content/wire-up is pass 2 per the user's plan

Both deferrals are noted in the commit message. The page works client-side today and is indexable because modern Google renders JS.

## Test plan
- [x] `npm run build` succeeds; new chunk `PlayerProfileView-*.js` emitted
- [x] `npm run typecheck` introduces no new errors (pre-existing `activeView` width error unchanged)
- [x] Dev server returns HTTP 200 on `/players/josh-allen-6803`
- [ ] **Browser smoke-test** — I couldn't open a browser in this environment. Worth manually clicking through: modal "View full profile →" navigates correctly, page back-button works, Vegas props/news/matchup grade load, quick-look modal reopens, refresh on `/players/...` URL re-hydrates correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SRCoUtpg2x65SjJyvx92e5)_