### PR TITLE
Fix Sleeper league connect & sync reliability bugs

### DIFF
--- a/server/src/routes/leagues.ts
+++ b/server/src/routes/leagues.ts
@@ -493,15 +493,39 @@ leagueRoutes.post('/connect', authMiddleware, async (c) => {
       }
 
       // Add user to existing league (store sleeperUserId for reliable sync matching, fall back to username)
+      const storedExternalUsername = sleeperUserId || sleeperUsername || null;
       await db.insert(schema.leagueMembers).values({
         id: generateId(),
         userId: user.id,
         leagueId: existingLeague.id,
         role: 'member',
-        externalUsername: sleeperUserId || sleeperUsername || null,
+        externalUsername: storedExternalUsername,
       });
 
-      // Create team for user
+      // If a team for this Sleeper user already exists in the league (because
+      // another app user already imported the league and synced rosters),
+      // associate the joining user with that existing team rather than
+      // creating a duplicate placeholder. The team keeps its original
+      // ownerId; the joining user's view of "my team" is resolved at read
+      // time via league_members.externalUsername → teams.externalOwnerId.
+      if (sleeperUserId) {
+        const existingTeam = await db.query.teams.findFirst({
+          where: and(
+            eq(schema.teams.leagueId, existingLeague.id),
+            eq(schema.teams.externalOwnerId, sleeperUserId)
+          ),
+        });
+        if (existingTeam) {
+          return c.json({
+            league: existingLeague,
+            team: { id: existingTeam.id, name: existingTeam.name },
+          }, 201);
+        }
+      }
+
+      // No matching team yet (e.g. original connector hasn't synced).
+      // Create a placeholder; sync will reconcile it with the real roster
+      // via the externalUsername → externalOwnerId match.
       const teamId = generateId();
       await db.insert(schema.teams).values({
         id: teamId,
@@ -562,8 +586,9 @@ leagueRoutes.post('/connect', authMiddleware, async (c) => {
       team: { id: teamId, name: `${user.username}'s Team` },
     }, 201);
   } catch (error) {
-    console.error('Connect league error:', error);
-    return c.json({ error: 'Failed to connect league' }, 500);
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.error('Connect league error:', err);
+    return c.json({ error: err.message || 'Failed to connect league' }, 500);
   }
 });
 
@@ -698,11 +723,8 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
         userMap.set(sleeperUser.user_id, sleeperUser);
       }
 
-      // Find the current user's team in our database
-      const userTeam = league.teams.find(t => t.ownerId === user.id);
-
-      // Find which Sleeper user matches this app user
-      // externalUsername may contain a Sleeper user_id (preferred) or a username/display_name
+      // Find which Sleeper user matches this app user.
+      // externalUsername may contain a Sleeper user_id (preferred) or a username/display_name.
       let userSleeperUserId: string | null = null;
       if (membership.externalUsername) {
         const stored = membership.externalUsername;
@@ -723,6 +745,16 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
           }
         }
       }
+
+      // Find the current user's team in our database.
+      // Prefer a team this user already owns (the common single-user case).
+      // For users who joined an already-connected league, ownership stays with
+      // the original importer, so also resolve via externalUsername → externalOwnerId.
+      const userTeam =
+        league.teams.find(t => t.ownerId === user.id) ||
+        (userSleeperUserId
+          ? league.teams.find(t => t.externalOwnerId === userSleeperUserId)
+          : undefined);
 
       // Track which roster ID belongs to the user
       let userRosterAssigned = false;
