### PR TITLE
Proxy Sleeper/ESPN/MFL through backend to fix browser fetch failures

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,6 +26,7 @@ import { tradeFinderRoutes } from './routes/tradeFinder';
 import { analyticsRoutes } from './routes/analytics';
 import { articleRoutes } from './routes/articles';
 import { draftRankingsRoutes } from './routes/draftRankings';
+import { platformProxyRoutes } from './routes/platformProxy';
 
 // Types
 export type Env = {
@@ -210,6 +211,10 @@ app.route('/api/admin', adminStatsRoutes);
 app.route('/api/analytics', analyticsRoutes);
 app.route('/api/articles', articleRoutes);
 app.route('/api/draft-rankings', draftRankingsRoutes);
+// Proxy for external fantasy platform read APIs (Sleeper/ESPN/MFL).
+// Routes browser-originated lookups through our own origin to avoid CORS,
+// ad-blockers, and policy changes on upstream platforms.
+app.route('/api', platformProxyRoutes);
 
 // 404 handler
 app.notFound((c) => {

--- a/server/src/routes/platformProxy.ts
+++ b/server/src/routes/platformProxy.ts
@@ -65,8 +65,14 @@ async function fetchUpstream(url: string): Promise<{ ok: true; data: unknown } |
 // Limits keep path params from being abused as SSRF vectors. Sleeper user_ids
 // are numeric strings, usernames are short alphanumeric; ESPN/MFL league IDs
 // are numeric. 64 chars is generous enough for any legitimate value.
+// `..` is rejected explicitly: the WHATWG URL constructor normalizes `..`
+// segments when fetch parses the URL, so an input like ".." would silently
+// rewrite the upstream path. Not a security hole (base URLs are hardcoded,
+// upstream is public read-only), but it surfaces as confusing 404s.
 function isSafeIdent(s: string | undefined, maxLen = 64): s is string {
-  return !!s && s.length > 0 && s.length <= maxLen && /^[a-zA-Z0-9_.-]+$/.test(s);
+  if (!s || s.length === 0 || s.length > maxLen) return false;
+  if (s.includes('..')) return false;
+  return /^[a-zA-Z0-9_.-]+$/.test(s);
 }
 
 // ============================================

--- a/server/src/routes/platformProxy.ts
+++ b/server/src/routes/platformProxy.ts
@@ -1,0 +1,195 @@
+// Backend proxy for external fantasy platform APIs (Sleeper, ESPN, MFL).
+//
+// Why: prior to this, the frontend hit api.sleeper.app, lm-api-reads.fantasy.espn.com,
+// and api.myfantasyleague.com directly from the browser. Any CORS policy change,
+// ad-blocker false positive, browser extension, or mixed-content issue surfaced
+// as a generic "Failed to fetch" — and we had no way to investigate or recover.
+// Routing through our own origin removes that whole class of failures.
+//
+// Each route is a thin pass-through: auth-gated + rate-limited, 10s upstream
+// timeout, transparent status code translation. No response caching yet —
+// add when usage justifies it.
+
+import { Hono } from 'hono';
+import { authMiddleware } from '../middleware/auth';
+import { rateLimit } from '../middleware/rateLimit';
+import type { Env, Variables } from '../index';
+
+// 30 req/min per IP across all platform proxy endpoints. Generous enough for
+// the normal connect flow (lookup → list leagues → fetch league details) but
+// caps abuse if someone treats this as a free Sleeper proxy.
+const platformRateLimit = rateLimit(30, 60 * 1000);
+
+export const platformProxyRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
+platformProxyRoutes.use('*', platformRateLimit, authMiddleware);
+
+const UPSTREAM_TIMEOUT_MS = 10_000;
+
+// Map an upstream HTTP status to the status we return to the browser.
+// 404 → 404, anything 5xx (including network errors) → 502 so the client
+// can distinguish "doesn't exist" from "platform is down".
+function mapUpstreamStatus(status: number): number {
+  if (status === 404) return 404;
+  if (status === 401 || status === 403) return status;
+  if (status >= 500) return 502;
+  if (status >= 400) return 502; // upstream client errors aren't user-actionable
+  return status;
+}
+
+async function fetchUpstream(url: string): Promise<{ ok: true; data: unknown } | { ok: false; status: number; message: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'filmroomfantasy/1.0' },
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      return { ok: false, status: mapUpstreamStatus(res.status), message: body.slice(0, 200) || `Upstream returned ${res.status}` };
+    }
+    const data = await res.json();
+    return { ok: true, data };
+  } catch (err) {
+    const isAbort = err instanceof DOMException && err.name === 'AbortError';
+    return {
+      ok: false,
+      status: isAbort ? 504 : 502,
+      message: isAbort ? 'Upstream timed out' : (err instanceof Error ? err.message : 'Upstream fetch failed'),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Limits keep path params from being abused as SSRF vectors. Sleeper user_ids
+// are numeric strings, usernames are short alphanumeric; ESPN/MFL league IDs
+// are numeric. 64 chars is generous enough for any legitimate value.
+function isSafeIdent(s: string | undefined, maxLen = 64): s is string {
+  return !!s && s.length > 0 && s.length <= maxLen && /^[a-zA-Z0-9_.-]+$/.test(s);
+}
+
+// ============================================
+// SLEEPER
+// ============================================
+
+// Look up a Sleeper user by username.
+platformProxyRoutes.get('/sleeper/user/:username', async (c) => {
+  const username = c.req.param('username');
+  if (!isSafeIdent(username, 32)) return c.json({ error: 'Invalid username' }, 400);
+
+  const result = await fetchUpstream(`https://api.sleeper.app/v1/user/${encodeURIComponent(username)}`);
+  if (!result.ok) {
+    if (result.status === 404) return c.json({ error: 'User not found' }, 404);
+    return c.json({ error: `Sleeper unavailable: ${result.message}` }, result.status as 502 | 504);
+  }
+  return c.json(result.data);
+});
+
+// Fetch all NFL leagues for a Sleeper user across the last 3 seasons. Combined
+// server-side so the browser makes one request instead of three. Per-season
+// failures are tolerated as long as at least one season returns data — the
+// caller sees "no leagues" only when every season legitimately had none.
+platformProxyRoutes.get('/sleeper/user/:userId/leagues', async (c) => {
+  const userId = c.req.param('userId');
+  if (!isSafeIdent(userId, 32)) return c.json({ error: 'Invalid user id' }, 400);
+
+  const currentYear = new Date().getFullYear();
+  const seasons = [currentYear, currentYear - 1, currentYear - 2];
+
+  const results = await Promise.allSettled(
+    seasons.map(s => fetchUpstream(`https://api.sleeper.app/v1/user/${encodeURIComponent(userId)}/leagues/nfl/${s}`))
+  );
+
+  const successes: unknown[] = [];
+  let allFailed = true;
+  for (const r of results) {
+    if (r.status === 'fulfilled' && r.value.ok) {
+      allFailed = false;
+      const arr = Array.isArray(r.value.data) ? r.value.data : [];
+      successes.push(...arr);
+    } else if (r.status === 'fulfilled' && !r.value.ok && r.value.status === 404) {
+      // 404 on a season means no leagues that year — that's a successful "empty" response.
+      allFailed = false;
+    }
+  }
+
+  if (allFailed) {
+    return c.json({ error: 'Sleeper unavailable for all seasons' }, 502);
+  }
+
+  // Dedupe by league_id in case Sleeper returns the same league across years.
+  const seen = new Set<string>();
+  const leagues = [];
+  for (const l of successes as any[]) {
+    const id = l?.league_id;
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    leagues.push(l);
+  }
+  return c.json(leagues);
+});
+
+// Look up a single Sleeper league by ID.
+platformProxyRoutes.get('/sleeper/league/:leagueId', async (c) => {
+  const leagueId = c.req.param('leagueId');
+  if (!isSafeIdent(leagueId, 32)) return c.json({ error: 'Invalid league id' }, 400);
+
+  const result = await fetchUpstream(`https://api.sleeper.app/v1/league/${encodeURIComponent(leagueId)}`);
+  if (!result.ok) {
+    if (result.status === 404) return c.json({ error: 'League not found' }, 404);
+    return c.json({ error: `Sleeper unavailable: ${result.message}` }, result.status as 502 | 504);
+  }
+  return c.json(result.data);
+});
+
+// ============================================
+// ESPN
+// ============================================
+
+// Public-league read. Private leagues (which require SWID + ESPN_S2 cookies)
+// surface as 401/403 — pass through so the UI can show the right error.
+platformProxyRoutes.get('/espn/league/:leagueId', async (c) => {
+  const leagueId = c.req.param('leagueId');
+  if (!isSafeIdent(leagueId, 32)) return c.json({ error: 'Invalid league id' }, 400);
+
+  const yearParam = c.req.query('year');
+  const year = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();
+  if (!Number.isInteger(year) || year < 2000 || year > 2100) {
+    return c.json({ error: 'Invalid year' }, 400);
+  }
+
+  const url = `https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl/seasons/${year}/segments/0/leagues/${encodeURIComponent(leagueId)}?view=mSettings`;
+  const result = await fetchUpstream(url);
+  if (!result.ok) {
+    if (result.status === 404) return c.json({ error: 'League not found' }, 404);
+    if (result.status === 401 || result.status === 403) {
+      return c.json({ error: 'ESPN league is private. Make it public in ESPN settings.', code: 'ESPN_PRIVATE' }, 403);
+    }
+    return c.json({ error: `ESPN unavailable: ${result.message}` }, result.status as 502 | 504);
+  }
+  return c.json(result.data);
+});
+
+// ============================================
+// MFL
+// ============================================
+
+platformProxyRoutes.get('/mfl/league/:leagueId', async (c) => {
+  const leagueId = c.req.param('leagueId');
+  if (!isSafeIdent(leagueId, 32)) return c.json({ error: 'Invalid league id' }, 400);
+
+  const yearParam = c.req.query('year');
+  const year = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();
+  if (!Number.isInteger(year) || year < 2000 || year > 2100) {
+    return c.json({ error: 'Invalid year' }, 400);
+  }
+
+  const url = `https://api.myfantasyleague.com/${year}/export?TYPE=league&L=${encodeURIComponent(leagueId)}&JSON=1`;
+  const result = await fetchUpstream(url);
+  if (!result.ok) {
+    if (result.status === 404) return c.json({ error: 'League not found' }, 404);
+    return c.json({ error: `MFL unavailable: ${result.message}` }, result.status as 502 | 504);
+  }
+  return c.json(result.data);
+});

--- a/src/services/leagueConnect.ts
+++ b/src/services/leagueConnect.ts
@@ -1,5 +1,12 @@
-// League Connection Service - Connects to external fantasy platforms
-import api from './api';
+// League Connection Service - Connects to external fantasy platforms.
+//
+// All upstream platform reads (Sleeper, ESPN, MFL) go through our own
+// backend proxy now. The browser only ever talks to our origin, which
+// removes a whole class of failures: CORS policy changes, ad-blocker
+// false positives, browser extensions, mixed-content blocks, etc.
+// See server/src/routes/platformProxy.ts for the proxy endpoints.
+
+import api, { ApiError } from './api';
 
 export type Platform = 'sleeper' | 'espn' | 'yahoo' | 'mfl';
 
@@ -83,142 +90,115 @@ export class PlatformError extends Error {
   }
 }
 
-// Wrap a fetch call so failures land in PlatformError with a stable `kind`
-// the UI can branch on. 404s become `not_found` (caller sees null);
-// other non-OK responses + network errors throw with a meaningful kind.
-async function platformFetch(
-  url: string,
-  platform: Platform,
-  timeoutMs = 10_000,
-  init?: RequestInit
-): Promise<Response | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+// Call a backend proxy endpoint and translate ApiError into PlatformError
+// so the UI's existing error-routing logic keeps working unchanged.
+async function proxyGet<T>(path: string, platform: Platform): Promise<T | null> {
   try {
-    const res = await fetch(url, { ...init, signal: controller.signal });
-    if (res.status === 404) return null;
-    if (res.status === 429) {
-      throw new PlatformError('rate_limited', platform, `${platform} is rate-limiting requests. Please wait a minute and try again.`, 429);
-    }
-    if (res.status >= 500) {
-      throw new PlatformError('unavailable', platform, `${platform} is currently unavailable (HTTP ${res.status}). Please try again shortly.`, res.status);
-    }
-    if (!res.ok) {
-      throw new PlatformError('unknown', platform, `${platform} returned HTTP ${res.status}`, res.status);
-    }
-    return res;
+    return await api.get<T>(path);
   } catch (err) {
-    if (err instanceof PlatformError) throw err;
-    if (err instanceof DOMException && err.name === 'AbortError') {
-      throw new PlatformError('timeout', platform, `Timed out reaching ${platform}. Please try again.`);
+    if (err instanceof ApiError) {
+      if (err.status === 404) return null;
+      if (err.status === 504) {
+        throw new PlatformError('timeout', platform, `Timed out reaching ${platform}. Please try again.`, 504);
+      }
+      if (err.status === 502 || err.status === 503) {
+        throw new PlatformError('unavailable', platform, `${platform} is currently unavailable. Please try again shortly.`, err.status);
+      }
+      if (err.status === 429) {
+        throw new PlatformError('rate_limited', platform, `Too many requests — please wait a minute and try again.`, 429);
+      }
+      if (err.status === 403) {
+        // ESPN private-league signal — bubble the upstream message through.
+        throw new PlatformError('unknown', platform, err.message || `Access denied by ${platform}`, 403);
+      }
+      throw new PlatformError('unknown', platform, err.message || `Failed to reach ${platform}`, err.status);
     }
-    const msg = err instanceof Error ? err.message : 'Network error';
-    throw new PlatformError('network', platform, `Couldn't reach ${platform}: ${msg}`);
-  } finally {
-    clearTimeout(timer);
+    // ApiError(0, ...) covers "backend unreachable" — surface as a network problem
+    // pointing at our own server rather than the platform.
+    if (err instanceof Error) {
+      throw new PlatformError('network', platform, `Couldn't reach our server: ${err.message}`);
+    }
+    throw new PlatformError('unknown', platform, 'Unknown error');
   }
 }
 
-// Sleeper API - Public API, no auth needed
+// Raw Sleeper response types (returned as-is by our backend proxy)
+interface SleeperUserRaw { user_id: string; username: string; display_name: string }
+interface SleeperLeagueRaw {
+  league_id: string;
+  name: string;
+  season: string;
+  total_rosters: number;
+  scoring_settings?: { rec?: number };
+}
+
+function mapSleeperLeague(league: SleeperLeagueRaw): ExternalLeague {
+  return {
+    externalId: league.league_id,
+    platform: 'sleeper',
+    name: league.name,
+    seasonYear: parseInt(league.season),
+    teamCount: league.total_rosters,
+    scoringFormat: league.scoring_settings?.rec === 1 ? 'ppr' :
+                   league.scoring_settings?.rec === 0.5 ? 'half_ppr' : 'standard',
+  };
+}
+
+// Sleeper API — all calls route through /api/sleeper/* (see platformProxy.ts).
+// Browsers never hit api.sleeper.app directly; that path was killed off because
+// every CORS or ad-blocker hiccup surfaced as "Failed to fetch" with no recovery.
 export const sleeperApi = {
-  // Get user by username. Returns null for 404, throws PlatformError otherwise
-  // so the UI can distinguish "username doesn't exist" from "Sleeper is down".
-  getUser: async (username: string): Promise<{ user_id: string; username: string; display_name: string } | null> => {
-    const res = await platformFetch(`https://api.sleeper.app/v1/user/${encodeURIComponent(username)}`, 'sleeper');
-    if (!res) return null;
-    return res.json();
+  getUser: async (username: string): Promise<SleeperUserRaw | null> => {
+    return proxyGet<SleeperUserRaw>(`/sleeper/user/${encodeURIComponent(username)}`, 'sleeper');
   },
 
-  // Get leagues for a user (fetches last 3 seasons in parallel).
-  // If every season fails the request throws (so the UI doesn't silently
-  // show "no leagues found" when Sleeper is actually down).
   getUserLeagues: async (userId: string): Promise<ExternalLeague[]> => {
-    const currentYear = new Date().getFullYear();
-    const seasons = [currentYear, currentYear - 1, currentYear - 2];
-    const allLeagues: ExternalLeague[] = [];
-    const seen = new Set<string>();
-
-    const results = await Promise.allSettled(
-      seasons.map(season =>
-        platformFetch(`https://api.sleeper.app/v1/user/${userId}/leagues/nfl/${season}`, 'sleeper')
-          .then(res => res ? res.json() as Promise<any[]> : [])
-      )
-    );
-
-    const allRejected = results.every(r => r.status === 'rejected');
-    if (allRejected) {
-      const firstErr = results[0] as PromiseRejectedResult;
-      if (firstErr.reason instanceof PlatformError) throw firstErr.reason;
-      throw new PlatformError('unknown', 'sleeper', 'Failed to fetch Sleeper leagues');
-    }
-
-    for (const r of results) {
-      if (r.status !== 'fulfilled') continue;
-      for (const league of r.value) {
-        const id = league.league_id;
-        if (seen.has(id)) continue;
-        seen.add(id);
-        allLeagues.push({
-          externalId: id,
-          platform: 'sleeper' as Platform,
-          name: league.name,
-          seasonYear: parseInt(league.season),
-          teamCount: league.total_rosters,
-          scoringFormat: league.scoring_settings?.rec === 1 ? 'ppr' :
-                         league.scoring_settings?.rec === 0.5 ? 'half_ppr' : 'standard',
-        });
-      }
-    }
-    return allLeagues;
+    const result = await proxyGet<SleeperLeagueRaw[]>(`/sleeper/user/${encodeURIComponent(userId)}/leagues`, 'sleeper');
+    if (!result) return [];
+    return result.map(mapSleeperLeague);
   },
 
-  // Get league details
   getLeague: async (leagueId: string): Promise<ExternalLeague | null> => {
-    const res = await platformFetch(`https://api.sleeper.app/v1/league/${encodeURIComponent(leagueId)}`, 'sleeper');
-    if (!res) return null;
-    const league = await res.json();
-    return {
-      externalId: league.league_id,
-      platform: 'sleeper',
-      name: league.name,
-      seasonYear: parseInt(league.season),
-      teamCount: league.total_rosters,
-      scoringFormat: league.scoring_settings?.rec === 1 ? 'ppr' :
-                     league.scoring_settings?.rec === 0.5 ? 'half_ppr' : 'standard',
-    };
+    const league = await proxyGet<SleeperLeagueRaw>(`/sleeper/league/${encodeURIComponent(leagueId)}`, 'sleeper');
+    if (!league) return null;
+    return mapSleeperLeague(league);
   },
 
-  // Get rosters for a league
-  getRosters: async (leagueId: string): Promise<SleeperRoster[]> => {
-    const res = await platformFetch(`https://api.sleeper.app/v1/league/${encodeURIComponent(leagueId)}/rosters`, 'sleeper');
-    if (!res) return [];
-    return res.json();
+  // The roster/users endpoints below are kept for the (currently unused)
+  // direct-from-browser code path but would also benefit from proxying if
+  // anything starts calling them. The backend sync path uses Sleeper directly
+  // (no CORS exposure there), so adding proxy routes for them isn't urgent.
+  getRosters: async (_leagueId: string): Promise<SleeperRoster[]> => {
+    console.warn('[sleeperApi.getRosters] not yet proxied; not callable from browser');
+    return [];
   },
-
-  // Get users in a league
-  getLeagueUsers: async (leagueId: string): Promise<SleeperLeagueUser[]> => {
-    const res = await platformFetch(`https://api.sleeper.app/v1/league/${encodeURIComponent(leagueId)}/users`, 'sleeper');
-    if (!res) return [];
-    return res.json();
+  getLeagueUsers: async (_leagueId: string): Promise<SleeperLeagueUser[]> => {
+    console.warn('[sleeperApi.getLeagueUsers] not yet proxied; not callable from browser');
+    return [];
   },
 };
 
-// ESPN API - public leagues only (private leagues require SWID/ESPN_S2 cookies — TODO)
+// ESPN API — public leagues via /api/espn/league/:id. Private leagues
+// (requiring SWID/ESPN_S2 cookies) surface as a 403 from the proxy, which
+// proxyGet() maps to PlatformError('unknown', 'espn', ..., 403).
 export const espnApi = {
   getLeague: async (leagueId: string, season: number = new Date().getFullYear()): Promise<ExternalLeague | null> => {
-    const res = await platformFetch(
-      `https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl/seasons/${season}/segments/0/leagues/${encodeURIComponent(leagueId)}?view=mSettings`,
-      'espn'
-    );
-    if (!res) return null;
-    const data = await res.json();
+    interface EspnLeagueRaw {
+      settings?: {
+        name?: string;
+        size?: number;
+        scoringSettings?: { scoringItems?: Array<{ statId: number; points: number }> };
+      };
+    }
+    const data = await proxyGet<EspnLeagueRaw>(`/espn/league/${encodeURIComponent(leagueId)}?year=${season}`, 'espn');
+    if (!data) return null;
     const settings = data.settings;
-    const scoringSettings = settings?.scoringSettings;
+    const scoringItems = settings?.scoringSettings?.scoringItems;
 
     let scoringFormat = 'standard';
-    if (scoringSettings?.scoringItems) {
-      // statId 53 is the reception stat — points per reception determines PPR/Half/Std
-      const recItem = scoringSettings.scoringItems.find((item: { statId: number; points: number }) => item.statId === 53);
+    if (scoringItems) {
+      // statId 53 = reception stat → points-per-reception determines format
+      const recItem = scoringItems.find((item) => item.statId === 53);
       if (recItem) {
         if (recItem.points === 1) scoringFormat = 'ppr';
         else if (recItem.points === 0.5) scoringFormat = 'half_ppr';
@@ -236,20 +216,22 @@ export const espnApi = {
   },
 };
 
-// MFL API - Public API (league ID + year)
+// MFL API — public read via /api/mfl/league/:id.
 export const mflApi = {
   getLeague: async (leagueId: string, season: number = new Date().getFullYear()): Promise<ExternalLeague | null> => {
-    const res = await platformFetch(
-      `https://api.myfantasyleague.com/${season}/export?TYPE=league&L=${encodeURIComponent(leagueId)}&JSON=1`,
-      'mfl'
-    );
-    if (!res) return null;
-    const data = await res.json();
-    const league = data?.league;
+    interface MflLeagueResponse {
+      league?: {
+        name?: string;
+        franchises?: { franchise?: Array<unknown> | unknown };
+      };
+    }
+    const data = await proxyGet<MflLeagueResponse>(`/mfl/league/${encodeURIComponent(leagueId)}?year=${season}`, 'mfl');
+    if (!data) return null;
+    const league = data.league;
     if (!league) return null;
 
     const franchises = Array.isArray(league.franchises?.franchise)
-      ? league.franchises.franchise
+      ? league.franchises!.franchise
       : league.franchises?.franchise ? [league.franchises.franchise] : [];
 
     return {


### PR DESCRIPTION
## Why

User reports of `Couldn't reach sleeper: Failed to fetch` during the Connect League flow, with a valid Sleeper username:

> *(screenshot in chat — username `yosefu123`, network error)*

PR #227 made the underlying error visible (previously silenced as "User not found"). This PR fixes the underlying error.

The browser was calling `https://api.sleeper.app/v1/user/:username` directly. "Failed to fetch" is the browser's generic error for any fetch that fails *before* a response arrives — CORS, CSP, mixed-content, ad-blockers, geographic blocks, or a transient upstream outage. Without browser DevTools we can't pin down the exact cause for any given user, but **all of those failure modes go away if the browser only ever talks to our own origin**.

## What

New file `server/src/routes/platformProxy.ts` adds thin proxy endpoints:

| Method | Path | Notes |
|---|---|---|
| GET | `/api/sleeper/user/:username` | Look up by username |
| GET | `/api/sleeper/user/:userId/leagues` | Combines last 3 seasons server-side, dedupes by `league_id` |
| GET | `/api/sleeper/league/:leagueId` | League details by ID |
| GET | `/api/espn/league/:leagueId?year=YYYY` | Public ESPN read; 401/403 → 403 `ESPN_PRIVATE` |
| GET | `/api/mfl/league/:leagueId?year=YYYY` | Public MFL read |

All proxy endpoints share:
- `authMiddleware` (Connect flow is logged-in only)
- 30 req/min/IP rate limit
- 10s upstream `AbortController` timeout
- Path-param validation: `/^[a-zA-Z0-9_.-]+$/`, max 32 chars — prevents SSRF / weird URL injection
- Status translation: `404→404`, `401/403→403`, `5xx→502`, `timeout→504`, other→`502`

Frontend (`src/services/leagueConnect.ts`):
- `platformFetch` (direct upstream) replaced with `proxyGet` that routes through our `api` client and re-throws `ApiError` as the existing `PlatformError` so all UI error handling keeps working unchanged.
- `sleeperApi.getRosters` / `getLeagueUsers` reduced to no-op stubs with a console warning — they were never called from the browser in the connect flow.

Backend sync handlers in `routes/leagues.ts` (`/:id/sync`, `/:id/sync/quick`) still call upstreams directly. They run server-side, so no CORS exposure there.

## Test plan

- [ ] Production deploy: connect a Sleeper league via username lookup → confirm the username step succeeds where it currently fails with "Failed to fetch".
- [ ] Connect a public ESPN league by ID → confirm fetch + connect + sync still work.
- [ ] Connect a public MFL league by ID → same.
- [ ] Try a private ESPN league → confirm "ESPN league is private. Make it public in ESPN settings." surfaces.
- [ ] Spam the username lookup 30+ times in a minute → confirm 429 from the rate limiter, not 5xx.
- [ ] Verify no regressions on the Yahoo OAuth flow (untouched, included only for the index.ts diff).

## Security review

- Path params validated against a strict regex + 32-char cap → no SSRF.
- All endpoints behind auth → can't be abused as a free Sleeper proxy.
- Rate limit prevents single-IP abuse.
- No response caching → no risk of leaking one user's lookup to another.

https://claude.ai/code/session_01EtGbwCCmrXKUYAJ8fy4hZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtGbwCCmrXKUYAJ8fy4hZ1)_