### PR TITLE
UI cohesion sweep (page-by-page de-shadow + de-tint stragglers)

### DIFF
--- a/src/components/DraftRankingsView.tsx
+++ b/src/components/DraftRankingsView.tsx
@@ -385,13 +385,14 @@ export function DraftRankingsView({ onPlayerClick, isDarkMode, onNavigate }: Dra
 
       {/* Search */}
       <div className="relative">
-        <Search className={`absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`} />
+        <Search style={{ left: '0.875rem' }} className={`absolute top-1/2 -translate-y-1/2 w-3.5 h-3.5 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`} />
         <input
           type="text"
           placeholder="Search player..."
           value={searchQuery}
           onChange={e => setSearchQuery(e.target.value)}
-          className={`pl-8 pr-3 py-1.5 text-sm rounded-lg border w-full sm:w-64 outline-none ${
+          style={{ paddingLeft: '2.5rem' }}
+          className={`pr-3 py-1.5 text-sm rounded-lg border w-full sm:w-64 outline-none ${
             isDarkMode
               ? 'bg-slate-900 border-slate-700 text-slate-200 placeholder:text-slate-500 focus:border-blue-500'
               : 'bg-white border-slate-200 text-slate-700 placeholder:text-slate-400 focus:border-blue-500'

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -160,17 +160,18 @@ export function Header({ onPlayerClick, isDarkMode, isAuthenticated = false, onP
           {searchOpen ? (
             <div className="flex items-center gap-2">
               <div className="relative">
-                <Search className={`absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`} />
+                <Search style={{ left: '0.875rem' }} className={`absolute top-1/2 -translate-y-1/2 w-4 h-4 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`} />
                 <input
                   type="text"
                   placeholder="Search players..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className={`w-48 sm:w-64 pl-9 pr-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent ${isDarkMode ? 'bg-slate-800 border-slate-700 text-white placeholder-slate-500' : 'bg-slate-50 border-slate-200 text-slate-900 placeholder-slate-400'}`}
+                  style={{ paddingLeft: '2.625rem', paddingRight: '0.75rem' }}
+                  className={`w-48 sm:w-64 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent ${isDarkMode ? 'bg-slate-800 border-slate-700 text-white placeholder-slate-500' : 'bg-slate-50 border-slate-200 text-slate-900 placeholder-slate-400'}`}
                   autoFocus
                 />
                 {isSearching && (
-                  <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-blue-500" />
+                  <Loader2 style={{ right: '0.75rem' }} className="absolute top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-blue-500" />
                 )}
               </div>
             </div>

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -362,8 +362,8 @@ export function HomeView({ onPlayerClick, onViewChange, onGameSelect, isDarkMode
         <div
           style={{
             backgroundImage: isDarkMode
-              ? 'linear-gradient(135deg, rgb(15,23,42) 0%, rgb(15,23,42) 50%, rgba(23,37,84,0.4) 100%)'
-              : 'linear-gradient(135deg, #ffffff, rgba(239,246,255,0.4))',
+              ? 'linear-gradient(135deg, #1a1a1a 0%, #1a1a1a 55%, rgba(59,130,246,0.10) 100%)'
+              : 'linear-gradient(135deg, #ffffff, rgba(245,245,245,0.6))',
           }}
           className={`relative overflow-hidden rounded-2xl border p-6 ${
           isDarkMode ? 'border-slate-700' : 'border-slate-200'
@@ -413,7 +413,7 @@ export function HomeView({ onPlayerClick, onViewChange, onGameSelect, isDarkMode
               }`}>
                 <div className="flex items-center gap-3 fr-min-w-0">
                   <div
-                    style={{ backgroundImage: 'linear-gradient(135deg, #3b82f6, #a855f7)' }}
+                    style={{ backgroundImage: 'linear-gradient(135deg, #3b82f6, #60a5fa)' }}
                     className="w-11 h-11 rounded-xl flex items-center justify-center text-white font-bold text-sm flex-shrink-0"
                   >
                     {getInitials(userTeam?.name || 'You')}

--- a/src/components/TradeAnalyzerShell.tsx
+++ b/src/components/TradeAnalyzerShell.tsx
@@ -39,7 +39,7 @@ export function TradeAnalyzerShell({ isDarkMode }: TradeAnalyzerShellProps) {
               onClick={() => setTab(t.id)}
               className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-colors whitespace-nowrap ${
                 active
-                  ? 'bg-blue-600 text-white shadow-sm'
+                  ? 'bg-blue-600 text-white'
                   : isDarkMode
                   ? 'text-slate-300 hover:bg-slate-800'
                   : 'text-slate-700 hover:bg-slate-100'

--- a/src/components/TradeAnalyzerView.tsx
+++ b/src/components/TradeAnalyzerView.tsx
@@ -309,7 +309,7 @@ function PlayerSearchInput({
       </div>
       {showDropdown && (
         <div
-          className={`absolute z-50 mt-1 w-full rounded-lg border shadow-lg max-h-48 overflow-y-auto ${
+          className={`absolute z-50 mt-1 w-full rounded-lg border max-h-48 overflow-y-auto ${
             isDarkMode ? 'bg-slate-800 border-slate-600' : 'bg-white border-slate-200'
           }`}
         >
@@ -860,7 +860,7 @@ function FairnessMeter({
       />
       <div className="relative h-0">
         <div
-          className={`absolute w-5 h-5 rounded-full shadow transition-all duration-500 ${markerBorder} ${
+          className={`absolute w-5 h-5 rounded-full transition-all duration-500 ${markerBorder} ${
             isDarkMode ? 'bg-white' : 'bg-slate-900'
           }`}
           style={{
@@ -941,10 +941,10 @@ function FollowUpChat({
       )}
 
       <div
-        className={`flex items-center gap-2 p-2 rounded-2xl border shadow-lg ${
+        className={`flex items-center gap-2 p-2 rounded-2xl border ${
           isDarkMode
-            ? 'bg-slate-900 border-slate-700 shadow-black/40'
-            : 'bg-white border-slate-200 shadow-slate-200/60'
+            ? 'bg-slate-900 border-slate-700'
+            : 'bg-white border-slate-200'
         }`}
       >
         <div
@@ -1159,7 +1159,7 @@ function TradeResultsCard({
       <div
         style={{
           backgroundImage: isDarkMode
-            ? 'linear-gradient(135deg, rgb(15,23,42), rgba(16,185,129,0.05))'
+            ? 'linear-gradient(135deg, #1a1a1a, rgba(16,185,129,0.05))'
             : 'linear-gradient(135deg, #ffffff, rgba(236,253,245,0.5))',
         }}
         className={`rounded-2xl border p-6 ${
@@ -1244,10 +1244,10 @@ function TradeResultsCard({
             : isDarkMode ? 'border-amber-500/30' : 'border-amber-200';
           const cardBgImage = isWinner
             ? isDarkMode
-              ? 'linear-gradient(135deg, rgb(15,23,42), rgba(16,185,129,0.05))'
+              ? 'linear-gradient(135deg, #1a1a1a, rgba(16,185,129,0.05))'
               : 'linear-gradient(135deg, #ffffff, rgba(236,253,245,0.6))'
             : isDarkMode
-              ? 'linear-gradient(135deg, rgb(15,23,42), rgba(245,158,11,0.05))'
+              ? 'linear-gradient(135deg, #1a1a1a, rgba(245,158,11,0.05))'
               : 'linear-gradient(135deg, #ffffff, rgba(255,251,235,0.6))';
           const badgeClasses = isWinner
             ? isDarkMode
@@ -1362,7 +1362,7 @@ function TradeResultsCard({
         <div
           style={{
             backgroundImage: isDarkMode
-              ? 'linear-gradient(135deg, rgb(15,23,42), rgba(59,130,246,0.05))'
+              ? 'linear-gradient(135deg, #1a1a1a, rgba(59,130,246,0.05))'
               : 'linear-gradient(135deg, #ffffff, rgba(239,246,255,0.6))',
           }}
           className={`rounded-xl border p-5 ${
@@ -2005,7 +2005,7 @@ export function TradeAnalyzerView({ isDarkMode }: TradeAnalyzerViewProps) {
       onClick={onClick}
       className={`px-3 py-1.5 text-xs font-semibold rounded-md border transition-all ${
         active
-          ? 'bg-blue-600 text-white border-blue-600 shadow-sm'
+          ? 'bg-blue-600 text-white border-blue-600'
           : isDarkMode
           ? 'bg-slate-950 border-slate-800 text-slate-300 hover:border-slate-600 hover:text-white'
           : 'bg-white border-slate-200 text-slate-600 hover:border-slate-300 hover:text-slate-900'
@@ -2647,7 +2647,7 @@ export function TradeAnalyzerView({ isDarkMode }: TradeAnalyzerViewProps) {
             disabled={!canAnalyze}
             className={`flex-1 px-6 py-3 rounded-lg text-sm font-bold transition-all flex items-center justify-center gap-2 ${
               canAnalyze
-                ? 'bg-blue-600 text-white hover:bg-blue-700 shadow-lg shadow-blue-600/20'
+                ? 'bg-blue-600 text-white hover:bg-blue-700'
                 : isDarkMode
                 ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
                 : 'bg-slate-100 text-slate-400 cursor-not-allowed'


### PR DESCRIPTION
Page-by-page UI cohesion cleanup on top of the merged app-wide de-tint (#237). Each page: remove off-standard `shadow-*` (depth = borders only) and neutralize hardcoded off-palette colors/gradients per docs/design-standard.md.

- **HomeView** — hero gradient (slate-900 + blue-purple -> neutral + faint brand-blue) and user-avatar gradient (blue->purple -> blue->blue).
- **Trade Analyzer** (+ shell) — removed 6 shadows (dropdown, slider thumb, chat input, active pill, analyze button, active tab); neutralized 4 result-card gradient bases (slate-900 -> #1a1a1a), keeping semantic tints + the fairness-slider data-viz.

More pages to follow on this branch. Build green; no logic changes.