@@ -789,10 +821,17 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
             })
             .where(eq(schema.teams.id, team.id));
         } else {
-          // Check if team already exists (by external roster ID stored in name temporarily)
-          const existingTeam = league.teams.find(t =>
-            t.name === teamName || t.name.includes(`Roster ${roster.roster_id}`)
-          );
+          // Check if an opponent team already exists for this Sleeper user.
+          // Prefer externalOwnerId — it's the stable Sleeper user_id and won't
+          // collide when two teams share a display name. Fall back to the
+          // legacy name-based match only for teams created by older syncs
+          // that never recorded externalOwnerId.
+          const sleeperOwnerId = String(roster.owner_id);
+          const existingTeam =
+            league.teams.find(t => t.externalOwnerId === sleeperOwnerId) ||
+            league.teams.find(t =>
+              !t.externalOwnerId && (t.name === teamName || t.name.includes(`Roster ${roster.roster_id}`))
+            );
 
           if (existingTeam) {
             team = existingTeam;
@@ -834,17 +873,27 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
           }
         }
 
-        // Sync roster players
+        // Sync roster players.
+        // We build the full set of new roster_spots rows in memory first, then
+        // delete + bulk-insert at the end. D1 has no real transactions, so the
+        // previous pattern (delete-then-insert-in-a-loop) left a team with an
+        // empty roster if any player insert failed mid-way. Doing all the work
+        // up-front means a thrown error aborts before we wipe the old rows.
         if (roster.players && roster.players.length > 0 && (isUserTeam || team)) {
-          // First, delete existing roster spots for this team
-          await db.delete(schema.rosterSpots)
-            .where(eq(schema.rosterSpots.teamId, team.id));
-
           // Get starters array from roster. Sleeper orders this array to match the
           // non-bench entries of the league's `roster_positions`, and uses the
           // sentinel "0" / "Invalid" for empty starter slots — so `starters[i]`
           // corresponds to `starterSlots[i]` position-for-position.
           const starters = roster.starters || [];
+
+          const newSpots: Array<{
+            id: string;
+            teamId: string;
+            playerId: string;
+            slot: string;
+            isStarter: boolean;
+            acquiredType: 'sync';
+          }> = [];
 
           for (let i = 0; i < roster.players.length; i++) {
             const playerId = roster.players[i];
@@ -867,7 +916,11 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
             // Check if player exists in our database (from pre-fetched batch)
             let player = existingPlayersByExtId.get(playerId) || null;
 
-            // If player doesn't exist, create from pre-fetched Sleeper data
+            // If player doesn't exist, create from pre-fetched Sleeper data.
+            // Player-row leaks across syncs are harmless (rows in a shared
+            // table), so we don't bother rolling them back if a later step
+            // fails — but we still let the error propagate to abort the sync
+            // rather than silently producing an incomplete roster.
             if (!player) {
               const playerData = sleeperPlayers[playerId];
 
@@ -894,20 +947,29 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
                 jerseyNumber: playerData?.number,
                 depthChartOrder: playerData?.depth_chart_order,
               });
-              player = { id: newPlayerId } as any;
+              player = { id: newPlayerId };
               existingPlayersByExtId.set(playerId, { id: newPlayerId });
             }
 
-            // Insert roster spot (player is guaranteed to exist at this point)
-            if (player) {
-              await db.insert(schema.rosterSpots).values({
-                id: generateId(),
-                teamId: team.id,
-                playerId: player.id,
-                slot,
-                isStarter,
-                acquiredType: 'sync',
-              });
+            newSpots.push({
+              id: generateId(),
+              teamId: team.id,
+              playerId: player.id,
+              slot,
+              isStarter,
+              acquiredType: 'sync',
+            });
+          }
+
+          // All new rows successfully constructed — now swap them in.
+          // Delete + insert still aren't atomic in D1, but the window is tiny
+          // and any failure here is logged at the outer catch.
+          await db.delete(schema.rosterSpots)
+            .where(eq(schema.rosterSpots.teamId, team.id));
+          if (newSpots.length > 0) {
+            // Chunk inserts to stay well under D1's bound-parameter ceiling.
+            for (let i = 0; i < newSpots.length; i += 50) {
+              await db.insert(schema.rosterSpots).values(newSpots.slice(i, i + 50));
             }
           }
         }
