### PR TITLE
Add PlayerCard Compare quick action

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,6 +11,10 @@
 > `docs/COMPLETION_PLAN.md` for the plan and `TODO.md` for what remains
 > (owner-blocked credentials, external data sources, premium roadmap).
 > Checkboxes below are historical; `TODO.md` is the live list.
+>
+> **Follow-up:** PlayerCard gained a Compare quick action (client-only
+> compare basket + side-by-side season-stat modal). See `TODO.md` →
+> "Shipped since the completion sprint".
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,16 @@ Deploy notes: migrations `0037`–`0041` auto-apply on merge; superflex +
 ceiling/floor data appears after the next Monday ranking batch; rank
 history accrues from the first daily cron.
 
+## Shipped since the completion sprint
+
+- PlayerCard Compare quick action: a client-only (localStorage) compare
+  basket (`useCompareBasket`, up to 4 players) with a "Compare" toggle
+  next to Watch/Share and a `PlayerCompareModal` showing season PPG /
+  games / season total side by side. Independent from the Draft Rankings
+  page's own compare feature (that one compares rank/tier/ADP within a
+  single ranking variant; this compares season stats for any player from
+  any context).
+
 ---
 
 ## P0 — Owner action required (not code)
@@ -55,9 +65,9 @@ history accrues from the first daily cron.
   email delivery (and waiver/trade/lineup-lock event types) remain.
 - [ ] **Season projections** — full-season projected totals per player;
   current pipeline is weekly-props-derived only.
-- [ ] **PlayerCard Alert/Pin/Compare actions** — deliberately skipped in
-  the sprint (Watch/Share shipped). Compare could reuse the Draft
-  Rankings compare-basket pattern.
+- [ ] **PlayerCard Alert/Pin actions** — Compare shipped as a follow-up
+  (see below); Alert needs notification delivery (see push/email item
+  below) and Pin needs its own persistence layer.
 - [ ] **Redraft / Dynasty / Rookie three-way split** — backend still
   bundles `dynasty_rookie`; splitting needs regeneration plumbing.
 

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useState, useMemo, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
-import { X, ArrowLeft, TrendingUp, TrendingDown, Zap, Target, Calendar, Star, Clock, Heart, Share2, Check, Sparkles, Lock } from 'lucide-react';
+import { X, ArrowLeft, TrendingUp, TrendingDown, Zap, Target, Calendar, Star, Clock, Heart, Share2, Check, Plus, Sparkles, Lock } from 'lucide-react';
 import { Player } from '../App';
 import api, { ApiError } from '../services/api';
 import { playerService } from '../services';
 import type { PlayerNews, MatchupGradeResponse, PlayerProjection } from '../services';
 import { useWatchlist } from '../hooks/useWatchlist';
+import { useCompareBasket } from '../hooks/useCompareBasket';
 import { useAuth } from '../context/AuthContext';
 import { buildPlayerProfilePath } from '../utils/slug';
 import { NewsSnippet } from './NewsSnippet';
+import { PlayerCompareModal } from './PlayerCompareModal';
 
 
 
@@ -153,6 +155,20 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
       }
     }
   };
+
+  // --- Quick action: Compare ---
+  const compare = useCompareBasket();
+  const isComparing = compare.isInBasket(player.id);
+  const [showCompareModal, setShowCompareModal] = useState(false);
+
+  const handleToggleCompare = () => {
+    compare.toggle({ id: player.id, name: player.name, position: player.position, team: player.team });
+  };
+
+  // Close the comparison modal automatically once the basket is emptied.
+  useEffect(() => {
+    if (compare.basket.length === 0) setShowCompareModal(false);
+  }, [compare.basket.length]);
 
   // --- FilmRoom AI Take (Pro/Elite) ---
   const { user, isAuthenticated } = useAuth();
@@ -519,11 +535,32 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
                       {shareCopied ? <Check className="w-3.5 h-3.5" /> : <Share2 className="w-3.5 h-3.5" />}
                       <span className="hidden sm:inline">{shareCopied ? 'Copied!' : 'Share'}</span>
                     </button>
