### PR TITLE
Add prioritized TODO.md of remaining work

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -128,14 +128,21 @@ Click-to-add real draft picks (with original-owner info) in the builder, instead
 
 ## P3 — Draft Rankings: Enhancements
 
+> **Status (post-cleanup sprint):** The cleanup sprint ripped out `Math.sin`-derived fake data columns and several buttons are still rendered in `DraftRankingsView.tsx` as visible-but-inert placeholders (Compare, Export, Ask AI, Watch, Trade value, Add to compare). Wiring the buttons below has gone from "nice-to-have polish" to "finish the visible UI." Tackle the button-wiring items first, then the data-infrastructure ones.
+
+### Button wiring (visible dead UI — do first)
+- [ ] **Compare drawer (up to N)** (~1 day frontend) — `+ Compare (0)` header button opens side-drawer with 2–4 players side-by-side. Client-side `selectedForCompare: Set<string>` threaded through `PlayerRow` with hover checkbox. Reuse expanded-row panel markup per column. Pair with the per-row "Add to compare" button (same state).
+- [ ] **Export rankings** (~2h) — CSV download of current filtered rankings (`#, Player, Position, Team, ProjPts, ADP, ValueDelta, Tier, Analysis`). Pure frontend `data:text/csv` blob. Smallest cheap win — wires up the dead Export button.
+- [ ] **"Ask AI about draft" button** (~half day) — Quick chat modal against currently loaded rankings ("who should I draft at pick 5?"). Reuse `/trades/follow-up` pattern via new `/draft-rankings/ask` endpoint. Pro/Elite gated.
+- [ ] **Watch / watchlist** (~1 day frontend + backend) — Per-row "Watch" button persists to a new `user_player_watchlist` table (auth-gated). Frontend shows a saved indicator + a filter chip "Watching only". Same pattern reusable across PlayerCard, Board, etc.
+- [ ] **Trade value link** (~1h) — Per-row "Trade value" button opens the Trade Analyzer pre-populated with that player on the user's side. Just a routing handler + query param — no new backend needed.
+
+### Data infrastructure (real metrics behind the columns we removed)
 - [ ] **4-week trend sparkline** (~half day frontend + 1-day backend) — `rank_history` table keyed on `(playerId, scoringFormat, superflex, rankingType, snapshotDate)`, daily cron snapshots from `draft_rankings`. Extend `/draft-rankings` to return `recentRanks: number[]`. Inline 60×20 SVG path in TREND slot.
 - [ ] **24h / 7d / 30d / Preseason Open rank movement** (~4h frontend if rank_history exists) — Four deltas in expanded row's `Rank Movement` panel. Green up, red down. Depends on sparkline task landing first.
 - [ ] **Ceiling / Floor** (~half day backend) — Extend AI generator in `server/src/services/draftRankings.ts` to emit `ceilingRank` and `floorRank`, store on `draft_rankings`, surface in response.
 - [ ] **Detailed projection breakdown in expanded row** (~1 day) — PPG, Rush Yds, Rush TDs, Rec, Rec Yds per player. Either join `player_projections` at query time or snapshot stats onto `draft_rankings` row at generation.
 - [ ] **ECR (Expert Consensus Rank) + Best Ball ADP** (~2 days) — New `player_external_ranks` table. ECR via FantasyPros API (gated). Best Ball ADP via Underdog (friendly) or DraftKings (fragile). Surface in `Draft Value` panel.