@@ -922,11 +984,13 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
         where: eq(schema.teams.leagueId, league.id),
       });
 
-      // Map rosters to teams by matching names
+      // Map rosters to teams by externalOwnerId (stable Sleeper user_id).
+      // Falling back to name would mis-route matchups when two Sleeper users
+      // share a display name; the team rows we just upserted above all carry
+      // externalOwnerId, so this lookup is reliable.
       for (const roster of rosters) {
-        const sleeperUser = userMap.get(roster.owner_id);
-        const teamName = sleeperUser?.metadata?.team_name || sleeperUser?.display_name || `Team ${roster.roster_id}`;
-        const matchingTeam = updatedTeams.find(t => t.name === teamName);
+        const sleeperOwnerId = String(roster.owner_id);
+        const matchingTeam = updatedTeams.find(t => t.externalOwnerId === sleeperOwnerId);
         if (matchingTeam) {
           rosterIdToTeamId.set(roster.roster_id, matchingTeam.id);
         }
@@ -1367,6 +1431,15 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
         console.error('Trade ingest failed (non-blocking):', e);
       }
 
+      // If we couldn't pin the user to a Sleeper roster, surface a warning so
+      // the UI can prompt them to set their Sleeper username (otherwise their
+      // "my team" view will be empty even though the league synced fine).
+      const userMatchWarning = !userRosterAssigned
+        ? (membership.externalUsername
+            ? `We synced the league but couldn't find a Sleeper roster matching "${membership.externalUsername}". Re-enter your Sleeper username in league settings.`
+            : 'We synced the league but don\'t know which roster is yours. Add your Sleeper username in league settings to see your team.')
+        : null;
+
       return c.json({
         success: true,
         message: `League synced successfully from Sleeper. ${rosters.length} teams, ${matchupsImported} matchups, ${statsImported} player stats, ${propsProjectionsCount} projections from book lines, ${projectionsImported} projections from Sleeper, and ${tradesIngested} trades updated.`,
@@ -1376,6 +1449,8 @@ leagueRoutes.post('/:id/sync', syncRateLimit, authMiddleware, async (c) => {
         projectionsImported,
         propsProjections: propsProjectionsCount,
         tradesIngested,
+        userTeamMatched: userRosterAssigned,
+        warning: userMatchWarning,
       });
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -302,7 +302,14 @@ export function SettingsView({ isDarkMode = true, onToggleDarkMode, onLeagueSync
       // Auto-sync the league to import teams and rosters
       if (result.league?.id) {
         try {
-          await leagueConnectService.syncLeague(result.league.id);
+          const syncResult = await leagueConnectService.syncLeague(result.league.id);
+          // The sync may succeed at the league level but fail to identify
+          // which Sleeper roster belongs to this user (e.g. wrong username,
+          // or the league was connected by ID without a username). Surface
+          // that as a warning so the user knows to fix it in settings.
+          if (syncResult?.warning) {
+            setConnectError(syncResult.warning);
+          }
         } catch (syncError: unknown) {
           const msg = syncError instanceof Error ? syncError.message : 'Sync failed';
           setConnectError(`League connected but sync failed: ${msg}. You can try syncing manually.`);

--- a/src/services/leagueConnect.ts
+++ b/src/services/leagueConnect.ts
@@ -283,8 +283,13 @@ export const leagueConnectService = {
   },
 
   // Sync league data from external platform
-  syncLeague: async (leagueId: string): Promise<{ success: boolean; message: string }> => {
-    return api.post<{ success: boolean; message: string }>(`/leagues/${leagueId}/sync`);
+  syncLeague: async (leagueId: string): Promise<{
+    success: boolean;
+    message: string;
+    userTeamMatched?: boolean;
+    warning?: string | null;
+  }> => {
+    return api.post(`/leagues/${leagueId}/sync`);
   },
 
   // Disconnect a league


### PR DESCRIPTION
## Summary

Audited the Sleeper league-connect flow after a user reported "connect failed entirely" and fixed seven verified bugs across `/api/leagues/connect`, `/api/leagues/:id/sync`, and the connect modal. The most likely cause of the reported failure — a generic 500 burying the real error — is fixed; the other six are correctness/reliability issues the same audit surfaced.

## What changed

### Connect (`server/src/routes/leagues.ts`)
- **Surface real errors from `/connect`.** The outer `catch` was returning `{ error: 'Failed to connect league' }` regardless of the actual cause. Now it returns `err.message`, matching the sync handler's existing behavior. Any 402 (free-tier limit), 400 (already connected), D1 error, etc. will now reach the UI instead of being flattened to a generic string.
- **No more duplicate placeholder teams when a 2nd app user joins an already-imported league.** Previously the handler always inserted a fresh team with `ownerId = joiningUser.id` and no `externalOwnerId`, so the league ended up with 13 teams (12 originals owned by user A + 1 placeholder owned by user B). Now it looks up the existing team in that league whose `externalOwnerId === sleeperUserId` and associates the joining user with it via the membership row. Falls back to the placeholder only when no Sleeper roster has been synced yet.

### Sync (`server/src/routes/leagues.ts`)
- **Resolve "my team" via `membership.externalUsername → teams.externalOwnerId`** in addition to `ownerId === user.id`. Without this, a user who joined an already-imported league could never be matched to their roster (the matching team's ownerId belongs to the original importer).
- **Match opponent teams by `externalOwnerId`, not team name.** Two Sleeper users with the same display name (common in casual leagues) no longer collide. The legacy name-based path is kept as a fallback only for teams created before `externalOwnerId` was recorded.
- **Map `roster_id → team_id` for matchups by `externalOwnerId` instead of name** (same collision risk on the matchup path).
- **Safe `roster_spots` refresh.** Previously we deleted all of a team's roster spots and then inserted new ones one-by-one in a loop — D1 has no transactions, so a mid-loop failure left the team with an empty roster. Now we build the full new row set in memory first, then delete + bulk-insert (chunked at 50 to stay under D1's bound-parameter ceiling). If anything throws beforehand, the existing rows stay intact.
- **`userTeamMatched` + `warning` in the sync response.** When `userRosterAssigned` stays false after processing all rosters, the response carries a clear warning explaining what to fix. Sync itself still returns `success: true` so league-level data is preserved.

### Frontend (`src/services/leagueConnect.ts`, `src/components/SettingsView.tsx`)
- Sync response type now includes `userTeamMatched?` and `warning?`.
- The connect modal surfaces `syncResult.warning` to the user via the existing `setConnectError` channel, so they're prompted to fix their Sleeper username instead of silently ending up with an empty team.

## False alarms (disregarded during audit)

- `https://api.sleeper.com/stats/...` and `.../projections/...` are **correct** — Sleeper's stats/projections live on `.com`, not the documented `.app` host. Both domains are used consistently across `admin.ts`, `players.ts`, `leagues.ts`.
- The sync handler's outer catch already surfaces `err.message`; only the connect handler was burying errors.

## Test plan

- [ ] Connect a brand-new Sleeper league via the username flow → league appears, sync runs, user's team shows the right roster.
- [ ] Connect via league-ID-only (no username entered) → league connects, sync succeeds, modal displays the warning prompting the user to set their Sleeper username.
- [ ] Have a 2nd account join the same Sleeper league an existing account already connected → league shows 12 teams (not 13), each user's "my team" view resolves correctly to their own roster.
- [ ] Verify a sync that hits a transient Sleeper hiccup mid-roster doesn't wipe an existing roster (build-then-swap behavior).
- [ ] Trigger a real connect error (e.g. attempt 2nd league on free tier) and confirm the modal shows the actual error message, not "Failed to connect league".

🤖 Generated with [Claude Code](https://claude.com/claude-code)