### PR TITLE
Hotfix: Ask AI broken — claude-sonnet-4-6 retired

### DIFF
--- a/server/src/routes/draftRankings.ts
+++ b/server/src/routes/draftRankings.ts
@@ -223,7 +223,7 @@ draftRankingsRoutes.post('/ask', authMiddleware, rateLimit(20, 60_000), async (c
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-sonnet-4-6',
+        model: 'claude-sonnet-5',
         max_tokens: 1024,
         system: buildDraftAskSystemPrompt(rankingType, scoringFormat, contextBlock),
         messages: [...recentHistory, { role: 'user', content: question }],

--- a/server/src/routes/tradeHistory.ts
+++ b/server/src/routes/tradeHistory.ts
@@ -1114,7 +1114,7 @@ Provide your JSON analysis. Weight the ACTUAL OUTCOME block more heavily than th
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-sonnet-4-6',
+        model: 'claude-sonnet-5',
         max_tokens: 2048,
         system: systemPrompt,
         messages: [{ role: 'user', content: userMessage }],

--- a/server/src/routes/trades.ts
+++ b/server/src/routes/trades.ts
@@ -500,7 +500,7 @@ tradesRoutes.post(
           'anthropic-version': '2023-06-01',
         },
         body: JSON.stringify({
-          model: 'claude-sonnet-4-6',
+          model: 'claude-sonnet-5',
           max_tokens: 1024,
           system: buildFollowUpSystemPrompt(),
           messages: [

--- a/server/src/services/draftRankings.ts
+++ b/server/src/services/draftRankings.ts
@@ -25,7 +25,7 @@ import { generateId } from '../utils/id';
 
 type DB = ReturnType<typeof drizzle<typeof schema>>;
 
-const ANTHROPIC_MODEL = 'claude-sonnet-4-6';
+const ANTHROPIC_MODEL = 'claude-sonnet-5';
 // 200 redraft players × ~900 tokens each (rank + tier + projected points +
 // 1-sentence rationale + 3-5 sentence analysis + JSON scaffolding) easily
 // exceeds 32k, which silently truncates the model output mid-array. Sonnet

--- a/server/src/services/tradeAnalyzer.ts
+++ b/server/src/services/tradeAnalyzer.ts
@@ -409,7 +409,7 @@ Respond with the JSON schema described in the system prompt.`;
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-sonnet-4-6',
+        model: 'claude-sonnet-5',
         max_tokens: 2048,
         system: systemPrompt,
         messages: [{ role: 'user', content: userMessage }],


### PR DESCRIPTION
## Summary

Live "Ask AI" (Draft Rankings) and trade-analysis AI features are broken in production. Root cause: `claude-sonnet-4-6` has been retired by Anthropic — the exact same failure class fixed by #242 on 2026-06-19, which swapped `claude-sonnet-4-20250514` (retired 2026-06-15) to `claude-sonnet-4-6`. Every affected call now falls through to the `!res.ok` branch and returns a generic "AI analysis failed" / empty response.

This swaps the five remaining call sites currently live on `main` to `claude-sonnet-5` (current generation):
- `server/src/services/tradeAnalyzer.ts` (trade grading)
- `server/src/services/draftRankings.ts` (ranking generation)
- `server/src/routes/draftRankings.ts` (`/ask`)
- `server/src/routes/trades.ts` (follow-up chat)
- `server/src/routes/tradeHistory.ts` (retro trade grading)

Minimal, one-line-per-file diff, no other changes. The `ai.ts` Haiku call site (news relevance) is unaffected — `claude-haiku-4-5-20251001` is still current.

## Test plan
- `cd server && npx tsc --noEmit` — clean

**This is a live production bug affecting paying Pro/Elite users right now — recommend merging as soon as CI is green rather than waiting on other work.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESYBhQBorBLvKaSJVy2HkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESYBhQBorBLvKaSJVy2HkH)_