### PR TITLE
Split dynasty_rookie draft rankings into dynasty + rookie

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,6 +11,11 @@
 > `docs/COMPLETION_PLAN.md` for the plan and `TODO.md` for what remains
 > (owner-blocked credentials, external data sources, premium roadmap).
 > Checkboxes below are historical; `TODO.md` is the live list.
+>
+> **Follow-up:** the Draft Rankings `dynasty_rookie` type split into
+> `dynasty` (whole-player-pool, long-term asset value) and `rookie`
+> (unchanged rookie-only ranking). See `TODO.md` → "Shipped since the
+> completion sprint".
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,16 @@ Deploy notes: migrations `0037`–`0041` auto-apply on merge; superflex +
 ceiling/floor data appears after the next Monday ranking batch; rank
 history accrues from the first daily cron.
 
+## Shipped since the completion sprint
+
+- Draft Rankings three-way split: `dynasty_rookie` is now two distinct
+  ranking types — `dynasty` (whole-player-pool, long-term asset value,
+  age-curve-aware AI prompt) and `rookie` (unchanged rookie-only ranking,
+  renamed for clarity). New `Dynasty`/`Rookie` pills in the UI, 12
+  `DEFAULT_VARIANTS` (was 8), migration `0042` renames existing
+  `dynasty_rookie` rows to `rookie`. Dynasty data appears after the next
+  Monday ranking batch.
+
 ---
 
 ## P0 — Owner action required (not code)
@@ -58,8 +68,6 @@ history accrues from the first daily cron.
 - [ ] **PlayerCard Alert/Pin/Compare actions** — deliberately skipped in
   the sprint (Watch/Share shipped). Compare could reuse the Draft
   Rankings compare-basket pattern.
-- [ ] **Redraft / Dynasty / Rookie three-way split** — backend still
-  bundles `dynasty_rookie`; splitting needs regeneration plumbing.
 
 ## P2 — Data feeds (see roadmap in docs/COMPLETION_PLAN.md)
 