+                    <button
+                      onClick={handleToggleCompare}
+                      aria-pressed={isComparing}
+                      title={isComparing ? 'Remove from comparison' : `Add to comparison (up to ${compare.max})`}
+                      className={`flex items-center gap-1.5 text-xs font-semibold px-2.5 py-1.5 rounded-lg border transition-colors ${
+                        isComparing
+                          ? 'bg-blue-500/15 border-blue-500/40 text-blue-500 hover:bg-blue-500/25'
+                          : isDarkMode ? 'bg-slate-800 border-slate-700 text-slate-300 hover:border-slate-600' : 'bg-white border-slate-200 text-slate-700 hover:border-slate-300'
+                      }`}
+                    >
+                      {isComparing ? <Check className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
+                      <span className="hidden sm:inline">{isComparing ? 'Added' : 'Compare'}</span>
+                    </button>
                   </div>
                   {matchupGrade && (
                     <span className="text-xs font-medium px-3 py-1.5 rounded-md border" style={getGradeStyle(matchupGrade)} title={matchupData?.message || `${getMatchupGradeLabel(matchupGrade)} matchup`}>
                       {matchupData?.opponent ? `vs ${matchupData.opponent} ` : 'Matchup '}{matchupGrade}
                     </span>
+                  )}
+                  {compare.basket.length >= 2 && (
+                    <button
+                      onClick={() => setShowCompareModal(true)}
+                      className={`text-xs font-semibold px-2.5 py-1 rounded-md transition-colors ${isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'}`}
+                    >
+                      View comparison ({compare.basket.length}) →
+                    </button>
                   )}
                 </div>
               </div>
@@ -1492,6 +1529,16 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
           </div>
         </div>
       </div>
+      {showCompareModal && (
+        <PlayerCompareModal
+          players={compare.basket}
+          isDarkMode={isDarkMode}
+          seasonYear={propsSeasonYear}
+          scoringFormat={scoringFormat}
+          onClose={() => setShowCompareModal(false)}
+          onRemove={compare.remove}
+        />
+      )}
     </div>,
     document.body
   );