-- [ ] **Compare drawer (up to N)** (~1 day frontend) — `+ Compare (0)` header button opens side-drawer with 2–4 players side-by-side. Client-side `selectedForCompare: Set<string>` threaded through `PlayerRow` with hover checkbox. Reuse expanded-row panel markup per column.
-- [ ] **Export rankings** (~2h) — CSV download of current filtered rankings (`#, Player, Position, Team, ProjPts, ADP, ValueDelta, Tier, Analysis`). Pure frontend `data:text/csv` blob.
-- [ ] **"Ask AI about draft" button** (~half day) — Quick chat modal against currently loaded rankings ("who should I draft at pick 5?"). Reuse `/trades/follow-up` pattern via new `/draft-rankings/ask` endpoint. Pro/Elite gated.
 - [ ] **Redraft / Dynasty / Rookie three-way split** (~3h backend + 1h frontend) — Current backend bundles Dynasty + Rookie as `dynasty_rookie`. Split into three independent ranking types. Existing rows stay until regenerated.
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,218 @@
+# FilmRoom Fantasy — TODO
+
+Every outstanding item from `BACKLOG.md`, re-prioritized end-to-end. Completed work and historical context live in `BACKLOG.md`; this file is what's left to finish.
+
+Snapshot: 2026-05-20.
+
+Priority tiers:
+- **P0** — Launch blockers. Must ship before public.
+- **P1** — Core feature gaps. Visible holes a user will hit.
+- **P2** — Quality, polish, audits.
+- **P3** — Feature expansion (AI surfaces, new pages, finder/rankings depth).
+- **P4** — SEO follow-through (standalone player page is live; the rest of the org-search lever isn't).
+- **P5** — Monetization infrastructure. Hard prereq for any paid feature.
+- **P6** — Premium features and future / optional work.
+
+---
+
+## P0 — Launch Blockers
+
+- [ ] **Finish Google OAuth setup** — Obtain real Google OAuth Client ID from Google Cloud Console, set `GOOGLE_CLIENT_ID` in `server/.dev.vars` and `VITE_GOOGLE_CLIENT_ID` in `.env`, configure authorized origins/redirect URIs, run `wrangler secret put GOOGLE_CLIENT_ID` for production. Code is wired; only the credential is missing.
+- [ ] **Mobile optimization** — Comprehensive pass: touch targets, table scrolling, modal sizing, bottom nav, responsive breakpoints across every view. Largest single user-experience risk for launch.
+
+---
+
+## P1 — Core Feature Gaps
+
+### Player Card
+- [ ] **Quick actions (Alert / Pin / Compare / Share)** — Re-add the four action buttons with real functionality. Were removed because they were non-functional stubs.
+- [ ] **FilmRoom Insights working** — Wire up the FilmRoom Insights section on player cards to display real analysis data.
+- [ ] **Projection breakdown working** — Real breakdown of projected points by stat category (pass yards, rush yards, receptions, TDs, etc.).
+- [ ] **Matchup page insights working** — Re-add the FilmRoom Edge Analysis section on the Matchup page with real data-driven insights (position advantages, start/sit suggestions, injury alerts). Was removed because it was hardcoded fake content.
+
+### Notifications
+- [ ] **Working notifications** — Real push/in-app notifications for injuries, lineup locks, trade offers, waiver results. Bell icon already in header with "coming soon" tooltip; needs backend + delivery.
+
+### Data & Rankings
+- [ ] **Draft rankings** — Pre-draft player rankings with tiers, positional scarcity, ADP comparison. Sidebar nav item removed for beta — re-add `{ icon: Medal, label: 'Draft Rankings', view: 'DraftRankings' }` to `Sidebar.tsx` menuItems. Route and `ComingSoonView` still exist in `App.tsx`.
+- [ ] **Season projections** — Full-season projected stats and fantasy point totals for all players, updated weekly.
+- [ ] **Top waiver pickups from multiple platforms** — Source trending waiver pickups from Sleeper, ESPN, and Yahoo for better consensus recommendations.
+
+---
+
+## P2 — Quality, Polish, Audits
+
+### Code audits — views
+Each component: bugs, hardcoded/fake data, unused code, missing error handling, a11y (aria, keyboard nav), type safety, performance (memoization, key props), memory leaks.
+
+- [ ] **TeamView** — Roster display, player cards, team stats
+- [ ] **WaiversView** — Waiver claims, player search, bid management
+- [ ] **GameSlateView + GameDetailModal** — NFL schedule, live scores, game detail overlay
+- [ ] **TrendsView** — Roster trends, projection movers
+- [ ] **AllPlayersView** — Full player list with filters, pagination
+- [ ] **ProfileView** — User profile, password change, Google link status
+- [ ] **LoginView + RegisterView + ForgotPasswordView** — Auth forms, rate limiting, Google OAuth
+- [ ] **PlayerCard** — Player detail modal, game log, stats, matchup grade, projections
+
+### Code audits — shared components
+- [ ] **Sidebar** — Navigation, responsive collapse, active state
+- [ ] **Header + LeagueManager** — Search bar, league switcher dropdown, notifications bell
+- [ ] **PlayerAvatar** — Image loading, fallback initials
+- [ ] **NewsPanel + NewsSnippet + BiggestMovers** — News feed, player movers widget
+- [ ] **ErrorBoundary** — Error catch/display, recovery
+- [ ] **App.tsx** — Routing, state management, context wiring, page transitions
+
+### Polish
+- [ ] **Page-by-page polish pass** — Tighten loading states, empty states, error messages, micro-animations, hover states, focus rings, typography/spacing consistency. Audit each view for "feels finished vs. feels prototype" gaps across HomeView, Board, Matchup, GameSlate, Trends, AllPlayers, Team, Waivers, PlayoffPredictor, TradeAnalyzer, TradeHistory, TradeFinder, DraftRankings, Settings, Profile, LeagueAnalyzer (new), standalone player page.
+
+---
+
+## P3 — Trade Finder: API Cost & Rate-Limit Hardening
+
+Reduce Anthropic API pressure on `/trade-finder/recommendations` (currently 6–10 parallel Claude calls per cold request). Ordered by impact-vs-effort.
+
+- [ ] **Enable Anthropic prompt caching on static system prompts** (~1h) — Biggest win, ~50-60% input token reduction. Add `cache_control: { type: 'ephemeral' }` to system prompt blocks in `tradeConstructor.ts` (`constructTrades`), `tradeAnalyzer.ts` (`analyzeTrade`), and `tradeFinder.ts` (`buildTeamNeeds`). Requires converting `system:` strings to content-block arrays.
+- [ ] **Drop `maxRecommendations` from 8 to 5** (~5min) — `routes/tradeFinder.ts:354`. Cuts verification calls by 37%.
+- [ ] **Split rate limits per trade-finder endpoint** (~10min) — `/needs` keeps 20/min, `/recommendations` drops to 5/min per user.
+- [ ] **Persist verification results in `trade_verifications` table** (~2h) — Key by `(sortedSendIds + sortedReceiveIds + picksHash + leagueType + seasonYear + currentWeek)`. Look up the hash before calling `analyzeTrade`. Kills redundant grading across searches.
+- [ ] **Share `LeagueContextSnapshot` across users in the same league** (~half day) — Cache in D1 or KV keyed by `(leagueId, latestSyncTimestamp)`. Saves ~50–100ms D1 per request and reduces multi-user load.
+- [ ] **Lazy verification** (~half day) — Verify top 3 by deterministic `valueImbalancePct` first, stream them back. Lazy-verify next 5 only on "show more." Cuts verification calls ~60% for non-scrollers.
+- [ ] **Move constructor to Haiku** (~30min + regression testing) — Constructor reasoning is simpler than verification. Test that Haiku follows ID-echo and packaging rules reliably. Keep Sonnet for the analyzer.
+- [ ] **Cloudflare Queues for verification fan-out** (~1 day) — Move verification calls behind a queue with producer rate cap. Only needed at real scale.
+
+---
+
+## P3 — Trade Finder: Discovery Enhancements
+
+> Most require the existing mega-call path to be stable first.
+
+- [ ] **"Target a specific player" UI entry point** (~half day) — Collapsible panel in `TradeFinderView.tsx` with searchable combobox of every non-user player. Runs a single focused construction call for that exact player. Extend `RecommendationsBody` with `targetPlayerId`, thread through `findTradeRecommendations`, bump `CACHE_VERSION`.
+- [ ] **Historical league-specific trade anchors** (~1 day) — `tradeIngest.ts` + `tradeOutcomes.ts` already ingest accepted trades into the `trades` table but finder never reads them. Pull 3 most recent accepted trades for the user's league and inject as calibration examples in the constructor prompt. Add `getRecentAcceptedTradesForLeague(leagueId, limit)` helper.
+- [ ] **Per-target parallel fan-out discovery** (~1–2 days) — Scrapped in commits c638590/cfbe354 (reverted in ef13304) because the prompt was too aggressive about returning null. Retry once mega-call path is stable and prompt caching is enabled. Lessons: (a) per-target prompt needs encouraging framing not "null is valid"; (b) gate 4 must relax with required assets; (c) same ID-echo bug applies and must be fixed per call.
+- [ ] **Expand matcher package shapes beyond 2-for-1** (~half day) — `tradeMatcher.ts` only builds 1-for-1, 2-for-1, 1-for-2. Extend `tryBuildPair()` for 2-for-2, 3-for-1, 3-for-2 with size cap (~5 per side). Deterministic, doesn't hit AI.
+- [ ] **Follow-up conversation refinement for finder results** (~1 day) — Reuse the existing `/follow-up` endpoint from `TradeFinderView` so users can iterate ("show me cheaper options", "don't touch my RB1") without re-running the pipeline.
+- [ ] **Empty-state diagnostic surface** (~2h) — When finder returns zero trades, expose stage counts (raw constructor output, validation drops, gate 4 drops) in response as a `diagnostics` field. Collapsible "Why no trades?" panel.
+- [ ] **Manual refresh button for scouting report** (~30min) — Small refresh icon next to "Your Team Needs" heading in `TradeFinderView.tsx` that clears the saved row and triggers a fresh scout. Escape hatch after injury news or wrong assessment.
+
+---
+
+## P3 — Trade Analyzer: Draft Pick Inventory
+
+Click-to-add real draft picks (with original-owner info) in the builder, instead of typing them via the year/round modal. Caveat: Sleeper/MFL don't expose exact pick slots mid-season — only year + round + original owner. UI should show `2026 1st (originally Team Y's)`.
+
+- [ ] **Phase 1 — Sleeper MVP** (~400–500 LOC across schema + service + routes + UI):
+  - New `team_draft_picks` table keyed on `(leagueId, draftYear, draftRound, originalOwnerId)` with mutating `ownerId` so pick chains collapse to current ownership. Columns: `id`, `leagueId`, `ownerId`, `originalOwnerId`, `draftYear`, `draftRound`, `acquiredVia` ('native' | 'trade'), timestamps.
+  - New `syncDraftPicks(leagueId, externalLeagueId)` in `server/src/services/sleeper.ts`: seed native ownership for current + 3 future years × rounds 1–N, then overlay `/league/{externalId}/traded_picks`. Comment scaffold already at `sleeper.ts:1-5`.
+  - Wire into existing league-refresh in `server/src/routes/leagues.ts:6-26` alongside rosters/schedule. Optional `POST /api/admin/sync-draft-picks/:leagueId`.
+  - Extend `buildTeamRoster()` in `server/src/routes/rosters.ts` so `TeamRosterOut` gains sorted `picks: Array<{ year, round, originalOwnerId, originalOwnerName, isNative }>`. Same `/api/rosters/:leagueId/all` endpoint.
+  - Frontend: extend `TradeTeamCard` in `src/components/TradeAnalyzerView.tsx` with "Roster & picks" collapsible (expanded on user's card, collapsed on opponents). Two chip rows: Players (click → sends) and Picks (`2026 1st` or `2026 1st (via Team Y)`). Add optional `originalOwnerName` to `TradeAsset`.
+- [ ] **Phase 2 — MFL parity** (~200 LOC) — MFL has `?TYPE=futureDraftPicks&JSON=1` but `server/src/services/mfl.ts` doesn't call it. Mirror Phase 1. Verify response schema against a real MFL league first.
+- [ ] **Phase 3 — ESPN / Yahoo** (DEFERRED) — Neither platform has league sync today (ESPN is NFL game data only, Yahoo is OAuth-only). Pick sync becomes a small additive step once broader integration lands.
+
+---
+
+## P3 — Draft Rankings: Enhancements
+
+- [ ] **4-week trend sparkline** (~half day frontend + 1-day backend) — `rank_history` table keyed on `(playerId, scoringFormat, superflex, rankingType, snapshotDate)`, daily cron snapshots from `draft_rankings`. Extend `/draft-rankings` to return `recentRanks: number[]`. Inline 60×20 SVG path in TREND slot.
+- [ ] **24h / 7d / 30d / Preseason Open rank movement** (~4h frontend if rank_history exists) — Four deltas in expanded row's `Rank Movement` panel. Green up, red down. Depends on sparkline task landing first.
+- [ ] **Ceiling / Floor** (~half day backend) — Extend AI generator in `server/src/services/draftRankings.ts` to emit `ceilingRank` and `floorRank`, store on `draft_rankings`, surface in response.
+- [ ] **Detailed projection breakdown in expanded row** (~1 day) — PPG, Rush Yds, Rush TDs, Rec, Rec Yds per player. Either join `player_projections` at query time or snapshot stats onto `draft_rankings` row at generation.
+- [ ] **ECR (Expert Consensus Rank) + Best Ball ADP** (~2 days) — New `player_external_ranks` table. ECR via FantasyPros API (gated). Best Ball ADP via Underdog (friendly) or DraftKings (fragile). Surface in `Draft Value` panel.
+- [ ] **Compare drawer (up to N)** (~1 day frontend) — `+ Compare (0)` header button opens side-drawer with 2–4 players side-by-side. Client-side `selectedForCompare: Set<string>` threaded through `PlayerRow` with hover checkbox. Reuse expanded-row panel markup per column.
+- [ ] **Export rankings** (~2h) — CSV download of current filtered rankings (`#, Player, Position, Team, ProjPts, ADP, ValueDelta, Tier, Analysis`). Pure frontend `data:text/csv` blob.
+- [ ] **"Ask AI about draft" button** (~half day) — Quick chat modal against currently loaded rankings ("who should I draft at pick 5?"). Reuse `/trades/follow-up` pattern via new `/draft-rankings/ask` endpoint. Pro/Elite gated.
+- [ ] **Redraft / Dynasty / Rookie three-way split** (~3h backend + 1h frontend) — Current backend bundles Dynasty + Rookie as `dynasty_rookie`. Split into three independent ranking types. Existing rows stay until regenerated.
+
+---
+
+## P3 — Player Rankings: Enhancements
+
+- [ ] **4-week trend sparkline in TREND column** (~half day frontend + 1-day backend) — Extend `/players` response with `recentWeeklyScores: number[]` (last 4, most recent last). 60×20 SVG path in TREND. Falls back to existing delta pill when empty.
+- [ ] **Expanded player row with stat breakdown + AI take** (~1–2 days) — In-place row expand with 4 columns: PASSING/RUSHING/RECEIVING (per position), SEASON AVG (PPG + position rank), FILMROOM AI TAKE (1–2 paragraph analysis + Trade value / Full game log buttons). Two pieces: (a) expose per-player weekly stats in `/players` list, (b) weekly board-scoped AI analysis endpoint. AI take Pro/Elite gated.
+- [ ] **"Your Roster" right sidebar on Board view** (~1 day frontend + small LeagueContext plumbing) — Swap the existing 1/3 right column (`NewsPanel` + `BiggestMovers`) for `RosterWeekPanel` (starters + current scores + position rank + Full lineup link) and `RosterOverUnderPanel` (boom/bust tally for current week) when user has a connected league. Keep existing sidebar as fallback for un-synced users.
+- [ ] **"YOUR TEAM" row highlight + badge** (~2h) — Blue left-border + "YOUR TEAM" pill on owned-player rows. Derive from `LeagueContext.roster`. Pure frontend.
+- [ ] **Week prev/next arrows + "Full Season" toggle** (~3h) — Replace week dropdown with `< Week N >` chevrons + Full Season pill (flips to season totals via existing `seasonStats` support).
+- [ ] **Header action buttons: Export + Ask AI** (~3h total) — Export (~1h) CSV of filtered rankings. Ask AI (~2h) chat modal seeded with current week + scoring format + filtered players. New `/players/ask` endpoint. Pro/Elite gated.
+- [ ] **Page breadcrumb: "Rankings / Player Rankings"** (~1h) — Small `Breadcrumb` component mapping `activeView` → parent section. Useful beyond just this view.
+- [ ] **Header subtitle with player count + week context** (~1h) — "2025 Season · Week 1 (Final) · Actual points scored · 883 players". Pull `totalPlayers` from existing `/players` response.
+
+---
+
+## P3 — AI Surfaces & New Pages
+
+- [ ] **League Analyzer page with AI team analyzer** — New top-level view auditing the user's league: team-by-team strength grades, positional surplus/deficit, schedule difficulty ROS, championship odds, AI-generated narrative per team ("biggest strength", "biggest hole", "most likely to fall off", "trade target fits"). Reuses Monte Carlo from PlayoffPredictorView + trade-finder's `LeagueContextSnapshot`. Sidebar nav already exists as "Coming Soon" placeholder. Pro/Elite gated.
+- [ ] **AI analysis of players** — 1–2 paragraph per-player take in PlayerCard modal AND standalone player page. Covers recent form, matchup, role/usage trend, start/sit recommendation. Cache by `(playerId, week, season)`. Reuse prompt/model setup from `server/src/services/draftRankings.ts`. Pro/Elite gated.
+- [ ] **AI post-game analysis** — Short AI recap per finalized NFL game focused on fantasy takeaways (exceeded/missed expectations, target share/carry shifts, injury-driven role changes, waiver implications). Surfaced on GameDetailModal and user matchup recap. Cron triggers on `gameStatus === 'final'` transitions. Cache per `(gameId, season, week)`.
+- [ ] **AI chat assistant** — Persistent chat bubble (bottom-right) answering fantasy questions in user's league context: roster, matchup, waivers, trades, start/sit. Reuses `LeagueContextSnapshot`. Streamed responses, persisted history. Entry points from PlayerCard ("Ask about Josh Allen"), Matchup ("Who should I start?"), Trade Analyzer follow-ups. Pro/Elite gated.
+- [ ] **Finish odds movement tracking on Trends** — Third tab on TrendsView: "Odds Movement" — player prop line movement (over/under yardage, anytime TD, receptions). External odds source (DraftKings/FanDuel public or paid like The Odds API). New `player_prop_lines` table keyed on `(playerId, propType, sportsbook, capturedAt)` with daily-or-better cron. Per-player chip: current line, opening line, % change, sparkline. Consolidates with LOW item "Trends based on player prop movements" and MEDIUM "Projection breakdown working."
+
+---
+
+## P4 — SEO Follow-Through
+
+Standalone player page route (`/players/:slug-:id`) shipped in commit `21de3f3` (`src/components/PlayerProfileView.tsx`). The "View full profile →" modal link is implied as done — verify and check off. Everything below is the actual indexability work.
+
+- [ ] **Extend `scripts/generate-static-pages.js`** to emit one static HTML per rostered skill player (~300–400) at build time, seeded from `nfl_players` + recent stats/projections. Makes pages instantly indexable on Cloudflare Pages (no JS render wait).
+- [ ] **Semantic markup on the player page** — `<h1>{name}</h1>`, `<h2>` section headers (Projections, Matchup, Recent News, Season Stats, Props History), proper `<table>` / `<th scope="col">` for stat rows.
+- [ ] **`schema.org` JSON-LD** on each page — `Person` + `Athlete` with `name`, `affiliation` (team), `jobTitle` (position), `memberOf` (NFL league). Enables rich snippets.
+- [ ] **Per-page `<title>` and meta description** — Templated `{Name} Fantasy Stats, Projections & News | FilmRoom Fantasy` and 150-char summary with top stat + team + position.
+- [ ] **Open Graph + Twitter card tags per player** — Shared links render rich previews (name, headshot, recent stat line).
+- [ ] **Canonical URL** — `/players/josh-allen-6802` (slug + sleeper-id) so the same player can't be duplicated under multiple slugs.
+- [ ] **Add player URLs to `public/sitemap.xml`** (or generate dynamically) — Google discovers them without crawling the app.
+- [ ] **`<link rel="alternate">`** from in-app modal URL state to the player page — preserves SEO intent during in-app navigation.
+
+---
+
+## P5 — Monetization Infrastructure
+
+Hard prereq for any paid feature in P6. Stripe + DB columns + gating must land before any tier-locked feature ships.
+
+- [ ] **Integrate Stripe for payments**
+- [ ] **Add `subscription_tier` and `subscription_expires_at` columns** to `users` table
+- [ ] **Add feature gating middleware** — check JWT claims for plan tier
+- [ ] **Restore Membership section in ProfileView** — entire card + `membershipPlan` state removed from `ProfileView.tsx` for beta. Re-add between password section and logout button, wire Upgrade/Manage plan to Stripe.
+- [ ] **Build upgrade / downgrade / cancellation flow**
+- [ ] **Add billing webhook handlers** (Stripe events)
+
+---
+
+## P6 — Premium Features (Pro Tier, $4.99/mo)
+
+- [ ] **AI Trade Analyzer** — GPT-powered "Who wins this trade?" with ROS projections. Sidebar nav item removed for beta — re-add `{ icon: ArrowRightLeft, label: 'Trade Analyzer', view: 'TradeAnalyzer' }` to `Sidebar.tsx` menuItems. Route + `ComingSoonView` still exist.
+- [ ] **Start/Sit Optimizer** — Matchup-based lineup recommendations (weather, Vegas lines, defensive rankings)
+- [ ] **Waiver Wire Rankings** — Priority-ranked targets with FAAB bid suggestions
+- [ ] **Advanced Projections** — Multi-source consensus (ESPN, FantasyPros, PFF) with trend graphs
+- [ ] **Custom Alerts** — Push/email notifications for injuries, lineup locks, stat milestones
+- [ ] **Snap Count Analytics** — Usage trend charts (target share, snap %, red zone opportunities)
+
+## P6 — Premium Features (Elite Tier, $9.99/mo)
+
+- [ ] **Multi-League Dashboard** — Unified view across leagues with player exposure tracking
+- [ ] **Playoff Probability Engine** — Monte Carlo of remaining schedule (PlayoffPredictorView already runs Monte Carlo; this would be the multi-league / elite-tier variant)
+- [ ] **DFS Lineup Optimizer** — Salary cap optimizer for DraftKings/FanDuel
+- [ ] **Live Draft Assistant** — Real-time ADP comparison, positional scarcity, best available
+- [ ] **Opponent Scouting Report** — Weekly opponent roster strengths/weaknesses
+- [ ] **Dynasty Rankings & Age Curves** — Long-term valuations for keeper/dynasty
+- [ ] **Historical Splits Database** — Multi-season splits (home/away, indoor/outdoor, division, primetime)
+
+## P6 — One-Time Purchases
+
+- [ ] **Draft Kit ($14.99)** — Pre-draft tiers, mock draft simulator, printable cheat sheets
+- [ ] **Playoff Bundle ($4.99)** — Enhanced bracket predictor, championship-week optimal lineups
+- [ ] **Commissioner Toolkit ($7.99)** — League history archive, all-time records, custom trophies/awards
+
+---
+
+## P6 — Future / Optional
+
+- [ ] **Trends based on player prop movements** — Folded into "Finish odds movement tracking on Trends" in P3 above. Drop this duplicate once that ships.
+- [ ] **Email collection for newsletter** — Signup form for weekly newsletter (waiver targets, start/sit, injuries).
+- [ ] **Ad integration** — Evaluate non-intrusive ad placements (sidebar banners, interstitial between views) for free-tier monetization.
+
+---
+
+## Notes
+
+- This file is a snapshot. Source of truth for new ideas + completed history remains `BACKLOG.md`.
+- When something here ships, check it off here AND mirror to `BACKLOG.md` so the historical record stays accurate.
+- Several P3 trade-finder hardening items are <1h each and would meaningfully reduce ongoing Anthropic spend — consider knocking out prompt caching, the 8→5 drop, and the rate-limit split as a single "trade-finder cost reduction" PR before anything else in P3.

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,20 @@ Priority tiers:
 
 ---
 