--- a/server/migrations/0042_rename_dynasty_rookie_to_rookie.sql
+++ b/server/migrations/0042_rename_dynasty_rookie_to_rookie.sql
@@ -1,0 +1,9 @@
+-- Splits the "dynasty_rookie" ranking type into two distinct types:
+-- "dynasty" (new — whole-player-pool long-term asset value) and "rookie"
+-- (the existing rookie-only ranking, renamed for clarity now that it's no
+-- longer the only dynasty-flavored variant). Existing rows tagged
+-- 'dynasty_rookie' are rookie-only rankings, so they rename to 'rookie'
+-- directly; the new 'dynasty' variant has no historical data and starts
+-- fresh on the next batch.
+UPDATE `draft_rankings` SET `ranking_type` = 'rookie' WHERE `ranking_type` = 'dynasty_rookie';
+UPDATE `rank_history` SET `ranking_type` = 'rookie' WHERE `ranking_type` = 'dynasty_rookie';

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -752,7 +752,7 @@ export type NewPlayerAiAnalysis = typeof playerAiAnalyses.$inferInsert;
 export const draftRankings = sqliteTable('draft_rankings', {
   id: text('id').primaryKey(),
   playerId: text('player_id').notNull().references(() => nflPlayers.id, { onDelete: 'cascade' }),
-  rankingType: text('ranking_type').notNull(), // 'redraft' | 'dynasty_rookie'
+  rankingType: text('ranking_type').notNull(), // 'redraft' | 'dynasty' | 'rookie'
   scoringFormat: text('scoring_format').notNull(), // 'ppr' | 'half-ppr' | 'standard'
   superflex: integer('superflex', { mode: 'boolean' }).notNull().default(false),
   overallRank: integer('overall_rank').notNull(),
@@ -790,7 +790,7 @@ export type NewDraftRanking = typeof draftRankings.$inferInsert;
 export const rankHistory = sqliteTable('rank_history', {
   id: text('id').primaryKey(),
   playerId: text('player_id').notNull().references(() => nflPlayers.id, { onDelete: 'cascade' }),
-  rankingType: text('ranking_type').notNull(), // 'redraft' | 'dynasty_rookie'
+  rankingType: text('ranking_type').notNull(), // 'redraft' | 'dynasty' | 'rookie'
   scoringFormat: text('scoring_format').notNull(), // 'ppr' | 'half-ppr' | 'standard'
   superflex: integer('superflex', { mode: 'boolean' }).notNull().default(false),
   overallRank: integer('overall_rank').notNull(),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -360,10 +360,14 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
     await callSync('/api/admin/generate-draft-rankings', { type: 'redraft', scoring: 'half-ppr' });
     await callSync('/api/admin/generate-draft-rankings', { type: 'redraft', scoring: 'ppr', superflex: true });
     await callSync('/api/admin/generate-draft-rankings', { type: 'redraft', scoring: 'half-ppr', superflex: true });
-    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty_rookie', scoring: 'ppr' });
-    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty_rookie', scoring: 'half-ppr' });
-    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty_rookie', scoring: 'ppr', superflex: true });
-    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty_rookie', scoring: 'half-ppr', superflex: true });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty', scoring: 'ppr' });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty', scoring: 'half-ppr' });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty', scoring: 'ppr', superflex: true });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'dynasty', scoring: 'half-ppr', superflex: true });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'rookie', scoring: 'ppr' });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'rookie', scoring: 'half-ppr' });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'rookie', scoring: 'ppr', superflex: true });
+    await callSync('/api/admin/generate-draft-rankings', { type: 'rookie', scoring: 'half-ppr', superflex: true });
   } else if (event.cron === '15 * * * *') {
     // Hourly: drain any ranking batches that have ended. Cheap no-op when
     // there are no pending batches.

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1983,7 +1983,7 @@ adminRoutes.post('/bulk-set-tier', async (c) => {
  * runs that hourly).
  *
  * Body:
- *  - type: 'redraft' | 'dynasty_rookie' (default: 'redraft')
+ *  - type: 'redraft' | 'dynasty' | 'rookie' (default: 'redraft')
  *  - scoring: 'ppr' | 'half-ppr' | 'standard' (default: 'ppr')
  *  - superflex: boolean (default: false)
  *  - season: number (default: current year)
@@ -2004,13 +2004,13 @@ adminRoutes.post('/generate-draft-rankings', async (c) => {
       season?: number;
     };
 
-    const rankingType = (body.type || 'redraft') as 'redraft' | 'dynasty_rookie';
+    const rankingType = (body.type || 'redraft') as 'redraft' | 'dynasty' | 'rookie';
     const scoringFormat = (body.scoring || 'ppr') as 'ppr' | 'half-ppr' | 'standard';
     const superflex = body.superflex ?? false;
     const seasonYear = body.season || new Date().getFullYear();
 
-    if (!['redraft', 'dynasty_rookie'].includes(rankingType)) {
-      return c.json({ error: 'Invalid type — use "redraft" or "dynasty_rookie"' }, 400);
+    if (!['redraft', 'dynasty', 'rookie'].includes(rankingType)) {
+      return c.json({ error: 'Invalid type — use "redraft", "dynasty", or "rookie"' }, 400);
     }
     if (!['ppr', 'half-ppr', 'standard'].includes(scoringFormat)) {
       return c.json({ error: 'Invalid scoring — use "ppr", "half-ppr", or "standard"' }, 400);

--- a/server/src/routes/draftRankings.ts
+++ b/server/src/routes/draftRankings.ts
@@ -15,20 +15,20 @@ export const draftRankingsRoutes = new Hono<{ Bindings: Env; Variables: Variable
  * GET /api/draft-rankings
  *
  * Query params:
- *  - type: 'redraft' | 'dynasty_rookie' (default: 'redraft')
+ *  - type: 'redraft' | 'dynasty' | 'rookie' (default: 'redraft')
  *  - scoring: 'ppr' | 'half-ppr' | 'standard' (default: 'ppr')
  *  - superflex: '0' | '1' (default: '0')
  *  - season: number (default: current year)
  */
 draftRankingsRoutes.get('/', async (c) => {
   const db = c.get('db');
-  const rankingType = (c.req.query('type') || 'redraft') as 'redraft' | 'dynasty_rookie';
+  const rankingType = (c.req.query('type') || 'redraft') as 'redraft' | 'dynasty' | 'rookie';
   const scoringFormat = (c.req.query('scoring') || 'ppr') as 'ppr' | 'half-ppr' | 'standard';
   const superflex = c.req.query('superflex') === '1';
   const season = parseInt(c.req.query('season') || String(new Date().getFullYear()), 10);
 
   // Validate
-  if (!['redraft', 'dynasty_rookie'].includes(rankingType)) {
+  if (!['redraft', 'dynasty', 'rookie'].includes(rankingType)) {
     return c.json({ error: 'Invalid ranking type' }, 400);
   }
   if (!['ppr', 'half-ppr', 'standard'].includes(scoringFormat)) {
@@ -190,7 +190,7 @@ function buildDraftAskContext(
 }
 
 function buildDraftAskSystemPrompt(rankingType: string, scoringFormat: string, contextBlock: string): string {
-  const label = rankingType === 'dynasty_rookie' ? 'dynasty rookie' : 'redraft';
+  const label = rankingType === 'dynasty' ? 'dynasty' : rankingType === 'rookie' ? 'dynasty rookie' : 'redraft';
   return `You are FilmRoom's draft assistant helping a user with their fantasy football draft. You have FilmRoom's current ${label} rankings in ${scoringFormat.toUpperCase()} scoring (below). Answer the user's question using these rankings — recommend players, compare options, suggest picks by ADP and tier, and explain your reasoning concisely.
 
 Respond in plain text (not JSON), under 4 short paragraphs. If the question is outside fantasy football drafting, politely redirect to draft topics.
@@ -222,11 +222,11 @@ draftRankingsRoutes.post('/ask', authMiddleware, requireTier('pro', 'Ask AI'), r
     return c.json({ error: 'question required' }, 400);
   }
 
-  const rankingType = (body.type || 'redraft') as 'redraft' | 'dynasty_rookie';
+  const rankingType = (body.type || 'redraft') as 'redraft' | 'dynasty' | 'rookie';
   const scoringFormat = (body.scoring || 'ppr') as 'ppr' | 'half-ppr' | 'standard';
   const superflex = body.superflex === true;
   const season = body.season || new Date().getFullYear();
-  if (!['redraft', 'dynasty_rookie'].includes(rankingType)) {
+  if (!['redraft', 'dynasty', 'rookie'].includes(rankingType)) {
     return c.json({ error: 'Invalid ranking type' }, 400);
   }
   if (!['ppr', 'half-ppr', 'standard'].includes(scoringFormat)) {

--- a/server/src/services/draftRankings.ts
+++ b/server/src/services/draftRankings.ts
@@ -8,7 +8,7 @@
  *
  * Flow:
  *  1. Weekly cron calls submitDraftRankingsBatch({ variants: [...] }).
- *  2. That builds one Claude request per variant (redraft/dynasty_rookie ×
+ *  2. That builds one Claude request per variant (redraft/dynasty/rookie ×
  *     ppr/half-ppr × 1-QB/superflex), wraps them in a single
  *     POST /v1/messages/batches submission, records a row in ranking_batch_jobs,
  *     and returns immediately.
@@ -40,10 +40,14 @@ const ANTHROPIC_BATCH_URL = 'https://api.anthropic.com/v1/messages/batches';
 // drafts (Josh Allen @ ADP 2.21 instead of ~20), which pollutes 1-QB
 // rankings badly.
 //
-// Dynasty rookie ADP comes from FantasyCalc (primary) — they publish
-// dynasty values that include rookies with age/prospect-adjusted ranks;
-// after filtering to rookies-only at write time we get a clean rookie
-// pecking order. MFL IS_KEEPER=R is kept as a fallback for rookies that
+// Dynasty ADP (all players, long-term asset value) comes straight from
+// FantasyCalc's overall dynasty rank — no rookie filter, no fallback
+// merge, since FC's dynasty pool has full veteran + rookie coverage.
+//
+// Rookie ADP comes from FantasyCalc (primary) — they publish dynasty
+// values that include rookies with age/prospect-adjusted ranks; after
+// filtering to rookies-only at write time we get a clean rookie pecking
+// order. MFL IS_KEEPER=R is kept as a fallback for rookies that
 // FantasyCalc doesn't cover yet (e.g. late-breaking rookies).
 
 /**
@@ -176,6 +180,25 @@ async function fetchFantasyCalcDynastyValues(
     console.error('[draftRankings] FantasyCalc dynasty fetch failed:', err);
     return new Map();
   }
+}
+
+/**
+ * Build a whole-player-pool dynasty ADP map straight from FantasyCalc's
+ * overall dynasty rank (1 = most valuable dynasty asset). Unlike the rookie
+ * map below, no re-indexing or MFL fallback is needed — FC's dynasty
+ * dataset already covers the full veteran + rookie pool.
+ */
+async function buildDynastyAdpMap(
+  scoringFormat: 'ppr' | 'half-ppr' | 'standard',
+  superflex: boolean,
+): Promise<Map<string, number>> {
+  const fcDynasty = await fetchFantasyCalcDynastyValues(scoringFormat, superflex);
+  const result = new Map<string, number>();
+  for (const [name, { rank }] of fcDynasty) {
+    result.set(name, rank);
+  }
+  console.log(`[draftRankings] Dynasty ADP: ${result.size} entries`);
+  return result;
 }
 
 /**
@@ -312,7 +335,7 @@ interface PlayerContext {
 
 async function buildPlayerContexts(
   db: DB,
-  rankingType: 'redraft' | 'dynasty_rookie',
+  rankingType: 'redraft' | 'dynasty' | 'rookie',
   scoringFormat: 'ppr' | 'half-ppr' | 'standard',
   seasonYear: number,
   adpByNormalizedName: Map<string, number>,
@@ -322,7 +345,10 @@ async function buildPlayerContexts(
     where: inArray(schema.nflPlayers.position, posFilter),
   });
 
-  let players = rankingType === 'dynasty_rookie'
+  // Rookie rankings scope to this year's incoming class; redraft and dynasty
+  // both rank the full active pool (dynasty just weighs long-term value
+  // instead of single-season points).
+  let players = rankingType === 'rookie'
     ? allPlayers.filter(p => p.yearsExp === 0)
     : allPlayers.filter(p => p.status !== 'inactive' && p.team !== 'FA');
 
@@ -458,7 +484,75 @@ IMPORTANT:
 - analysis: 3-5 sentences of real scouting — strengths, weaknesses, situation, fantasy outlook. This is the main value-add. Be specific: reference stats, scheme, coaching, age curves, injury history. "Elite volume" is lazy; "led NFL with 178 targets at age 24, now gets a healthy Dak back after relying on Cooper Rush for 6 games" is good.`;
 }
 
-function buildDynastyRookiePrompt(
+function buildDynastyPrompt(
+  players: PlayerContext[],
+  scoringFormat: string,
+  superflex: boolean,
+): string {
+  const playerLines = players
+    .filter(p => p.lastSeasonPoints !== null || p.adp !== null)
+    .sort((a, b) => (a.adp ?? 999) - (b.adp ?? 999))
+    .slice(0, 250)
+    .map(p => {
+      const ppg = p.lastSeasonPoints && p.lastSeasonGames
+        ? (p.lastSeasonPoints / p.lastSeasonGames).toFixed(1)
+        : 'N/A';
+      const newsStr = p.recentNews.length > 0 ? ` | News: ${p.recentNews.join('; ')}` : '';
+      return `${p.name} (${p.position}, ${p.team}) | Age: ${p.age ?? '?'} | Exp: ${p.yearsExp ?? '?'}yr | Status: ${p.status}${p.injuryNote ? ` (${p.injuryNote})` : ''} | Depth: ${p.depthChartOrder ?? '?'} | Last Season: ${p.lastSeasonPoints?.toFixed(1) ?? 'N/A'} pts in ${p.lastSeasonGames ?? 0} games (${ppg} ppg) | Dynasty ADP: ${p.adp ?? 'N/A'}${newsStr}`;
+    })
+    .join('\n');
+
+  return `You are an expert fantasy football dynasty analyst generating DYNASTY ${scoringFormat.toUpperCase()} rankings — a long-term asset-value ranking of the full player pool (not a single-season redraft ranking).${superflex ? ' This is a SUPERFLEX league — QBs hold their dynasty value far longer and rank much higher than in 1-QB.' : ' This is a 1-QB league — QB dynasty value is real but capped by scarcity of a single starting slot.'}
+
+TASK: Rank these players by long-term dynasty asset value — the combination of a player's expected production over the NEXT 3+ SEASONS, not just next year. Dynasty ADP is your primary anchor — stay within ±10 spots of Dynasty ADP unless you have a SPECIFIC, CONCRETE reason (age cliff, contract/opportunity change, injury with long recovery, coaching change altering scheme fit for multiple years).
+
+PLAYER DATA:
+${playerLines}
+
+RESPOND WITH ONLY VALID JSON — an array of objects, one per ranked player. Rank the top 200 players:
+[
+  {
+    "name": "Player Name",
+    "position": "QB|RB|WR|TE",
+    "overallRank": 1,
+    "positionRank": 1,
+    "tier": 1,
+    "projectedPoints": 320.5,
+    "ceilingRank": 1,
+    "floorRank": 8,
+    "rationale": "1 concise sentence summarizing dynasty value and age/opportunity outlook",
+    "analysis": "3-5 sentence detailed breakdown covering: age curve and remaining runway, situation/opportunity stability, injury/durability history, and long-term outlook vs redraft-only value. Reference specific ages, contract/depth-chart situations, and multi-year trends."
+  }
+]
+
+CEILING/FLOOR: ceilingRank is the player's realistic best-case dynasty rank if things break right (a number <= overallRank); floorRank is the realistic worst-case rank if age/situation turns (a number >= overallRank). Young ascending players get tighter ceiling bands; aging or crowded-situation players get wider floor bands. Both must be integers.
+
+DYNASTY-SPECIFIC VALUE RULES (critical — this is NOT a redraft ranking):
+- AGE IS A DIRECT INPUT, not a tiebreaker. A 24-year-old WR1 outranks a 30-year-old WR1 with similar current production, because dynasty value compounds over the RB/WR age cliff (typically 27-29) and the longer QB/TE prime.
+- RBs decline earliest and hardest — a 27+ year old RB, even an elite one, should be discounted relative to redraft value. A 22-23 year old RB in a good situation can outrank a same-production 28-year-old RB.
+- WRs and TEs age more gracefully — prime years often extend to 29-31.
+- QBs hold dynasty value longest (often into their mid-30s), which is why ${superflex ? 'SUPERFLEX dynasty startups spend early first-round picks on young QBs' : 'even in 1-QB, a young ascending QB1 is a top-15 dynasty asset despite modest redraft ADP'}.
+- Rookies and 2nd/3rd-year players with a clear opportunity path should rank ABOVE aging veterans with similar or even better current production, because dynasty value is about the next 3+ years, not just next year.
+- A player facing an imminent age cliff, declining role, or crowded backfield/depth chart should be marked DOWN from raw current production.
+
+TIER RULES (dynasty asset value):
+- Tier 1: Cornerstone assets — elite young players locked into their prime for years (top ~8-10)
+- Tier 2: High-end long-term assets (top ~20)
+- Tier 3: Strong dynasty holds (top ~40)
+- Tier 4: Solid contributors with real runway (top ~70)
+- Tier 5: Flex-worthy assets, moderate long-term value (top ~100)
+- Tier 6: Speculative holds — youth or role upside, unproven (top ~140)
+- Tier 7: Late-round dynasty stashes (top ~180)
+- Tier 8: Deep dynasty depth / aging veterans near their cliff (180+)
+
+IMPORTANT:
+- projectedPoints is this upcoming season's projected total for ${scoringFormat} scoring — informative context, but overallRank is driven by long-term dynasty value, not this number alone.
+- Deviating more than ±10 from Dynasty ADP requires a concrete age/situation/opportunity reason cited in the rationale.
+- rationale: 1 punchy sentence (shown inline in the rankings table)
+- analysis: 3-5 sentences of real dynasty scouting — age curve, situation stability, injury history, multi-year outlook. Be specific: "Age 24, entering his prime with a 3-year extension worth of target share locked in behind a stable young QB" is good. "Great player with upside" is worthless.`;
+}
+
+function buildRookiePrompt(
   players: PlayerContext[],
   scoringFormat: string,
   superflex: boolean,
@@ -532,7 +626,7 @@ IMPORTANT:
 // ── Batch submission ────────────────────────────────────────────────
 
 export interface RankingVariant {
-  rankingType: 'redraft' | 'dynasty_rookie';
+  rankingType: 'redraft' | 'dynasty' | 'rookie';
   scoringFormat: 'ppr' | 'half-ppr' | 'standard';
   superflex: boolean;
 }
@@ -553,7 +647,7 @@ export interface SubmitBatchResult {
 
 interface BatchVariantMeta {
   customId: string;
-  rankingType: 'redraft' | 'dynasty_rookie';
+  rankingType: 'redraft' | 'dynasty' | 'rookie';
   scoringFormat: 'ppr' | 'half-ppr' | 'standard';
   superflex: boolean;
 }
@@ -584,10 +678,13 @@ export async function submitDraftRankingsBatch(
     //  Redraft 1-QB → FantasyPros 1-QB ADP (MFL is dominated by superflex drafts)
     //  Redraft superflex → MFL ADP (their pool being superflex-dominated is
     //    exactly the anchor we want for SF variants)
-    //  Dynasty rookie → FantasyCalc dynasty values filtered to rookies
+    //  Dynasty → FantasyCalc dynasty values across the full player pool
+    //  Rookie → FantasyCalc dynasty values filtered to rookies
     //    (clean age/prospect-adjusted ranks) + MFL IS_KEEPER=R fallback
-    const adp = v.rankingType === 'dynasty_rookie'
+    const adp = v.rankingType === 'rookie'
       ? await buildRookieAdpMap(db, v.scoringFormat, v.superflex, seasonYear)
+      : v.rankingType === 'dynasty'
+      ? await buildDynastyAdpMap(v.scoringFormat, v.superflex)
       : v.superflex
       ? await fetchMFLADP(seasonYear, v.scoringFormat, 'N')
       : await fetchFantasyProsADP(v.scoringFormat);
@@ -598,7 +695,9 @@ export async function submitDraftRankingsBatch(
     }
     const prompt = v.rankingType === 'redraft'
       ? buildRedraftPrompt(contexts, v.scoringFormat, v.superflex)
-      : buildDynastyRookiePrompt(contexts, v.scoringFormat, v.superflex);
+      : v.rankingType === 'dynasty'
+      ? buildDynastyPrompt(contexts, v.scoringFormat, v.superflex)
+      : buildRookiePrompt(contexts, v.scoringFormat, v.superflex);
 
     const customId = variantCustomId(v);
     requests.push({
@@ -936,8 +1035,10 @@ async function writeVariantRankings(args: WriteVariantArgs): Promise<WriteVarian
   // Re-fetch ADP for adpDelta so it reflects current ADP at write time
   // rather than what was in effect hours ago when the batch was submitted.
   // Same source routing as the submit path.
-  const adp = meta.rankingType === 'dynasty_rookie'
+  const adp = meta.rankingType === 'rookie'
     ? await buildRookieAdpMap(db, meta.scoringFormat, meta.superflex, seasonYear)
+    : meta.rankingType === 'dynasty'
+    ? await buildDynastyAdpMap(meta.scoringFormat, meta.superflex)
     : meta.superflex
     ? await fetchMFLADP(seasonYear, meta.scoringFormat, 'N')
     : await fetchFantasyProsADP(meta.scoringFormat);
@@ -1083,8 +1184,12 @@ export const DEFAULT_VARIANTS: RankingVariant[] = [
   { rankingType: 'redraft', scoringFormat: 'half-ppr', superflex: false },
   { rankingType: 'redraft', scoringFormat: 'ppr', superflex: true },
   { rankingType: 'redraft', scoringFormat: 'half-ppr', superflex: true },
-  { rankingType: 'dynasty_rookie', scoringFormat: 'ppr', superflex: false },
-  { rankingType: 'dynasty_rookie', scoringFormat: 'half-ppr', superflex: false },
-  { rankingType: 'dynasty_rookie', scoringFormat: 'ppr', superflex: true },
-  { rankingType: 'dynasty_rookie', scoringFormat: 'half-ppr', superflex: true },
+  { rankingType: 'dynasty', scoringFormat: 'ppr', superflex: false },
+  { rankingType: 'dynasty', scoringFormat: 'half-ppr', superflex: false },
+  { rankingType: 'dynasty', scoringFormat: 'ppr', superflex: true },
+  { rankingType: 'dynasty', scoringFormat: 'half-ppr', superflex: true },
+  { rankingType: 'rookie', scoringFormat: 'ppr', superflex: false },
+  { rankingType: 'rookie', scoringFormat: 'half-ppr', superflex: false },
+  { rankingType: 'rookie', scoringFormat: 'ppr', superflex: true },
+  { rankingType: 'rookie', scoringFormat: 'half-ppr', superflex: true },
 ];

--- a/src/components/AdminView.tsx
+++ b/src/components/AdminView.tsx
@@ -47,8 +47,10 @@ type AdminTab = 'overview' | 'analytics' | 'articles';
 const DRAFT_RANKING_VARIANTS = [
   { label: 'Redraft · PPR', type: 'redraft', scoring: 'ppr' },
   { label: 'Redraft · Half PPR', type: 'redraft', scoring: 'half-ppr' },
-  { label: 'Dynasty Rookie · PPR', type: 'dynasty_rookie', scoring: 'ppr' },
-  { label: 'Dynasty Rookie · Half PPR', type: 'dynasty_rookie', scoring: 'half-ppr' },
+  { label: 'Dynasty · PPR', type: 'dynasty', scoring: 'ppr' },
+  { label: 'Dynasty · Half PPR', type: 'dynasty', scoring: 'half-ppr' },
+  { label: 'Rookie · PPR', type: 'rookie', scoring: 'ppr' },
+  { label: 'Rookie · Half PPR', type: 'rookie', scoring: 'half-ppr' },
 ] as const;
 
 interface RankingBatchJob {

--- a/src/components/DraftRankingsView.test.tsx
+++ b/src/components/DraftRankingsView.test.tsx
@@ -136,13 +136,23 @@ describe('DraftRankingsView — data fetching', () => {
     expect(url).toContain('superflex=0');
   });
 
-  it('refetches dynasty rookies when the Dynasty pill is clicked', async () => {
+  it('refetches dynasty rankings when the Dynasty pill is clicked', async () => {
     renderView();
     await loaded();
     fireEvent.click(screen.getByRole('button', { name: 'Dynasty' }));
     await waitFor(() => {
       const urls = hoisted.mockGet.mock.calls.map(c => c[0] as string);
-      expect(urls.some(u => u.includes('type=dynasty_rookie'))).toBe(true);
+      expect(urls.some(u => u.includes('type=dynasty'))).toBe(true);
+    });
+  });
+
+  it('refetches rookie rankings when the Rookie pill is clicked', async () => {
+    renderView();
+    await loaded();
+    fireEvent.click(screen.getByRole('button', { name: 'Rookie' }));
+    await waitFor(() => {
+      const urls = hoisted.mockGet.mock.calls.map(c => c[0] as string);
+      expect(urls.some(u => u.includes('type=rookie'))).toBe(true);
     });
   });
 

--- a/src/components/DraftRankingsView.tsx
+++ b/src/components/DraftRankingsView.tsx
@@ -73,7 +73,7 @@ interface DraftRankingsViewProps {
 
 // ── Constants ───────────────────────────────────────────────────────
 
-type RankingType = 'redraft' | 'dynasty_rookie';
+type RankingType = 'redraft' | 'dynasty' | 'rookie';
 type ScoringFormat = 'ppr' | 'half-ppr' | 'standard';
 type PositionFilter = 'ALL' | 'QB' | 'RB' | 'WR' | 'TE';
 
@@ -88,7 +88,17 @@ const TIER_LABELS: Record<string, Record<number, string>> = {
     7: 'Late-Round Fliers',
     8: 'Deep Sleepers',
   },
-  dynasty_rookie: {
+  dynasty: {
+    1: 'Cornerstone Assets',
+    2: 'High-End Long-Term',
+    3: 'Strong Holds',
+    4: 'Solid Contributors',
+    5: 'Flex-Worthy Assets',
+    6: 'Speculative Holds',
+    7: 'Late-Round Stashes',
+    8: 'Deep Dynasty Depth',
+  },
+  rookie: {
     1: '1.01-level',
     2: 'Round 1',
     3: 'Early 2nd',
@@ -119,8 +129,7 @@ export function DraftRankingsView({ onPlayerClick, isDarkMode, onNavigate }: Dra
   const defaultScoring: ScoringFormat = (league?.scoringFormat as ScoringFormat) || 'ppr';
   const defaultSuperflex = (league as { hasSuperflex?: boolean } | null)?.hasSuperflex ?? false;
 
-  const [rankingView, setRankingView] = useState<'redraft' | 'dynasty'>('redraft');
-  const rankingType: RankingType = rankingView === 'redraft' ? 'redraft' : 'dynasty_rookie';
+  const [rankingType, setRankingType] = useState<RankingType>('redraft');
   const [scoringFormat, setScoringFormat] = useState<ScoringFormat>(defaultScoring);
   const [superflex, setSuperflex] = useState(defaultSuperflex);
   const [positionFilter, setPositionFilter] = useState<PositionFilter>('ALL');
@@ -364,8 +373,9 @@ export function DraftRankingsView({ onPlayerClick, isDarkMode, onNavigate }: Dra
       <div className="flex flex-wrap items-center gap-2">
         {/* Ranking view */}
         <div className="flex gap-1">
-          {pill(rankingView === 'redraft', () => setRankingView('redraft'), 'Redraft')}
-          {pill(rankingView === 'dynasty', () => setRankingView('dynasty'), 'Dynasty')}
+          {pill(rankingType === 'redraft', () => setRankingType('redraft'), 'Redraft')}
+          {pill(rankingType === 'dynasty', () => setRankingType('dynasty'), 'Dynasty')}
+          {pill(rankingType === 'rookie', () => setRankingType('rookie'), 'Rookie')}
         </div>
 
         <span className={`hidden sm:inline-block h-5 w-px ${isDarkMode ? 'bg-slate-700' : 'bg-slate-200'}`} />
@@ -558,7 +568,7 @@ export function DraftRankingsView({ onPlayerClick, isDarkMode, onNavigate }: Dra
 // ── Sub-components ──────────────────────────────────────────────────
 
 function EmptyState({ rankingType, superflex, isDarkMode }: { rankingType: RankingType; superflex: boolean; isDarkMode: boolean }) {
-  const label = rankingType === 'dynasty_rookie' ? 'Dynasty Rookie' : 'Redraft';
+  const label = rankingType === 'dynasty' ? 'Dynasty' : rankingType === 'rookie' ? 'Dynasty Rookie' : 'Redraft';
   return (
     <div className="flex flex-col items-center justify-center py-20 text-center">
       <Medal className={`w-12 h-12 mb-4 ${isDarkMode ? 'text-slate-600' : 'text-slate-300'}`} />


### PR DESCRIPTION
## Summary
`dynasty_rookie` was actually rookie-only (filtered to `yearsExp === 0`), so there was no ranking for long-term dynasty asset value across the whole player pool — only rookie-class ordering. This splits it into two real ranking types:

- **`dynasty`** (new) — whole-player-pool ranking driven by long-term asset value. New AI prompt weighs age curves (RB decline ~27-29, WR/TE longevity into 29-31, QB durability into mid-30s), opportunity stability, and multi-year outlook instead of single-season points. ADP anchor is FantasyCalc's overall dynasty rank, unfiltered.
- **`rookie`** (renamed) — the existing rookie-only ranking and prompt, unchanged in substance, renamed now that "dynasty" no longer means "rookies only".

## Changes
- `server/src/services/draftRankings.ts`: widened `RankingVariant`/`BatchVariantMeta` types, added `buildDynastyAdpMap` + `buildDynastyPrompt`, renamed `buildDynastyRookiePrompt` → `buildRookiePrompt`, updated ADP/prompt routing in both the submit and write paths, `DEFAULT_VARIANTS` grows 8 → 12.
- `server/src/routes/draftRankings.ts` + `admin.ts`: type whitelists and doc comments updated.
- `server/src/index.ts`: Monday cron now submits 12 variants instead of 8.
- `server/migrations/0042_rename_dynasty_rookie_to_rookie.sql`: renames existing `dynasty_rookie` rows to `rookie` in `draft_rankings` and `rank_history` (value rename, not a schema change — no `rankingType` CHECK constraint exists).
- `src/components/DraftRankingsView.tsx`: third **Rookie** pill alongside Redraft/Dynasty (collapsed the old `rankingView`→`rankingType` indirection into one 3-way state), dynasty-specific tier labels, 3-way empty-state copy.
- `src/components/AdminView.tsx`: manual-generate buttons for Dynasty and Rookie variants.
- `TODO.md`/`BACKLOG.md`: mirrored as shipped.

## Verification
- `npm run typecheck` ✓ (frontend + server)
- `npm test` ✓ (44 tests, +1 new for the Rookie pill)
- `npm run build` ✓
- Repo-wide grep confirms zero remaining `dynasty_rookie` references in `src/`/`server/`

## Deploy notes
Migration `0042` auto-applies on merge (existing CI pipeline). New `dynasty` data appears after the next Monday ranking batch — until then the Dynasty pill shows the "no rankings yet" empty state, same as any new variant.