--- a/src/components/PlayerCompareModal.tsx
+++ b/src/components/PlayerCompareModal.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import api from '../services/api';
+import type { CompareStub } from '../hooks/useCompareBasket';
+
+interface PlayerStatsResponse {
+  seasonTotals?: {
+    gamesPlayed?: number;
+    games?: number;
+    fantasyPointsPPR?: number;
+    fantasyPointsHalf?: number;
+    fantasyPointsStd?: number;
+  };
+  averagePointsPPR?: number;
+  averagePointsHalf?: number;
+  averagePointsStd?: number;
+}
+
+interface CompareRow {
+  stub: CompareStub;
+  loading: boolean;
+  gamesPlayed: number | null;
+  ppg: number | null;
+  seasonTotal: number | null;
+}
+
+const POSITION_COLORS: Record<string, string> = {
+  QB: 'text-red-400',
+  RB: 'text-green-400',
+  WR: 'text-blue-400',
+  TE: 'text-orange-400',
+};
+
+interface PlayerCompareModalProps {
+  players: CompareStub[];
+  isDarkMode: boolean;
+  seasonYear?: number;
+  /** Normalized scoring format, matching PlayerCard's own convention. */
+  scoringFormat?: 'ppr' | 'half_ppr' | 'standard';
+  onClose: () => void;
+  onRemove: (id: string) => void;
+}
+
+export function PlayerCompareModal({
+  players,
+  isDarkMode,
+  seasonYear,
+  scoringFormat = 'ppr',
+  onClose,
+  onRemove,
+}: PlayerCompareModalProps) {
+  const [rows, setRows] = useState<CompareRow[]>(
+    players.map((stub) => ({ stub, loading: true, gamesPlayed: null, ppg: null, seasonTotal: null })),
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setRows(players.map((stub) => ({ stub, loading: true, gamesPlayed: null, ppg: null, seasonTotal: null })));
+
+    const season = seasonYear || new Date().getFullYear();
+    Promise.all(
+      players.map(async (stub) => {
+        try {
+          const res = await api.get<PlayerStatsResponse>(`/players/${stub.id}/stats?season=${season}`);
+          const ppg = scoringFormat === 'half_ppr'
+            ? res.averagePointsHalf ?? null
+            : scoringFormat === 'standard'
+            ? res.averagePointsStd ?? null
+            : res.averagePointsPPR ?? null;
+          const seasonTotal = scoringFormat === 'half_ppr'
+            ? res.seasonTotals?.fantasyPointsHalf ?? null
+            : scoringFormat === 'standard'
+            ? res.seasonTotals?.fantasyPointsStd ?? null
+            : res.seasonTotals?.fantasyPointsPPR ?? null;
+          const gamesPlayed = res.seasonTotals?.gamesPlayed ?? res.seasonTotals?.games ?? null;
+          return { stub, loading: false, gamesPlayed, ppg: ppg ?? null, seasonTotal: seasonTotal ?? null };
+        } catch {
+          return { stub, loading: false, gamesPlayed: null, ppg: null, seasonTotal: null };
+        }
+      }),
+    ).then((results) => { if (!cancelled) setRows(results); });
+
+    return () => { cancelled = true; };
+  }, [players, seasonYear, scoringFormat]);
+
+  return (
+    <div className="fixed inset-0 z-[10000] flex items-center justify-center p-2 sm:p-4" role="dialog" aria-modal="true" aria-label="Player comparison">
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+      <div className={`relative w-full max-w-4xl max-h-[95vh] sm:max-h-[85vh] overflow-auto rounded-2xl border ${isDarkMode ? 'bg-slate-900 border-slate-700' : 'bg-white border-slate-200'}`}>
+        <div className={`sticky top-0 z-10 flex items-center justify-between px-5 py-3 border-b ${isDarkMode ? 'bg-slate-900 border-slate-800' : 'bg-white border-slate-200'}`}>
+          <h3 className={`text-sm font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+            Compare players ({rows.length})
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close comparison"
+            className={`inline-flex items-center justify-center w-11 h-11 sm:w-8 sm:h-8 rounded-lg border ${isDarkMode ? 'border-slate-700 text-slate-300 hover:bg-slate-800' : 'border-slate-200 text-slate-600 hover:bg-slate-50'}`}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="p-4 flex gap-3 overflow-x-auto">
+          {rows.map(({ stub, loading, gamesPlayed, ppg, seasonTotal }) => {
+            const posColor = POSITION_COLORS[stub.position] || 'text-slate-400';
+            const statRows: { label: string; value: string }[] = [
+              { label: 'Games', value: gamesPlayed != null ? String(gamesPlayed) : '—' },
+              { label: 'PPG', value: ppg != null ? ppg.toFixed(1) : '—' },
+              { label: 'Season Pts', value: seasonTotal != null ? seasonTotal.toFixed(1) : '—' },
+            ];
+            return (
+              <div
+                key={stub.id}
+                className={`min-w-[200px] flex-1 rounded-xl border p-3 ${isDarkMode ? 'bg-slate-900 border-slate-800' : 'bg-slate-50 border-slate-200'}`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className={`text-sm font-bold truncate ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{stub.name}</div>
+                    <div className="fr-text-11">
+                      <span className={`font-bold ${posColor}`}>{stub.position}</span>
+                      <span className={`ml-1.5 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>{stub.team}</span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => onRemove(stub.id)}
+                    aria-label={`Remove ${stub.name} from comparison`}
+                    className={`flex-shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-md border ${isDarkMode ? 'border-slate-700 text-slate-400 hover:bg-slate-800' : 'border-slate-200 text-slate-400 hover:bg-white'}`}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
+
+                <div className="mt-3 space-y-1.5">
+                  {loading ? (
+                    <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>Loading…</div>
+                  ) : (
+                    statRows.map(({ label, value }) => (
+                      <div key={label} className="flex justify-between text-xs">
+                        <span className={isDarkMode ? 'text-slate-400' : 'text-slate-500'}>{label}</span>
+                        <span className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{value}</span>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useCompareBasket.test.ts
+++ b/src/hooks/useCompareBasket.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCompareBasket, MAX_COMPARE } from './useCompareBasket';
+
+const player = (id: string) => ({ id, name: `Player ${id}`, position: 'RB', team: 'BUF' });
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useCompareBasket', () => {
+  it('starts empty when localStorage has nothing', () => {
+    const { result } = renderHook(() => useCompareBasket());
+    expect(result.current.basket).toEqual([]);
+  });
+
+  it('adds and removes a player via toggle', () => {
+    const { result } = renderHook(() => useCompareBasket());
+    act(() => result.current.toggle(player('a')));
+    expect(result.current.isInBasket('a')).toBe(true);
+    expect(result.current.basket).toHaveLength(1);
+
+    act(() => result.current.toggle(player('a')));
+    expect(result.current.isInBasket('a')).toBe(false);
+    expect(result.current.basket).toHaveLength(0);
+  });
+
+  it('caps the basket at MAX_COMPARE', () => {
+    const { result } = renderHook(() => useCompareBasket());
+    act(() => {
+      for (let i = 0; i < MAX_COMPARE + 2; i++) {
+        result.current.toggle(player(`p${i}`));
+      }
+    });
+    expect(result.current.basket).toHaveLength(MAX_COMPARE);
+    // The (MAX_COMPARE)th and (MAX_COMPARE+1)th players were dropped, not added.
+    expect(result.current.isInBasket(`p${MAX_COMPARE}`)).toBe(false);
+  });
+
+  it('remove() drops a single player regardless of basket size', () => {
+    const { result } = renderHook(() => useCompareBasket());
+    act(() => {
+      result.current.toggle(player('a'));
+      result.current.toggle(player('b'));
+    });
+    act(() => result.current.remove('a'));
+    expect(result.current.isInBasket('a')).toBe(false);
+    expect(result.current.isInBasket('b')).toBe(true);
+  });
+
+  it('clear() empties the basket', () => {
+    const { result } = renderHook(() => useCompareBasket());
+    act(() => {
+      result.current.toggle(player('a'));
+      result.current.toggle(player('b'));
+    });
+    act(() => result.current.clear());
+    expect(result.current.basket).toEqual([]);
+  });
+
+  it('persists across separate hook instances via localStorage', () => {
+    const first = renderHook(() => useCompareBasket());
+    act(() => first.result.current.toggle(player('a')));
+
+    const second = renderHook(() => useCompareBasket());
+    expect(second.result.current.isInBasket('a')).toBe(true);
+  });
+});

--- a/src/hooks/useCompareBasket.ts
+++ b/src/hooks/useCompareBasket.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface CompareStub {
+  id: string;
+  name: string;
+  position: string;
+  team: string;
+}
+
+const STORAGE_KEY = 'filmroom_compare_basket';
+const CHANGE_EVENT = 'filmroom:compare-basket-changed';
+export const MAX_COMPARE = 4;
+
+function readBasket(): CompareStub[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeBasket(list: CompareStub[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // Storage unavailable (private mode, quota) — the in-memory state still
+    // updates for this session via the dispatched event below.
+  }
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+/**
+ * Client-only "compare basket" for PlayerCard — lets a user star up to
+ * MAX_COMPARE players while browsing and pull up a side-by-side season-stat
+ * view. Deliberately separate from Draft Rankings' own compare feature: that
+ * one compares rank/tier/ADP within a single ranking variant, this one
+ * compares season averages for any player regardless of context, so the two
+ * data shapes don't need to be unified.
+ */
+export function useCompareBasket() {
+  const [basket, setBasket] = useState<CompareStub[]>(() => readBasket());
+
+  useEffect(() => {
+    const onChange = () => setBasket(readBasket());
+    window.addEventListener(CHANGE_EVENT, onChange);
+    window.addEventListener('storage', onChange);
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, onChange);
+      window.removeEventListener('storage', onChange);
+    };
+  }, []);
+
+  const isInBasket = useCallback(
+    (id: string) => basket.some((p) => p.id === id),
+    [basket],
+  );
+
+  const toggle = useCallback((stub: CompareStub) => {
+    const current = readBasket();
+    const exists = current.some((p) => p.id === stub.id);
+    if (exists) {
+      writeBasket(current.filter((p) => p.id !== stub.id));
+      return;
+    }
+    if (current.length >= MAX_COMPARE) return;
+    writeBasket([...current, stub]);
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    writeBasket(readBasket().filter((p) => p.id !== id));
+  }, []);
+
+  const clear = useCallback(() => writeBasket([]), []);
+
+  return { basket, isInBasket, toggle, remove, clear, max: MAX_COMPARE };
+}


### PR DESCRIPTION
## Summary
Watch/Share shipped in the completion sprint; Compare was deliberately skipped pending a decision on how to reuse the Draft Rankings compare-basket pattern. That page's `PlayerComparisonModal` is tightly coupled to `DraftRanking` (rank/tier/ADP/analysis) — fields PlayerCard doesn't have since it isn't scoped to any one ranking variant (PlayerCard opens from the board, watchlist, team view, matchup view, etc.). Rather than force that coupling, this adds an independent, client-only compare feature scoped to what PlayerCard actually has: season stats.

## Changes
- **`useCompareBasket`** (new hook) — localStorage-backed basket, capped at 4 players, synced across mounted `PlayerCard` instances via a custom event plus the native `storage` event for cross-tab updates. `toggle()`/`remove()` always re-read from storage rather than closing over React state, so rapid toggles or multiple mounted cards can't race each other into an inconsistent basket.
- **`PlayerCompareModal`** (new component) — side-by-side Games / PPG / Season Total for each basket player, fetched fresh from the same `/players/:id/stats` endpoint PlayerCard's own stats tab already calls.
- **`PlayerCard.tsx`** — new "Compare" toggle button next to Watch/Share (Plus → Check, same visual language as Watch), and a "View comparison (N)" link once 2+ players are queued, opening the modal as a layered overlay (z-[10000]) on top of the card.
- **Deliberately separate** from Draft Rankings' own compare feature — that one compares rank/tier/ADP within a single ranking variant; this compares season stats for any player from any context. Unifying them would mean forcing one of the two data shapes onto contexts that don't have it.
- `TODO.md`/`BACKLOG.md` updated: Compare checked off, Alert/Pin left open (Alert needs notification delivery, Pin needs its own persistence).

## Verification
- `npm run typecheck` ✓
- `npm test` ✓ (49 tests, +6 new for `useCompareBasket`)
- `npm run build` ✓