+## Current Focus
+
+Active sprint — work these next, in roughly this order. Each links into the detailed entries below.
+
+1. **AI systems foundation** — Ask AI chat assistant, AI post-game analysis, ROS rankings from AI, per-player AI take. (see P3 — AI Surfaces)
+2. **Implement League Analyzer** — Real page replacing the "Coming Soon" placeholder. (see P3 — AI Surfaces)
+3. **Fix draft rankings** — Restore sidebar nav + finish the rankings feature (tiers, ADP, projections). Then layer the P3 enhancements. (see P1 + P3 — Draft Rankings)
+4. **Fix Trends page** — Page is broken / incomplete. Audit + add "Recent Best Performers" as a new tab alongside Roster Trends / Projection Movers / Odds Movement. (see P2 audit + new P3 item below)
+5. **Polish Game Slate + GameDetailModal** — Audit + visual polish pass. (see P2 audit)
+6. **Polish standalone player page + Player modules** — PlayerCard, PlayerProfileView, PlayerAvatar, projection breakdown, FilmRoom Insights, quick actions. (see P1 player card + P2 audits)
+7. **Consistent UI / design system pass** — Establish shared tokens (spacing, type, color, radius, shadow, focus, motion) and apply across every view. (see new P2 entry)
+
+---
+
 ## P0 — Launch Blockers
 
 - [ ] **Finish Google OAuth setup** — Obtain real Google OAuth Client ID from Google Cloud Console, set `GOOGLE_CLIENT_ID` in `server/.dev.vars` and `VITE_GOOGLE_CLIENT_ID` in `.env`, configure authorized origins/redirect URIs, run `wrangler secret put GOOGLE_CLIENT_ID` for production. Code is wired; only the credential is missing.
@@ -63,7 +77,8 @@ Each component: bugs, hardcoded/fake data, unused code, missing error handling, 
 - [ ] **App.tsx** — Routing, state management, context wiring, page transitions
 
 ### Polish
-- [ ] **Page-by-page polish pass** — Tighten loading states, empty states, error messages, micro-animations, hover states, focus rings, typography/spacing consistency. Audit each view for "feels finished vs. feels prototype" gaps across HomeView, Board, Matchup, GameSlate, Trends, AllPlayers, Team, Waivers, PlayoffPredictor, TradeAnalyzer, TradeHistory, TradeFinder, DraftRankings, Settings, Profile, LeagueAnalyzer (new), standalone player page.
+- [ ] **Consistent UI / design system pass** — Establish a shared token set and apply across every view before doing the per-page polish below. Tokens to nail down: spacing scale (4/8/12/16/24/32/48), type ramp (display / h1 / h2 / h3 / body / caption / mono), color tokens (surface tiers, border tiers, text primary/secondary/muted, semantic success/warning/error/info, accent), radius scale (sm/md/lg/pill), elevation/shadow tiers, focus-ring style, motion duration + easing presets. Codify in `src/styles/tokens.css` (CSS vars) + a Tailwind config mapping. Then sweep every component to remove ad-hoc spacing, ad-hoc grays, ad-hoc font sizes, and ad-hoc shadows. Specific consistency targets: card surfaces (background + border + radius identical across HomeView, Board, Matchup, Settings, Profile, TradeAnalyzer, DraftRankings, etc.), table chrome (header row, divider, hover, selected), button heights and padding, modal chrome, empty-state pattern, loading skeleton pattern, error-banner pattern. This is the foundation that makes the per-page polish below trivial.
+- [ ] **Page-by-page polish pass** — After the design-system pass lands. Tighten loading states, empty states, error messages, micro-animations, hover states, focus rings, typography/spacing consistency. Audit each view for "feels finished vs. feels prototype" gaps across HomeView, Board, Matchup, GameSlate, Trends, AllPlayers, Team, Waivers, PlayoffPredictor, TradeAnalyzer, TradeHistory, TradeFinder, DraftRankings, Settings, Profile, LeagueAnalyzer (new), standalone player page.
 
 ---
 
@@ -143,8 +158,10 @@ Click-to-add real draft picks (with original-owner info) in the builder, instead
 - [ ] **League Analyzer page with AI team analyzer** — New top-level view auditing the user's league: team-by-team strength grades, positional surplus/deficit, schedule difficulty ROS, championship odds, AI-generated narrative per team ("biggest strength", "biggest hole", "most likely to fall off", "trade target fits"). Reuses Monte Carlo from PlayoffPredictorView + trade-finder's `LeagueContextSnapshot`. Sidebar nav already exists as "Coming Soon" placeholder. Pro/Elite gated.
 - [ ] **AI analysis of players** — 1–2 paragraph per-player take in PlayerCard modal AND standalone player page. Covers recent form, matchup, role/usage trend, start/sit recommendation. Cache by `(playerId, week, season)`. Reuse prompt/model setup from `server/src/services/draftRankings.ts`. Pro/Elite gated.
 - [ ] **AI post-game analysis** — Short AI recap per finalized NFL game focused on fantasy takeaways (exceeded/missed expectations, target share/carry shifts, injury-driven role changes, waiver implications). Surfaced on GameDetailModal and user matchup recap. Cron triggers on `gameStatus === 'final'` transitions. Cache per `(gameId, season, week)`.
-- [ ] **AI chat assistant** — Persistent chat bubble (bottom-right) answering fantasy questions in user's league context: roster, matchup, waivers, trades, start/sit. Reuses `LeagueContextSnapshot`. Streamed responses, persisted history. Entry points from PlayerCard ("Ask about Josh Allen"), Matchup ("Who should I start?"), Trade Analyzer follow-ups. Pro/Elite gated.
+- [ ] **AI chat assistant ("Ask AI")** — Persistent chat bubble (bottom-right) answering fantasy questions in user's league context: roster, matchup, waivers, trades, start/sit. Reuses `LeagueContextSnapshot`. Streamed responses, persisted history. Entry points from PlayerCard ("Ask about Josh Allen"), Matchup ("Who should I start?"), Trade Analyzer follow-ups. Slash-style entry from any page. Pro/Elite gated.
+- [ ] **ROS (Rest-of-Season) rankings from AI** — New ranking type that projects each player's remaining-season value, factoring in current form, schedule strength ROS, injury risk, and target/usage trajectory. Distinct from draft rankings (snapshot at draft time) and weekly player rankings (week-only). New `ranking_type = 'ros'` rows in `draft_rankings` (or new `ros_rankings` table if schema diverges). Daily regeneration cron during season. AI prompt seeds with: current season stats to date, remaining schedule, recent news, injury status. Surface as a tab on the Player Rankings view + a dedicated `/ros-rankings` page. Pro/Elite gated.
 - [ ] **Finish odds movement tracking on Trends** — Third tab on TrendsView: "Odds Movement" — player prop line movement (over/under yardage, anytime TD, receptions). External odds source (DraftKings/FanDuel public or paid like The Odds API). New `player_prop_lines` table keyed on `(playerId, propType, sportsbook, capturedAt)` with daily-or-better cron. Per-player chip: current line, opening line, % change, sparkline. Consolidates with LOW item "Trends based on player prop movements" and MEDIUM "Projection breakdown working."
+- [ ] **Recent Best Performers tab on Trends** — Fourth tab on TrendsView (alongside Roster Trends, Projection Movers, Odds Movement). Surfaces the highest-scoring players over the last 1 / 3 / season-to-date weeks with a small toggle. Per row: PPG over the window, delta vs. season average, % rostered, position rank, and a "trade target?" flag for non-rostered players. Data: existing `player_weekly_stats` aggregated server-side via a new `GET /players/recent-leaders?window=1|3|stf` endpoint. Cheap to build (no new AI, no new external source); pairs with the broken-trends-fix in the Current Focus list.
 
 ---
 

