### PR TITLE
Fix failing AI trade analysis (retired Sonnet 4 model)

### DIFF
--- a/server/src/routes/draftRankings.ts
+++ b/server/src/routes/draftRankings.ts
@@ -223,7 +223,7 @@ draftRankingsRoutes.post('/ask', authMiddleware, rateLimit(20, 60_000), async (c
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         max_tokens: 1024,
         system: buildDraftAskSystemPrompt(rankingType, scoringFormat, contextBlock),
         messages: [...recentHistory, { role: 'user', content: question }],

--- a/server/src/routes/tradeHistory.ts
+++ b/server/src/routes/tradeHistory.ts
@@ -1114,7 +1114,7 @@ Provide your JSON analysis. Weight the ACTUAL OUTCOME block more heavily than th
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         max_tokens: 2048,
         system: systemPrompt,
         messages: [{ role: 'user', content: userMessage }],

--- a/server/src/routes/trades.ts
+++ b/server/src/routes/trades.ts
@@ -500,7 +500,7 @@ tradesRoutes.post(
           'anthropic-version': '2023-06-01',
         },
         body: JSON.stringify({
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           max_tokens: 1024,
           system: buildFollowUpSystemPrompt(),
           messages: [

--- a/server/src/services/tradeAnalyzer.ts
+++ b/server/src/services/tradeAnalyzer.ts
@@ -409,7 +409,7 @@ Respond with the JSON schema described in the system prompt.`;
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         max_tokens: 2048,
         system: systemPrompt,
         messages: [{ role: 'user', content: userMessage }],


### PR DESCRIPTION
## Why AI trades were failing

All AI trade analysis (and the related follow-up, draft-ask, and trade-history endpoints) called the Anthropic API with model **`claude-sonnet-4-20250514`**. Anthropic **retired that model on 2026-06-15** — 4 days before today (2026-06-19).

A retired model ID returns a `404 not_found_error`, so each request hit the `if (!res.ok)` branch and returned *"AI analysis failed. Please try again later."* (HTTP 502). From the user's perspective, every trade analysis fails.

## Fix

Swap the retired ID for its documented drop-in replacement **`claude-sonnet-4-6`** at the four remaining call sites:

- `server/src/services/tradeAnalyzer.ts` (main trade grader)
- `server/src/routes/trades.ts` (follow-up chat)
- `server/src/routes/draftRankings.ts` (draft "Ask AI")
- `server/src/routes/tradeHistory.ts` (trade-history analysis)

`server/src/services/draftRankings.ts:28` was already on `claude-sonnet-4-6`, confirming the intended replacement — these four were simply missed.

## Compatibility

Sonnet 4.6 keeps the same request surface these calls use (`temperature`, `max_tokens`, plain user messages — no `budget_tokens`, thinking config, or assistant prefills), so the model-ID swap is the only change required. Server `tsc --noEmit` passes.

> Note: Sonnet 4.6 defaults to `high` effort, which can add some latency/cost vs. Sonnet 4. If that matters, a follow-up could set `thinking: {type: "disabled"}` + `output_config: {effort: "low"}` on these JSON-extraction calls — left out here to keep the fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6ttTwLfFpK5K6hjWQNuoj)_