--- a/server/migrations/0035_add_projection_source.sql
+++ b/server/migrations/0035_add_projection_source.sql
@@ -1,0 +1,12 @@
+-- Tag each projection (and each snapshot of an old projection) with its provider
+-- so the Projection Movers tab can:
+--   1. Display "OURS" vs "SLEEPER" per row
+--   2. Filter movement comparisons to same-source snapshots only — avoids
+--      conflating a provider switch (props → sleeper fallback) with real
+--      line movement.
+-- Backfill is 'sleeper' since auto mode has historically defaulted to Sleeper
+-- for any player without prop coverage; rows that were actually props-sourced
+-- self-correct on the next 4h sync cron.
+
+ALTER TABLE player_projections ADD COLUMN source TEXT NOT NULL DEFAULT 'sleeper';
+ALTER TABLE projection_line_snapshots ADD COLUMN source TEXT NOT NULL DEFAULT 'sleeper';

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -221,6 +221,9 @@ export const playerProjections = sqliteTable('player_projections', {
   projectedPointsHigh: real('projected_points_high'),
   scoringFormat: text('scoring_format').notNull(), // 'ppr' | 'half-ppr' | 'standard'
 
+  // 'props' (our prop-line model) | 'sleeper' (fallback). See migration 0035.
+  source: text('source').notNull().default('sleeper'),
+
   weekRank: integer('week_rank'),
   positionRank: integer('position_rank'),
 
@@ -246,6 +249,9 @@ export const projectionLineSnapshots = sqliteTable('projection_line_snapshots', 
   seasonYear: integer('season_year').notNull(),
   scoringFormat: text('scoring_format').notNull(),
   snapshotAt: integer('snapshot_at', { mode: 'timestamp' }).notNull(),
+  // Source of the value being snapshotted (the OLD row's source, captured before overwrite).
+  // Movement queries filter by current row's source to avoid cross-provider comparisons.
+  source: text('source').notNull().default('sleeper'),
   projectedPoints: real('projected_points').notNull(),
   projPassYards: real('proj_pass_yards'),
   projPassTDs: real('proj_pass_tds'),

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1309,6 +1309,7 @@ adminRoutes.post('/sync-projections', async (c) => {
                   seasonYear,
                   scoringFormat: dbFormat,
                   projectedPoints,
+                  source: 'sleeper' as const,
                   projPassYards: playerProj.pass_yd || null,
                   projPassTDs: playerProj.pass_td || null,
                   projRushYards: playerProj.rush_yd || null,
@@ -1320,6 +1321,28 @@ adminRoutes.post('/sync-projections', async (c) => {
                 };
 
                 if (existingProj) {
+                  // Snapshot the old projection before overwriting so /projection-movements can compute net change.
+                  // Snapshot's source matches the OLD row's source — the same-source filter on movement queries
+                  // then prevents conflating a provider switch with real line movement.
+                  projStatements.push(
+                    db.insert(schema.projectionLineSnapshots).values({
+                      id: generateId(),
+                      playerId,
+                      week: weekNum,
+                      seasonYear,
+                      scoringFormat: dbFormat,
+                      snapshotAt: new Date(),
+                      source: existingProj.source ?? 'sleeper',
+                      projectedPoints: existingProj.projectedPoints,
+                      projPassYards: existingProj.projPassYards ?? null,
+                      projPassTDs: existingProj.projPassTDs ?? null,
+                      projRushYards: existingProj.projRushYards ?? null,
+                      projRushTDs: existingProj.projRushTDs ?? null,
+                      projReceptions: existingProj.projReceptions ?? null,
+                      projRecYards: existingProj.projRecYards ?? null,
+                      projRecTDs: existingProj.projRecTDs ?? null,
+                    })
+                  );
                   projStatements.push(
                     db.update(schema.playerProjections)
                       .set(projData)

--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -615,8 +615,15 @@ playerRoutes.get('/projection-movements', optionalAuthMiddleware, async (c) => {
       const playerIds = currentProjections.map(p => p.playerId);
       if (playerIds.length === 0) return [];
 
+      // Map each player to its current source so we can filter snapshots to same-source comparisons.
+      // A provider switch (props → sleeper or vice versa) leaves the player with no matching snapshot,
+      // which causes movement to fall through to 0 and get filtered out below — intended behavior.
+      const currentSourceByPlayer = new Map<string, string>(
+        currentProjections.map(p => [p.playerId, p.source])
+      );
+
       const CHUNK = 50;
-      const snapshots: { playerId: string; projectedPoints: number; snapshotAt: Date }[] = [];
+      const snapshots: { playerId: string; projectedPoints: number; snapshotAt: Date; source: string }[] = [];
       for (let i = 0; i < playerIds.length; i += CHUNK) {
         const chunk = playerIds.slice(i, i + CHUNK);
         const rows = await db.query.projectionLineSnapshots.findMany({
@@ -628,11 +635,13 @@ playerRoutes.get('/projection-movements', optionalAuthMiddleware, async (c) => {
           ),
           orderBy: asc(schema.projectionLineSnapshots.snapshotAt),
         });
-        snapshots.push(...rows.map(r => ({ playerId: r.playerId, projectedPoints: r.projectedPoints, snapshotAt: r.snapshotAt })));
+        snapshots.push(...rows.map(r => ({ playerId: r.playerId, projectedPoints: r.projectedPoints, snapshotAt: r.snapshotAt, source: r.source })));
       }
 
       const earliestByPlayer = new Map<string, { projectedPoints: number; snapshotAt: Date }>();
       for (const s of snapshots) {
+        // Same-source filter: skip snapshots whose source doesn't match the current row's source.
+        if (s.source !== currentSourceByPlayer.get(s.playerId)) continue;
         if (!earliestByPlayer.has(s.playerId)) earliestByPlayer.set(s.playerId, { projectedPoints: s.projectedPoints, snapshotAt: s.snapshotAt });
       }
 
@@ -646,6 +655,7 @@ playerRoutes.get('/projection-movements', optionalAuthMiddleware, async (c) => {
             name: (p as any).player?.name,
             team: (p as any).player?.team,
             position: (p as any).player?.position,
+            source: p.source,
             previousProjectedPoints: prevPts,
             projectedPoints: p.projectedPoints,
             movement,

--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -668,8 +668,8 @@ playerRoutes.get('/projection-movements', optionalAuthMiddleware, async (c) => {
 playerRoutes.get('/recent-leaders', optionalAuthMiddleware, async (c) => {
   const db = c.get('db');
 
-  // window: '1' (last week) | '3' (last 3 weeks) | 'stf' (season-to-date)
-  const windowRaw = c.req.query('window') || '1';
+  // window: '1' (last week) | '3' (last 3 weeks, default — more stable than single-week) | 'stf' (season-to-date)
+  const windowRaw = c.req.query('window') || '3';
   if (windowRaw !== '1' && windowRaw !== '3' && windowRaw !== 'stf') {
     return c.json({ error: "window must be '1', '3', or 'stf'" }, 400);
   }

--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -709,11 +709,137 @@ playerRoutes.get('/recent-leaders', optionalAuthMiddleware, async (c) => {
   }
 
   try {
+    // 1. Find the most recent week with stats for this season.
+    const latestWeekResult = await db
+      .select({ maxWeek: sql<number>`max(${schema.playerWeeklyStats.week})` })
+      .from(schema.playerWeeklyStats)
+      .where(eq(schema.playerWeeklyStats.seasonYear, season));
+    const latestWeek = latestWeekResult[0]?.maxWeek ?? 0;
+
+    if (latestWeek < 1) {
+      return c.json({
+        window,
+        weeks: [],
+        latestWeek: 0,
+        leaders: [],
+        season,
+        position: position ?? null,
+        leagueId: leagueId ?? null,
+        limit,
+      });
+    }
+
+    // 2. Build the window's week list (clamped to ≥ 1).
+    let weeks: number[];
+    if (window === '1') {
+      weeks = [latestWeek];
+    } else if (window === '3') {
+      const start = Math.max(1, latestWeek - 2);
+      weeks = [];
+      for (let w = start; w <= latestWeek; w++) weeks.push(w);
+    } else {
+      weeks = [];
+      for (let w = 1; w <= latestWeek; w++) weeks.push(w);
+    }
+
+    // 3. Aggregate top-N by ppg over the window. Inner-join nfl_players so we can filter by position at the DB level.
+    //    Drop inactive rows by requiring at least some scoring signal — DEF/K have no offensive snaps so we can't gate on off_snaps.
+    const windowConditions: SQL[] = [
+      eq(schema.playerWeeklyStats.seasonYear, season),
+      inArray(schema.playerWeeklyStats.week, weeks),
+    ];
+    if (position) {
+      windowConditions.push(eq(schema.nflPlayers.position, position));
+    }
+    const windowAgg = await db
+      .select({
+        playerId: schema.playerWeeklyStats.playerId,
+        ppg: sql<number>`ROUND(AVG(${schema.playerWeeklyStats.fantasyPointsPPR}), 2)`.as('ppg'),
+        games: sql<number>`COUNT(*)`.as('games'),
+        total: sql<number>`ROUND(SUM(${schema.playerWeeklyStats.fantasyPointsPPR}), 2)`.as('total'),
+      })
+      .from(schema.playerWeeklyStats)
+      .innerJoin(schema.nflPlayers, eq(schema.nflPlayers.id, schema.playerWeeklyStats.playerId))
+      .where(and(...windowConditions))
+      .groupBy(schema.playerWeeklyStats.playerId)
+      .orderBy(sql`ppg DESC, total DESC`)
+      .limit(limit);
+
+    if (windowAgg.length === 0) {
+      return c.json({
+        window,
+        weeks,
+        latestWeek,
+        leaders: [],
+        season,
+        position: position ?? null,
+        leagueId: leagueId ?? null,
+        limit,
+      });
+    }
+
+    const topIds = windowAgg.map(r => r.playerId);
+
+    // 4. Hydrate player metadata.
+    const players = await db.query.nflPlayers.findMany({
+      where: inArray(schema.nflPlayers.id, topIds),
+    });
+    const playerById = new Map(players.map(p => [p.id, p]));
+
+    // 5. Season-to-date average for the same player set — used to compute delta vs. season norm.
+    //    Skip when window === 'stf' (delta is 0 by definition).
+    const seasonPpgById = new Map<string, number>();
+    if (window !== 'stf') {
+      const seasonAgg = await db
+        .select({
+          playerId: schema.playerWeeklyStats.playerId,
+          ppg: sql<number>`ROUND(AVG(${schema.playerWeeklyStats.fantasyPointsPPR}), 2)`.as('ppg'),
+        })
+        .from(schema.playerWeeklyStats)
+        .where(and(
+          eq(schema.playerWeeklyStats.seasonYear, season),
+          inArray(schema.playerWeeklyStats.playerId, topIds),
+        ))
+        .groupBy(schema.playerWeeklyStats.playerId);
+      for (const row of seasonAgg) {
+        seasonPpgById.set(row.playerId, row.ppg ?? 0);
+      }
+    }
+
+    // 6. Build leader rows + compute posRank within the result set (1..N per position).
+    const posCounter = new Map<string, number>();
+    const leaders = windowAgg
+      .map(row => {
+        const player = playerById.get(row.playerId);
+        if (!player) return null;
+        const seasonPpg = window === 'stf' ? row.ppg : (seasonPpgById.get(row.playerId) ?? row.ppg);
+        const delta = window === 'stf' ? 0 : Number((row.ppg - seasonPpg).toFixed(2));
+        const posKey = player.position || 'NA';
+        const nextRank = (posCounter.get(posKey) ?? 0) + 1;
+        posCounter.set(posKey, nextRank);
+        return {
+          id: player.id,
+          name: player.name,
+          team: player.team,
+          position: player.position,
+          headshotUrl: player.headshotUrl ?? null,
+          games: row.games,
+          ppg: row.ppg,
+          seasonPpg,
+          delta,
+          posRank: nextRank,
+          ownedPct: null as number | null,
+          ownedInLeague: null as boolean | null,
+          tradeTarget: false,
+        };
+      })
+      .filter(<T>(x: T | null): x is T => x !== null);
+
     return c.json({
       window,
-      weeks: [],
-      latestWeek: 0,
-      leaders: [],
+      weeks,
+      latestWeek,
+      leaders,
       season,
       position: position ?? null,
       leagueId: leagueId ?? null,

--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -709,142 +709,176 @@ playerRoutes.get('/recent-leaders', optionalAuthMiddleware, async (c) => {
   }
 
   try {
-    // 1. Find the most recent week with stats for this season.
-    const latestWeekResult = await db
-      .select({ maxWeek: sql<number>`max(${schema.playerWeeklyStats.week})` })
-      .from(schema.playerWeeklyStats)
-      .where(eq(schema.playerWeeklyStats.seasonYear, season));
-    const latestWeek = latestWeekResult[0]?.maxWeek ?? 0;
+    const cacheKey = `recent-leaders:${season}:${window}:${leagueId || 'none'}:${position || 'all'}:${limit}`;
+    const payload = await cached(cacheKey, 10 * 60 * 1000, async () => {
+      // 1. Find the most recent week with stats for this season.
+      const latestWeekResult = await db
+        .select({ maxWeek: sql<number>`max(${schema.playerWeeklyStats.week})` })
+        .from(schema.playerWeeklyStats)
+        .where(eq(schema.playerWeeklyStats.seasonYear, season));
+      const latestWeek = latestWeekResult[0]?.maxWeek ?? 0;
 
-    if (latestWeek < 1) {
-      return c.json({
-        window,
-        weeks: [],
-        latestWeek: 0,
-        leaders: [],
-        season,
-        position: position ?? null,
-        leagueId: leagueId ?? null,
-        limit,
-      });
-    }
+      if (latestWeek < 1) {
+        return {
+          window,
+          weeks: [],
+          latestWeek: 0,
+          leaders: [],
+          season,
+          position: position ?? null,
+          leagueId: leagueId ?? null,
+          limit,
+        };
+      }
 
-    // 2. Build the window's week list (clamped to ≥ 1).
-    let weeks: number[];
-    if (window === '1') {
-      weeks = [latestWeek];
-    } else if (window === '3') {
-      const start = Math.max(1, latestWeek - 2);
-      weeks = [];
-      for (let w = start; w <= latestWeek; w++) weeks.push(w);
-    } else {
-      weeks = [];
-      for (let w = 1; w <= latestWeek; w++) weeks.push(w);
-    }
+      // 2. Build the window's week list (clamped to ≥ 1).
+      let weeks: number[];
+      if (window === '1') {
+        weeks = [latestWeek];
+      } else if (window === '3') {
+        const start = Math.max(1, latestWeek - 2);
+        weeks = [];
+        for (let w = start; w <= latestWeek; w++) weeks.push(w);
+      } else {
+        weeks = [];
+        for (let w = 1; w <= latestWeek; w++) weeks.push(w);
+      }
 
-    // 3. Aggregate top-N by ppg over the window. Inner-join nfl_players so we can filter by position at the DB level.
-    //    Drop inactive rows by requiring at least some scoring signal — DEF/K have no offensive snaps so we can't gate on off_snaps.
-    const windowConditions: SQL[] = [
-      eq(schema.playerWeeklyStats.seasonYear, season),
-      inArray(schema.playerWeeklyStats.week, weeks),
-    ];
-    if (position) {
-      windowConditions.push(eq(schema.nflPlayers.position, position));
-    }
-    const windowAgg = await db
-      .select({
-        playerId: schema.playerWeeklyStats.playerId,
-        ppg: sql<number>`ROUND(AVG(${schema.playerWeeklyStats.fantasyPointsPPR}), 2)`.as('ppg'),
-        games: sql<number>`COUNT(*)`.as('games'),
-        total: sql<number>`ROUND(SUM(${schema.playerWeeklyStats.fantasyPointsPPR}), 2)`.as('total'),
-      })
-      .from(schema.playerWeeklyStats)
-      .innerJoin(schema.nflPlayers, eq(schema.nflPlayers.id, schema.playerWeeklyStats.playerId))
-      .where(and(...windowConditions))
-      .groupBy(schema.playerWeeklyStats.playerId)
-      .orderBy(sql`ppg DESC, total DESC`)
-      .limit(limit);
-
-    if (windowAgg.length === 0) {
-      return c.json({
-        window,
-        weeks,
-        latestWeek,
-        leaders: [],
-        season,
-        position: position ?? null,
-        leagueId: leagueId ?? null,
-        limit,
-      });
-    }
-
-    const topIds = windowAgg.map(r => r.playerId);
-
-    // 4. Hydrate player metadata.
-    const players = await db.query.nflPlayers.findMany({
-      where: inArray(schema.nflPlayers.id, topIds),
-    });
-    const playerById = new Map(players.map(p => [p.id, p]));
-
-    // 5. Season-to-date average for the same player set — used to compute delta vs. season norm.
-    //    Skip when window === 'stf' (delta is 0 by definition).
-    const seasonPpgById = new Map<string, number>();
-    if (window !== 'stf') {
-      const seasonAgg = await db
+      // 3. Aggregate top-N by ppg over the window. Inner-join nfl_players so we can filter by position at the DB level.
+      //    Drop inactive rows by requiring at least some scoring signal — DEF/K have no offensive snaps so we can't gate on off_snaps.
+      const windowConditions: SQL[] = [
+        eq(schema.playerWeeklyStats.seasonYear, season),
+        inArray(schema.playerWeeklyStats.week, weeks),
+      ];
+      if (position) {
+        windowConditions.push(eq(schema.nflPlayers.position, position));
+      }
+      const windowAgg = await db
         .select({
           playerId: schema.playerWeeklyStats.playerId,
           ppg: sql<number>`ROUND(AVG(${schema.playerWeeklyStats.fantasyPointsPPR}), 2)`.as('ppg'),
+          games: sql<number>`COUNT(*)`.as('games'),
+          total: sql<number>`ROUND(SUM(${schema.playerWeeklyStats.fantasyPointsPPR}), 2)`.as('total'),
         })
         .from(schema.playerWeeklyStats)
-        .where(and(
-          eq(schema.playerWeeklyStats.seasonYear, season),
-          inArray(schema.playerWeeklyStats.playerId, topIds),
-        ))
-        .groupBy(schema.playerWeeklyStats.playerId);
-      for (const row of seasonAgg) {
-        seasonPpgById.set(row.playerId, row.ppg ?? 0);
-      }
-    }
+        .innerJoin(schema.nflPlayers, eq(schema.nflPlayers.id, schema.playerWeeklyStats.playerId))
+        .where(and(...windowConditions))
+        .groupBy(schema.playerWeeklyStats.playerId)
+        .orderBy(sql`ppg DESC, total DESC`)
+        .limit(limit);
 
-    // 6. Build leader rows + compute posRank within the result set (1..N per position).
-    const posCounter = new Map<string, number>();
-    const leaders = windowAgg
-      .map(row => {
-        const player = playerById.get(row.playerId);
-        if (!player) return null;
-        const seasonPpg = window === 'stf' ? row.ppg : (seasonPpgById.get(row.playerId) ?? row.ppg);
-        const delta = window === 'stf' ? 0 : Number((row.ppg - seasonPpg).toFixed(2));
-        const posKey = player.position || 'NA';
-        const nextRank = (posCounter.get(posKey) ?? 0) + 1;
-        posCounter.set(posKey, nextRank);
+      if (windowAgg.length === 0) {
         return {
-          id: player.id,
-          name: player.name,
-          team: player.team,
-          position: player.position,
-          headshotUrl: player.headshotUrl ?? null,
-          games: row.games,
-          ppg: row.ppg,
-          seasonPpg,
-          delta,
-          posRank: nextRank,
-          ownedPct: null as number | null,
-          ownedInLeague: null as boolean | null,
-          tradeTarget: false,
+          window,
+          weeks,
+          latestWeek,
+          leaders: [],
+          season,
+          position: position ?? null,
+          leagueId: leagueId ?? null,
+          limit,
         };
-      })
-      .filter(<T>(x: T | null): x is T => x !== null);
+      }
 
-    return c.json({
-      window,
-      weeks,
-      latestWeek,
-      leaders,
-      season,
-      position: position ?? null,
-      leagueId: leagueId ?? null,
-      limit,
+      const topIds = windowAgg.map(r => r.playerId);
+
+      // 4. Hydrate player metadata.
+      const players = await db.query.nflPlayers.findMany({
+        where: inArray(schema.nflPlayers.id, topIds),
+      });
+      const playerById = new Map(players.map(p => [p.id, p]));
+
+      // 5. Season-to-date average for the same player set — used to compute delta vs. season norm.
+      //    Skip when window === 'stf' (delta is 0 by definition).
+      const seasonPpgById = new Map<string, number>();
+      if (window !== 'stf') {
+        const seasonAgg = await db
+          .select({
+            playerId: schema.playerWeeklyStats.playerId,
+            ppg: sql<number>`ROUND(AVG(${schema.playerWeeklyStats.fantasyPointsPPR}), 2)`.as('ppg'),
+          })
+          .from(schema.playerWeeklyStats)
+          .where(and(
+            eq(schema.playerWeeklyStats.seasonYear, season),
+            inArray(schema.playerWeeklyStats.playerId, topIds),
+          ))
+          .groupBy(schema.playerWeeklyStats.playerId);
+        for (const row of seasonAgg) {
+          seasonPpgById.set(row.playerId, row.ppg ?? 0);
+        }
+      }
+
+      // 6. League ownership (only if leagueId provided AND league actually has teams).
+      //    rosteredPlayerIds is intentionally empty when leagueTeamCount is 0 so ownedInLeague stays null below.
+      let leagueTeamCount = 0;
+      let rosteredPlayerIds = new Set<string>();
+      if (leagueId) {
+        const teams = await db.query.teams.findMany({
+          where: eq(schema.teams.leagueId, leagueId),
+          columns: { id: true },
+        });
+        leagueTeamCount = teams.length;
+        if (teams.length > 0) {
+          const teamIds = teams.map(t => t.id);
+          const rosterRows = await db
+            .select({ playerId: schema.rosterSpots.playerId })
+            .from(schema.rosterSpots)
+            .where(inArray(schema.rosterSpots.teamId, teamIds));
+          rosteredPlayerIds = new Set(rosterRows.map(r => r.playerId));
+        }
+      }
+
+      // 7. Build leader rows + compute posRank within the result set (1..N per position).
+      const POS_THRESHOLDS: Record<string, number> = { QB: 18, RB: 12, WR: 12, TE: 8, K: 8, DEF: 8 };
+      const ownershipAvailable = leagueId !== undefined && leagueTeamCount > 0;
+      const posCounter = new Map<string, number>();
+      const leaders = windowAgg
+        .map(row => {
+          const player = playerById.get(row.playerId);
+          if (!player) return null;
+          const seasonPpg = window === 'stf' ? row.ppg : (seasonPpgById.get(row.playerId) ?? row.ppg);
+          const delta = window === 'stf' ? 0 : Number((row.ppg - seasonPpg).toFixed(2));
+          const posKey = player.position || 'NA';
+          const nextRank = (posCounter.get(posKey) ?? 0) + 1;
+          posCounter.set(posKey, nextRank);
+
+          const ownedInLeague = ownershipAvailable ? rosteredPlayerIds.has(player.id) : null;
+          const ownedPct = ownedInLeague === null ? null : (ownedInLeague ? 100 : 0);
+          const threshold = POS_THRESHOLDS[posKey] ?? 999;
+          const tradeTarget =
+            ownedInLeague === false && delta >= 3 && row.ppg >= threshold;
+
+          return {
+            id: player.id,
+            name: player.name,
+            team: player.team,
+            position: player.position,
+            headshotUrl: player.headshotUrl ?? null,
+            games: row.games,
+            ppg: row.ppg,
+            seasonPpg,
+            delta,
+            posRank: nextRank,
+            ownedPct,
+            ownedInLeague,
+            tradeTarget,
+          };
+        })
+        .filter(<T>(x: T | null): x is T => x !== null);
+
+      return {
+        window,
+        weeks,
+        latestWeek,
+        leaders,
+        season,
+        position: position ?? null,
+        leagueId: leagueId ?? null,
+        limit,
+      };
     });
+
+    return c.json(payload);
   } catch (error) {
     console.error('Recent leaders error:', error);
     return c.json({ error: 'Failed to fetch recent leaders' }, 500);

--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -663,6 +663,68 @@ playerRoutes.get('/projection-movements', optionalAuthMiddleware, async (c) => {
   }
 });
 
+// Recent best performers — top scorers over the last 1 week, 3 weeks, or season-to-date.
+// Aggregates from player_weekly_stats. Optional leagueId surfaces ownership + "trade target" flag for non-rostered breakouts.
+playerRoutes.get('/recent-leaders', optionalAuthMiddleware, async (c) => {
+  const db = c.get('db');
+
+  // window: '1' (last week) | '3' (last 3 weeks) | 'stf' (season-to-date)
+  const windowRaw = c.req.query('window') || '1';
+  if (windowRaw !== '1' && windowRaw !== '3' && windowRaw !== 'stf') {
+    return c.json({ error: "window must be '1', '3', or 'stf'" }, 400);
+  }
+  const window = windowRaw as '1' | '3' | 'stf';
+
+  // season: optional int, clamped to 2000-2100. Defaults via resolveDisplaySeason (falls back to most recent year with games).
+  const requestedSeasonRaw = c.req.query('season');
+  let requestedSeason: number;
+  if (requestedSeasonRaw) {
+    const parsed = parseInt(requestedSeasonRaw);
+    if (isNaN(parsed) || parsed < 2000 || parsed > 2100) {
+      return c.json({ error: 'Invalid season' }, 400);
+    }
+    requestedSeason = parsed;
+  } else {
+    requestedSeason = new Date().getFullYear();
+  }
+  const resolved = await resolveDisplaySeason(db, requestedSeason);
+  const season = resolved.season;
+
+  // position: optional whitelist
+  const positionRaw = c.req.query('position');
+  const validPositions = new Set(['QB', 'RB', 'WR', 'TE', 'K', 'DEF']);
+  if (positionRaw && !validPositions.has(positionRaw)) {
+    return c.json({ error: 'Invalid position' }, 400);
+  }
+  const position = positionRaw as 'QB' | 'RB' | 'WR' | 'TE' | 'K' | 'DEF' | undefined;
+
+  // limit: int, clamped 1-50, default 25. Guard against NaN before clamping.
+  const limitRaw = parseInt(c.req.query('limit') || '25');
+  const limit = isNaN(limitRaw) ? 25 : Math.min(Math.max(limitRaw, 1), 50);
+
+  // leagueId: optional, length-capped + character-whitelisted to prevent abuse
+  const leagueId = c.req.query('leagueId');
+  if (leagueId && (leagueId.length > 100 || !/^[a-zA-Z0-9_-]+$/.test(leagueId))) {
+    return c.json({ error: 'Invalid leagueId' }, 400);
+  }
+
+  try {
+    return c.json({
+      window,
+      weeks: [],
+      latestWeek: 0,
+      leaders: [],
+      season,
+      position: position ?? null,
+      leagueId: leagueId ?? null,
+      limit,
+    });
+  } catch (error) {
+    console.error('Recent leaders error:', error);
+    return c.json({ error: 'Failed to fetch recent leaders' }, 500);
+  }
+});
+
 // Search players (quick search) — rate limited, input sanitized
 playerRoutes.get('/search', playerSearchRateLimit, optionalAuthMiddleware, async (c) => {
   const db = c.get('db');

--- a/server/src/services/projections.ts
+++ b/server/src/services/projections.ts
@@ -361,6 +361,7 @@ export async function generateProjectionsFromProps(
         seasonYear,
         scoringFormat: format,
         projectedPoints: points,
+        source: 'props' as const,
         projPassYards: proj.projectedStats.projPassYards,
         projPassTDs: proj.projectedStats.projPassTDs,
         projRushYards: proj.projectedStats.projRushYards,
@@ -372,7 +373,8 @@ export async function generateProjectionsFromProps(
       };
 
       if (existingProj) {
-        // Snapshot the old projection before overwriting
+        // Snapshot the old projection before overwriting. The snapshot's source matches the OLD row's source
+        // (the value being snapshotted) so /projection-movements can filter to same-source comparisons later.
         statements.push(
           db.insert(schema.projectionLineSnapshots).values({
             id: generateId(),
@@ -381,6 +383,7 @@ export async function generateProjectionsFromProps(
             seasonYear,
             scoringFormat: format,
             snapshotAt: new Date(),
+            source: existingProj.source ?? 'sleeper',
             projectedPoints: existingProj.projectedPoints,
             projPassYards: existingProj.projPassYards ?? null,
             projPassTDs: existingProj.projPassTDs ?? null,

--- a/src/components/TrendsView.tsx
+++ b/src/components/TrendsView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { TrendingUp, TrendingDown, Activity, Loader2, RefreshCw, ArrowUpRight, ArrowDownRight, Users, BarChart3 } from 'lucide-react';
+import { TrendingUp, TrendingDown, Activity, Loader2, RefreshCw, ArrowUpRight, ArrowDownRight, Users, BarChart3, Trophy } from 'lucide-react';
 import { Player } from '../App';
 import { useLeagueContext } from '../context/LeagueContext';
 import api from '../services/api';
@@ -35,7 +35,7 @@ interface ProjectionMover {
   movement: number;
 }
 
-type ActiveTab = 'trending' | 'projections';
+type ActiveTab = 'trending' | 'projections' | 'leaders';
 
 const VALID_POSITIONS = new Set<Player['position']>(['QB', 'RB', 'WR', 'TE', 'K', 'DEF', 'FLEX']);
 const TREND_WINDOW = 'Last 14 days';
@@ -210,6 +210,20 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
             <BarChart3 className="w-3.5 h-3.5" />
             Projection Movers
           </button>
+          <button
+            role="tab"
+            aria-selected={activeTab === 'leaders'}
+            aria-controls="panel-leaders"
+            onClick={() => setActiveTab('leaders')}
+            className={`px-3 py-1.5 text-sm rounded-lg transition-colors flex items-center gap-1.5 ${
+              activeTab === 'leaders'
+                ? 'bg-blue-600 text-white'
+                : isDarkMode ? 'bg-slate-800 text-slate-300 hover:bg-slate-700' : 'bg-white text-slate-600 hover:bg-slate-100 border border-slate-200'
+            }`}
+          >
+            <Trophy className="w-3.5 h-3.5" />
+            Recent Best Performers
+          </button>
         </div>
       </div>
 
@@ -217,6 +231,15 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
       {loading ? (
         <div className={`rounded-lg border p-12 flex items-center justify-center ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
           <Loader2 className="w-8 h-8 animate-spin text-blue-500" role="status" aria-label="Loading trends data" />
+        </div>
+      ) : activeTab === 'leaders' ? (
+        /* Leaders Tab — placeholder, wired up in next step */
+        <div id="panel-leaders" role="tabpanel" className={`rounded-lg border p-12 text-center ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
+          <Trophy className={`w-10 h-10 mx-auto mb-3 ${isDarkMode ? 'text-slate-600' : 'text-slate-300'}`} />
+          <h3 className={`font-semibold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Recent Best Performers</h3>
+          <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+            Top scorers over the last 3 weeks — coming up.
+          </p>
         </div>
       ) : error || !hasAnyData ? (
         <div className={`rounded-lg border p-12 text-center ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>

--- a/src/components/TrendsView.tsx
+++ b/src/components/TrendsView.tsx
@@ -87,6 +87,8 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
   const [leaders, setLeaders] = useState<RecentLeader[]>([]);
   const [leadersLoading, setLeadersLoading] = useState(false);
   const [leadersError, setLeadersError] = useState<string | null>(null);
+  const [leadersWindow, setLeadersWindow] = useState<'1' | '3' | 'stf'>('3');
+  const [leadersPosFilter, setLeadersPosFilter] = useState<'ALL' | 'QB' | 'RB' | 'WR' | 'TE'>('ALL');
   const leadersFetchVersion = useRef(0);
 
   const currentWeek = league?.currentWeek ?? 1;
@@ -128,15 +130,16 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
   }, [fetchData]);
 
   // Lazy fetch for the Recent Best Performers tab — only runs when the tab is active.
-  // Request-version counter prevents stale responses from clobbering newer ones on rapid tab switches.
+  // Request-version counter prevents stale responses from clobbering newer ones on rapid tab switches or chip clicks.
   useEffect(() => {
     if (activeTab !== 'leaders') return;
     const version = ++leadersFetchVersion.current;
+    const positionParam = leadersPosFilter === 'ALL' ? '' : `&position=${leadersPosFilter}`;
     setLeadersLoading(true);
     setLeadersError(null);
     api
       .get<RecentLeadersResponse>(
-        `/players/recent-leaders?window=3&season=${seasonYear}${leagueParam}&limit=25`
+        `/players/recent-leaders?window=${leadersWindow}&season=${seasonYear}${leagueParam}${positionParam}&limit=25`
       )
       .then((res) => {
         if (version !== leadersFetchVersion.current) return;
@@ -152,7 +155,7 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
         if (version !== leadersFetchVersion.current) return;
         setLeadersLoading(false);
       });
-  }, [activeTab, seasonYear, leagueParam]);
+  }, [activeTab, seasonYear, leagueParam, leadersWindow, leadersPosFilter]);
 
   const convertTrendingToPlayer = (p: TrendingPlayer, index: number): Player => {
     const position = VALID_POSITIONS.has(p.position as Player['position'])
@@ -309,12 +312,54 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
           <Loader2 className="w-8 h-8 animate-spin text-blue-500" role="status" aria-label="Loading trends data" />
         </div>
       ) : activeTab === 'leaders' ? (
-        /* Leaders Tab — Recent Best Performers over the last 3 weeks */
+        /* Leaders Tab — Recent Best Performers with window + position toggles */
         <div id="panel-leaders" role="tabpanel" className={`rounded-lg border overflow-hidden ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
-          <div className={`px-6 py-4 border-b flex items-center gap-2 ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
-            <Trophy className="w-4 h-4 text-amber-500" />
-            <h2 className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Recent Best Performers</h2>
-            <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>Last 3 weeks</span>
+          <div className={`px-6 py-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
+            <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Trophy className="w-4 h-4 text-amber-500" />
+                <h2 className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Recent Best Performers</h2>
+                <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+                  {leadersWindow === '1' ? 'Last week' : leadersWindow === '3' ? 'Last 3 weeks' : 'Season to date'}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="flex items-center gap-1" data-testid="leaders-window-toggle">
+                  {(['1', '3', 'stf'] as const).map((w) => (
+                    <button
+                      key={w}
+                      onClick={() => setLeadersWindow(w)}
+                      aria-pressed={leadersWindow === w}
+                      data-testid={`window-${w}`}
+                      className={`px-2.5 py-1 text-xs rounded-lg transition-colors ${
+                        leadersWindow === w
+                          ? 'bg-blue-600 text-white'
+                          : isDarkMode ? 'bg-slate-800 text-slate-300 hover:bg-slate-700' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                      }`}
+                    >
+                      {w === '1' ? '1W' : w === '3' ? '3W' : 'STF'}
+                    </button>
+                  ))}
+                </div>
+                <div className="flex flex-wrap items-center gap-1" data-testid="leaders-position-filter">
+                  {(['ALL', 'QB', 'RB', 'WR', 'TE'] as const).map((p) => (
+                    <button
+                      key={p}
+                      onClick={() => setLeadersPosFilter(p)}
+                      aria-pressed={leadersPosFilter === p}
+                      data-testid={`position-${p}`}
+                      className={`px-2.5 py-1 text-xs rounded-lg transition-colors ${
+                        leadersPosFilter === p
+                          ? 'bg-blue-600 text-white'
+                          : isDarkMode ? 'bg-slate-800 text-slate-300 hover:bg-slate-700' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                      }`}
+                    >
+                      {p}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
           </div>
           {leadersLoading ? (
             <div className="p-12 flex items-center justify-center">

--- a/src/components/TrendsView.tsx
+++ b/src/components/TrendsView.tsx
@@ -90,6 +90,7 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
   const [leadersWindow, setLeadersWindow] = useState<'1' | '3' | 'stf'>('3');
   const [leadersPosFilter, setLeadersPosFilter] = useState<'ALL' | 'QB' | 'RB' | 'WR' | 'TE'>('ALL');
   const leadersFetchVersion = useRef(0);
+  const fetchDataVersion = useRef(0);
 
   const currentWeek = league?.currentWeek;
   const seasonYear = getEffectiveSeason(league?.seasonYear);
@@ -97,6 +98,9 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
   const leagueParam = useMemo(() => league?.id ? `&leagueId=${league.id}` : '', [league?.id]);
 
   const fetchData = useCallback(async () => {
+    // Request-version guard prevents a slow earlier response from clobbering a newer one
+    // when the user switches leagues / season rapidly.
+    const version = ++fetchDataVersion.current;
     setLoading(true);
     setError(null);
     try {
@@ -117,17 +121,19 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
         projPromise,
       ]);
 
+      if (version !== fetchDataVersion.current) return;
       setTrendingUp(upRes.trending || []);
       setTrendingDown(downRes.trending || []);
       setProjectionMovers(projRes.movements || []);
     } catch (err) {
+      if (version !== fetchDataVersion.current) return;
       console.error('Failed to load trends data:', err);
       setError('Failed to load trends data.');
       setTrendingUp([]);
       setTrendingDown([]);
       setProjectionMovers([]);
     } finally {
-      setLoading(false);
+      if (version === fetchDataVersion.current) setLoading(false);
     }
   }, [currentWeek, seasonYear, leagueParam, league?.id]);
 

--- a/src/components/TrendsView.tsx
+++ b/src/components/TrendsView.tsx
@@ -141,10 +141,9 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
     fetchData();
   }, [fetchData]);
 
-  // Lazy fetch for the Recent Best Performers tab — only runs when the tab is active.
+  // Lazy fetch for the Recent Best Performers tab.
   // Request-version counter prevents stale responses from clobbering newer ones on rapid tab switches or chip clicks.
-  useEffect(() => {
-    if (activeTab !== 'leaders') return;
+  const fetchLeaders = useCallback(() => {
     const version = ++leadersFetchVersion.current;
     const positionParam = leadersPosFilter === 'ALL' ? '' : `&position=${leadersPosFilter}`;
     setLeadersLoading(true);
@@ -164,10 +163,19 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
         setLeaders([]);
       })
       .finally(() => {
-        if (version !== leadersFetchVersion.current) return;
-        setLeadersLoading(false);
+        if (version === leadersFetchVersion.current) setLeadersLoading(false);
       });
-  }, [activeTab, seasonYear, leagueParam, leadersWindow, leadersPosFilter]);
+  }, [leadersWindow, leadersPosFilter, seasonYear, leagueParam]);
+
+  useEffect(() => {
+    if (activeTab !== 'leaders') return;
+    fetchLeaders();
+  }, [activeTab, fetchLeaders]);
+
+  const handleRefresh = useCallback(() => {
+    fetchData();
+    if (activeTab === 'leaders') fetchLeaders();
+  }, [activeTab, fetchData, fetchLeaders]);
 
   const convertTrendingToPlayer = (p: TrendingPlayer, index: number): Player => {
     const position = VALID_POSITIONS.has(p.position as Player['position'])
@@ -259,12 +267,12 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
                 </div>
               </div>
               <button
-                onClick={fetchData}
-                disabled={loading}
+                onClick={handleRefresh}
+                disabled={loading || leadersLoading}
                 aria-label="Refresh trends data"
                 className={`p-2 rounded-lg transition-colors ${isDarkMode ? 'hover:bg-slate-800 text-slate-400' : 'hover:bg-slate-100 text-slate-500'}`}
               >
-                <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+                <RefreshCw className={`w-4 h-4 ${(loading || leadersLoading) ? 'animate-spin' : ''}`} />
               </button>
             </div>
           </div>
@@ -326,16 +334,12 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
             isDarkMode ? 'bg-red-950/30 border-red-900 text-red-300' : 'bg-red-50 border-red-200 text-red-700'
           }`}
         >
-          {error} Try refreshing.
+          {error.replace(/\.$/, '')} — try refreshing.
         </div>
       )}
 
-      {/* Loading */}
-      {loading ? (
-        <div className={`rounded-lg border p-12 flex items-center justify-center ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
-          <Loader2 className="w-8 h-8 animate-spin text-blue-500" role="status" aria-label="Loading trends data" />
-        </div>
-      ) : activeTab === 'leaders' ? (
+      {/* Leaders tab is checked first so the global loader (driven by the trending fetch) doesn't mask the leaders panel during initial mount. */}
+      {activeTab === 'leaders' ? (
         /* Leaders Tab — Recent Best Performers with window + position toggles */
         <div id="panel-leaders" role="tabpanel" className={`rounded-lg border overflow-hidden ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
           <div className={`px-6 py-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
@@ -426,7 +430,7 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
                       )}
                     </div>
                     <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
-                      {leader.team} • {leader.position}{leader.position ? leader.posRank : ''}
+                      {leader.team} • {leader.position ? `${leader.position}${leader.posRank}` : '—'}
                       <span className="mx-1">•</span>
                       {leader.games} {leader.games === 1 ? 'game' : 'games'}
                       {leader.ownedPct !== null && (
@@ -453,6 +457,10 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
               ))}
             </div>
           )}
+        </div>
+      ) : loading ? (
+        <div className={`rounded-lg border p-12 flex items-center justify-center ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
+          <Loader2 className="w-8 h-8 animate-spin text-blue-500" role="status" aria-label="Loading trends data" />
         </div>
       ) : activeTab === 'trending' ? (
         /* Trending Tab — two-column: Most Added / Most Dropped */

--- a/src/components/TrendsView.tsx
+++ b/src/components/TrendsView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { TrendingUp, TrendingDown, Activity, Loader2, RefreshCw, ArrowUpRight, ArrowDownRight, Users, BarChart3, Trophy } from 'lucide-react';
 import { Player } from '../App';
 import { useLeagueContext } from '../context/LeagueContext';
@@ -35,6 +35,33 @@ interface ProjectionMover {
   movement: number;
 }
 
+interface RecentLeader {
+  id: string;
+  name: string;
+  team: string;
+  position: string;
+  headshotUrl: string | null;
+  games: number;
+  ppg: number;
+  seasonPpg: number;
+  delta: number;
+  posRank: number;
+  ownedPct: number | null;
+  ownedInLeague: boolean | null;
+  tradeTarget: boolean;
+}
+
+interface RecentLeadersResponse {
+  window: '1' | '3' | 'stf';
+  weeks: number[];
+  latestWeek: number;
+  leaders: RecentLeader[];
+  season: number;
+  position: string | null;
+  leagueId: string | null;
+  limit: number;
+}
+
 type ActiveTab = 'trending' | 'projections' | 'leaders';
 
 const VALID_POSITIONS = new Set<Player['position']>(['QB', 'RB', 'WR', 'TE', 'K', 'DEF', 'FLEX']);
@@ -56,6 +83,11 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
   const [projFilter, setProjFilter] = useState<'all' | 'up' | 'down'>('all');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [leaders, setLeaders] = useState<RecentLeader[]>([]);
+  const [leadersLoading, setLeadersLoading] = useState(false);
+  const [leadersError, setLeadersError] = useState<string | null>(null);
+  const leadersFetchVersion = useRef(0);
 
   const currentWeek = league?.currentWeek ?? 1;
   const seasonYear = getEffectiveSeason(league?.seasonYear);
@@ -94,6 +126,33 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // Lazy fetch for the Recent Best Performers tab — only runs when the tab is active.
+  // Request-version counter prevents stale responses from clobbering newer ones on rapid tab switches.
+  useEffect(() => {
+    if (activeTab !== 'leaders') return;
+    const version = ++leadersFetchVersion.current;
+    setLeadersLoading(true);
+    setLeadersError(null);
+    api
+      .get<RecentLeadersResponse>(
+        `/players/recent-leaders?window=3&season=${seasonYear}${leagueParam}&limit=25`
+      )
+      .then((res) => {
+        if (version !== leadersFetchVersion.current) return;
+        setLeaders(res.leaders || []);
+      })
+      .catch((err) => {
+        if (version !== leadersFetchVersion.current) return;
+        console.error('Failed to load recent leaders:', err);
+        setLeadersError('Failed to load recent leaders.');
+        setLeaders([]);
+      })
+      .finally(() => {
+        if (version !== leadersFetchVersion.current) return;
+        setLeadersLoading(false);
+      });
+  }, [activeTab, seasonYear, leagueParam]);
 
   const convertTrendingToPlayer = (p: TrendingPlayer, index: number): Player => {
     const position = VALID_POSITIONS.has(p.position as Player['position'])
@@ -135,6 +194,23 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
     }),
     [projectionMovers, projFilter]
   );
+
+  const convertLeaderToPlayer = (l: RecentLeader, index: number): Player => {
+    const position = VALID_POSITIONS.has(l.position as Player['position'])
+      ? (l.position as Player['position'])
+      : 'FLEX';
+    return {
+      id: l.id,
+      rank: index + 1,
+      name: l.name,
+      team: l.team,
+      position,
+      keyLine: `${l.ppg.toFixed(1)} PPR/g`,
+      projectedPoints: l.ppg,
+      weekChange: l.delta,
+      headshotUrl: l.headshotUrl,
+    };
+  };
 
   const hasAnyData = trendingUp.length > 0 || trendingDown.length > 0 || projectionMovers.length > 0;
 
@@ -233,13 +309,81 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
           <Loader2 className="w-8 h-8 animate-spin text-blue-500" role="status" aria-label="Loading trends data" />
         </div>
       ) : activeTab === 'leaders' ? (
-        /* Leaders Tab — placeholder, wired up in next step */
-        <div id="panel-leaders" role="tabpanel" className={`rounded-lg border p-12 text-center ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
-          <Trophy className={`w-10 h-10 mx-auto mb-3 ${isDarkMode ? 'text-slate-600' : 'text-slate-300'}`} />
-          <h3 className={`font-semibold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Recent Best Performers</h3>
-          <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-            Top scorers over the last 3 weeks — coming up.
-          </p>
+        /* Leaders Tab — Recent Best Performers over the last 3 weeks */
+        <div id="panel-leaders" role="tabpanel" className={`rounded-lg border overflow-hidden ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
+          <div className={`px-6 py-4 border-b flex items-center gap-2 ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
+            <Trophy className="w-4 h-4 text-amber-500" />
+            <h2 className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Recent Best Performers</h2>
+            <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>Last 3 weeks</span>
+          </div>
+          {leadersLoading ? (
+            <div className="p-12 flex items-center justify-center">
+              <Loader2 className="w-8 h-8 animate-spin text-blue-500" role="status" aria-label="Loading recent leaders" />
+            </div>
+          ) : leadersError ? (
+            <div className={`p-12 text-center ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+              <Trophy className="w-8 h-8 mx-auto mb-2 opacity-50" />
+              <p className="text-sm">{leadersError}</p>
+              <p className="text-xs mt-1">Try refreshing or come back later.</p>
+            </div>
+          ) : leaders.length === 0 ? (
+            <div className={`p-12 text-center ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+              <Trophy className="w-8 h-8 mx-auto mb-2 opacity-50" />
+              <p className="text-sm">No recent leaders yet.</p>
+              <p className="text-xs mt-1">Weekly stats appear after games finalize.</p>
+            </div>
+          ) : (
+            <div className={`divide-y ${isDarkMode ? 'divide-slate-800' : 'divide-slate-100'}`}>
+              {leaders.map((leader, i) => (
+                <button
+                  key={leader.id}
+                  onClick={() => onPlayerClick(convertLeaderToPlayer(leader, i))}
+                  aria-label={`View ${leader.name} details`}
+                  data-testid={`leader-${i}`}
+                  className={`w-full px-6 py-3 text-left transition-colors flex items-center gap-3 ${isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-slate-50'}`}
+                >
+                  <span className={`text-xs font-mono w-5 text-center ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>{i + 1}</span>
+                  <div className={`w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 ${isDarkMode ? 'bg-slate-800 text-slate-300' : 'bg-slate-100 text-slate-600'}`}>
+                    {(leader.name || '?').split(' ').filter(Boolean).map(n => n[0]).join('').slice(0, 2)}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-1.5">
+                      <span className={`text-sm font-semibold truncate ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{leader.name || 'Unknown'}</span>
+                      {leader.tradeTarget && (
+                        <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium flex-shrink-0 ${isDarkMode ? 'bg-green-600/20 text-green-400' : 'bg-green-50 text-green-700'}`}>TRADE TARGET</span>
+                      )}
+                      {leader.ownedInLeague === true && !leader.tradeTarget && (
+                        <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium flex-shrink-0 ${isDarkMode ? 'bg-blue-600/20 text-blue-400' : 'bg-blue-50 text-blue-600'}`}>ROSTERED</span>
+                      )}
+                    </div>
+                    <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
+                      {leader.team} • {leader.position}{leader.position ? leader.posRank : ''}
+                      <span className="mx-1">•</span>
+                      {leader.games} {leader.games === 1 ? 'game' : 'games'}
+                      {leader.ownedPct !== null && (
+                        <>
+                          <span className="mx-1">•</span>
+                          {leader.ownedPct}% owned
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <div className="text-right flex-shrink-0 flex items-center gap-3">
+                    {leader.delta !== 0 && (
+                      <div className={`flex items-center gap-0.5 text-xs font-semibold ${leader.delta > 0 ? 'text-green-500' : 'text-red-500'}`}>
+                        {leader.delta > 0 ? <TrendingUp className="w-3.5 h-3.5" /> : <TrendingDown className="w-3.5 h-3.5" />}
+                        {leader.delta > 0 ? '+' : ''}{leader.delta.toFixed(1)}
+                      </div>
+                    )}
+                    <div>
+                      <div className={`text-sm font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{leader.ppg.toFixed(1)}</div>
+                      <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>PPR/g</div>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       ) : error || !hasAnyData ? (
         <div className={`rounded-lg border p-12 text-center ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>

--- a/src/components/TrendsView.tsx
+++ b/src/components/TrendsView.tsx
@@ -30,6 +30,7 @@ interface ProjectionMover {
   name: string;
   team: string;
   position: string;
+  source: 'props' | 'sleeper';
   previousProjectedPoints: number;
   projectedPoints: number;
   movement: number;
@@ -612,7 +613,28 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
                     {(mover.name || '?').split(' ').filter(Boolean).map(n => n[0]).join('').slice(0, 2)}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <div className={`text-sm font-semibold truncate ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{mover.name || 'Unknown'}</div>
+                    <div className="flex items-center gap-1.5">
+                      <span className={`text-sm font-semibold truncate ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{mover.name || 'Unknown'}</span>
+                      {mover.source === 'props' ? (
+                        <span
+                          title="Projection derived from our prop-line model"
+                          className={`text-[10px] px-1.5 py-0.5 rounded font-medium flex-shrink-0 ${
+                            isDarkMode ? 'bg-indigo-600/20 text-indigo-300' : 'bg-indigo-50 text-indigo-700'
+                          }`}
+                        >
+                          OURS
+                        </span>
+                      ) : mover.source === 'sleeper' ? (
+                        <span
+                          title="Projection sourced from Sleeper"
+                          className={`text-[10px] px-1.5 py-0.5 rounded font-medium flex-shrink-0 ${
+                            isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-slate-200 text-slate-600'
+                          }`}
+                        >
+                          SLEEPER
+                        </span>
+                      ) : null}
+                    </div>
                     <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
                       {mover.team} • {mover.position}
                       <span className="mx-1">•</span>

--- a/src/components/TrendsView.tsx
+++ b/src/components/TrendsView.tsx
@@ -91,7 +91,7 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
   const [leadersPosFilter, setLeadersPosFilter] = useState<'ALL' | 'QB' | 'RB' | 'WR' | 'TE'>('ALL');
   const leadersFetchVersion = useRef(0);
 
-  const currentWeek = league?.currentWeek ?? 1;
+  const currentWeek = league?.currentWeek;
   const seasonYear = getEffectiveSeason(league?.seasonYear);
 
   const leagueParam = useMemo(() => league?.id ? `&leagueId=${league.id}` : '', [league?.id]);
@@ -100,15 +100,21 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
     setLoading(true);
     setError(null);
     try {
+      // Skip the projections call when there's no league/week — otherwise it fires with week=1 against the wrong season
+      // and silently returns an empty list, which the UI then misreports as "no projection changes."
+      const projPromise = (currentWeek != null && league?.id != null)
+        ? api.get<{ movements: ProjectionMover[] }>(
+            `/players/projection-movements?week=${currentWeek}&season=${seasonYear}&scoringFormat=ppr&limit=20`
+          ).catch((err) => {
+            console.warn('Failed to fetch projection movements:', err);
+            return { movements: [] };
+          })
+        : Promise.resolve({ movements: [] });
+
       const [upRes, downRes, projRes] = await Promise.all([
         api.get<{ trending: TrendingPlayer[] }>(`/players/trending?direction=up${leagueParam}`),
         api.get<{ trending: TrendingPlayer[] }>(`/players/trending?direction=down${leagueParam}`),
-        api.get<{ movements: ProjectionMover[] }>(
-          `/players/projection-movements?week=${currentWeek}&season=${seasonYear}&scoringFormat=ppr&limit=20`
-        ).catch((err) => {
-          console.warn('Failed to fetch projection movements:', err);
-          return { movements: [] };
-        }),
+        projPromise,
       ]);
 
       setTrendingUp(upRes.trending || []);
@@ -123,7 +129,7 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
     } finally {
       setLoading(false);
     }
-  }, [currentWeek, seasonYear, leagueParam]);
+  }, [currentWeek, seasonYear, leagueParam, league?.id]);
 
   useEffect(() => {
     fetchData();
@@ -167,7 +173,9 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
       name: p.name,
       team: p.team,
       position,
-      keyLine: `${p.ownedPct}% owned`,
+      // ownedPct is only meaningful when a league is connected — without one, every value is 0 (no data).
+      // Fall back to "Trending" so the modal doesn't claim every player is 0% owned.
+      keyLine: league?.id ? `${p.ownedPct}% owned` : 'Trending',
       projectedPoints: p.projectedPoints || p.avgPointsPPR || 0,
       weekChange: p.trendDirection === 'up' ? p.trendValue : p.trendDirection === 'down' ? -p.trendValue : 0,
       headshotUrl: p.headshotUrl ?? null,
@@ -214,8 +222,6 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
       headshotUrl: l.headshotUrl,
     };
   };
-
-  const hasAnyData = trendingUp.length > 0 || trendingDown.length > 0 || projectionMovers.length > 0;
 
   return (
     <div className="max-w-[1400px] mx-auto space-y-6">
@@ -305,6 +311,18 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
           </button>
         </div>
       </div>
+
+      {/* Non-blocking error banner — shows when fetchData failed but doesn't hide the tab panels. */}
+      {error && (
+        <div
+          role="alert"
+          className={`rounded-lg border px-4 py-3 text-sm ${
+            isDarkMode ? 'bg-red-950/30 border-red-900 text-red-300' : 'bg-red-50 border-red-200 text-red-700'
+          }`}
+        >
+          {error} Try refreshing.
+        </div>
+      )}
 
       {/* Loading */}
       {loading ? (
@@ -430,14 +448,6 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
             </div>
           )}
         </div>
-      ) : error || !hasAnyData ? (
-        <div className={`rounded-lg border p-12 text-center ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
-          <Activity className={`w-10 h-10 mx-auto mb-3 ${isDarkMode ? 'text-slate-600' : 'text-slate-300'}`} />
-          <h3 className={`font-semibold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>No trend data available</h3>
-          <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-            {error || 'Could not load trending data. Try refreshing.'}
-          </p>
-        </div>
       ) : activeTab === 'trending' ? (
         /* Trending Tab — two-column: Most Added / Most Dropped */
         <div id="panel-trending" role="tabpanel" className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -542,7 +552,7 @@ export function TrendsView({ onPlayerClick, isDarkMode }: TrendsViewProps) {
         <div id="panel-projections" role="tabpanel" className={`rounded-lg border overflow-hidden ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
           <div className={`px-6 py-4 border-b flex items-center justify-between ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
             <h2 className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
-              Biggest Projection Movers — Week {currentWeek}
+              Biggest Projection Movers{currentWeek ? ` — Week ${currentWeek}` : ''}
             </h2>
             <div className="flex items-center gap-2" data-testid="projection-filters">
               {FILTER_OPTIONS.map((f) => {


### PR DESCRIPTION
## Summary
- Adds `TODO.md` — a fresh, end-to-end prioritized list extracted from every unchecked item in the 332-line `BACKLOG.md`.
- Organized into P0 (launch blockers) → P6 (future / optional). Leaves `BACKLOG.md` untouched as the historical record.
- Flags a few stale entries (e.g. standalone player page route shipped in `21de3f3`) and consolidates duplicates (Trends odds movement vs. prop movement trends).

## Priority snapshot
- **P0 (2):** Google OAuth credential, mobile optimization
- **P1 (7):** Player card insights/quick actions/projection breakdown, matchup insights, notifications, draft rankings, season projections, multi-platform waiver pickups
- **P2 (15):** Component audits + page-by-page polish pass
- **P3 (~50):** Trade finder cost/discovery hardening, trade analyzer pick inventory, draft + player rankings enhancements, AI surfaces (League Analyzer, per-player AI take, post-game AI, chat assistant), odds tracking
- **P4 (8):** SEO follow-through on the new player page route
- **P5 (6):** Stripe + gating infrastructure (prereq for P6)
- **P6 (~20):** Pro/Elite tier features, one-time purchases, newsletter, ads

## Test plan
- [ ] Skim `TODO.md` ordering — confirm P0/P1 reflect actual launch blockers
- [ ] Confirm no completed items leaked in (cross-check against `BACKLOG.md` checkmarks)
- [ ] Decide whether `BACKLOG.md` should now redirect readers to `TODO.md` for active work

https://claude.ai/code/session_01ADgAg8kwP4SD4Me85rwZbG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADgAg8kwP4SD4Me85rwZbG)_