### PR TITLE
Surface full-season AI projections on PlayerCard

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,6 +11,11 @@
 > `docs/COMPLETION_PLAN.md` for the plan and `TODO.md` for what remains
 > (owner-blocked credentials, external data sources, premium roadmap).
 > Checkboxes below are historical; `TODO.md` is the live list.
+>
+> **Follow-up:** added full-season AI projections (`GET
+> /players/:id/season-projection`, surfaced on PlayerCard) by exposing
+> Draft Rankings' existing redraft `projectedPoints` rather than building
+> a new model. See `TODO.md` → "Shipped since the completion sprint".
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,16 @@ Deploy notes: migrations `0037`–`0041` auto-apply on merge; superflex +
 ceiling/floor data appears after the next Monday ranking batch; rank
 history accrues from the first daily cron.
 
+## Shipped since the completion sprint
+
+- Season projections: new `GET /players/:id/season-projection` surfaces
+  the AI full-season point total that Draft Rankings' redraft batch
+  already generates (`draft_rankings.projectedPoints`) — no new model or
+  cron, just exposing existing data outside the Draft Rankings page.
+  Shown on PlayerCard's Averages tab alongside the existing week-derived
+  projection. Only covers the ~200 players the redraft batch ranks;
+  shows a graceful empty state for everyone else.
+
 ---
 
 ## P0 — Owner action required (not code)
@@ -53,8 +63,6 @@ history accrues from the first daily cron.
 
 - [ ] **Push notifications** — in-app notifications shipped; web push /
   email delivery (and waiver/trade/lineup-lock event types) remain.
-- [ ] **Season projections** — full-season projected totals per player;
-  current pipeline is weekly-props-derived only.
 - [ ] **PlayerCard Alert/Pin/Compare actions** — deliberately skipped in
   the sprint (Watch/Share shipped). Compare could reuse the Draft
   Rankings compare-basket pattern.

--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -1995,6 +1995,75 @@ playerRoutes.get('/:id/projections', optionalAuthMiddleware, async (c) => {
   }
 });
 
+/**
+ * GET /:id/season-projection
+ *
+ * A player's full-season projected point total. The weekly /projections
+ * endpoint above is derived from sportsbook prop lines and only ever covers
+ * one week at a time — there's no pipeline that sums those into a
+ * whole-season number. The Draft Rankings AI batch already produces one
+ * (`projectedPoints` on the redraft variant, generated alongside overall
+ * rank/tier), so this surfaces that existing number rather than building a
+ * second, possibly-inconsistent season model.
+ *
+ * Only the ~200 players covered by the redraft batch have a season
+ * projection; `available: false` for everyone else (deep bench/inactive).
+ *
+ * Query params:
+ *  - scoring: 'ppr' | 'half-ppr' | 'standard' (default: 'ppr')
+ *  - superflex: '0' | '1' (default: '0')
+ *  - season: number (default: current year)
+ */
+playerRoutes.get('/:id/season-projection', optionalAuthMiddleware, async (c) => {
+  const db = c.get('db');
+  let playerId = c.req.param('id');
+  const season = parseInt(c.req.query('season') || String(new Date().getFullYear()));
+  const scoringFormat = (c.req.query('scoring') || 'ppr') as 'ppr' | 'half-ppr' | 'standard';
+  const superflex = c.req.query('superflex') === '1';
+
+  if (!['ppr', 'half-ppr', 'standard'].includes(scoringFormat)) {
+    return c.json({ error: 'Invalid scoring format' }, 400);
+  }
+
+  try {
+    if (/^\d+$/.test(playerId)) {
+      const player = await db.query.nflPlayers.findFirst({
+        where: eq(schema.nflPlayers.externalId, playerId),
+      });
+      if (player) playerId = player.id;
+    }
+
+    const ranking = await db.query.draftRankings.findFirst({
+      where: and(
+        eq(schema.draftRankings.playerId, playerId),
+        eq(schema.draftRankings.rankingType, 'redraft'),
+        eq(schema.draftRankings.scoringFormat, scoringFormat),
+        eq(schema.draftRankings.superflex, superflex),
+        eq(schema.draftRankings.seasonYear, season),
+      ),
+    });
+
+    if (!ranking || ranking.projectedPoints == null) {
+      return c.json({ available: false });
+    }
+
+    return c.json({
+      available: true,
+      projectedPoints: ranking.projectedPoints,
+      overallRank: ranking.overallRank,
+      positionRank: ranking.positionRank,
+      tier: ranking.tier,
+      scoringFormat,
+      superflex,
+      season,
+      generatedAt: ranking.generatedAt,
+    });
+  } catch (error) {
+    console.error('Get season projection error:', error);
+    return c.json({ error: 'Failed to fetch season projection' }, 500);
+  }
+});
+
 // Get player news + articles linked to this player
 playerRoutes.get('/:id/news', optionalAuthMiddleware, async (c) => {
   const db = c.get('db');

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -4,7 +4,7 @@ import { X, ArrowLeft, TrendingUp, TrendingDown, Zap, Target, Calendar, Star, Cl
 import { Player } from '../App';
 import api, { ApiError } from '../services/api';
 import { playerService } from '../services';
-import type { PlayerNews, MatchupGradeResponse, PlayerProjection } from '../services';
+import type { PlayerNews, MatchupGradeResponse, PlayerProjection, PlayerSeasonProjection } from '../services';
 import { useWatchlist } from '../hooks/useWatchlist';
 import { useAuth } from '../context/AuthContext';
 import { buildPlayerProfilePath } from '../utils/slug';
@@ -113,6 +113,8 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
   const [selectedWeek, setSelectedWeek] = useState<number>(propsCurrentWeek || 1);
   const [projection, setProjection] = useState<PlayerProjection | null>(null);
   const [projectionLoading, setProjectionLoading] = useState(true);
+  const [seasonProjection, setSeasonProjection] = useState<PlayerSeasonProjection | null>(null);
+  const [seasonProjectionLoading, setSeasonProjectionLoading] = useState(true);
 
   // Some callers pass richer player objects than App's Player interface declares.
   const playerExtras = player as Player & { status?: string; externalId?: string };
@@ -194,6 +196,21 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
       .finally(() => { if (!cancelled) setProjectionLoading(false); });
     return () => { cancelled = true; };
   }, [player.id, selectedWeek, propsSeasonYear, propsScoringFormat]);
+
+  // Fetch the full-season AI projection (sourced from Draft Rankings' redraft
+  // batch) when the card opens or the scoring format changes. Independent of
+  // selectedWeek — this is a whole-season number, not a per-week one.
+  useEffect(() => {
+    if (!player?.id) return;
+    let cancelled = false;
+    setSeasonProjectionLoading(true);
+    const scoring = (propsScoringFormat === 'half_ppr' ? 'half-ppr' : propsScoringFormat === 'standard' ? 'standard' : 'ppr');
+    playerService.getPlayerSeasonProjection(player.id, { scoring, season: propsSeasonYear })
+      .then((res) => { if (!cancelled) setSeasonProjection(res); })
+      .catch(() => { if (!cancelled) setSeasonProjection(null); })
+      .finally(() => { if (!cancelled) setSeasonProjectionLoading(false); });
+    return () => { cancelled = true; };
+  }, [player.id, propsSeasonYear, propsScoringFormat]);
 
   // Fetch player props when card opens
   useEffect(() => {
@@ -842,6 +859,37 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
                       </div>
                     );
                   })()}
+
+                  {/* Full-season AI projection (sourced from Draft Rankings — a whole-season number, not the week-derived one above). */}
+                  <div>
+                    <h3 className={`font-bold mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>{propsSeasonYear || new Date().getFullYear()} Season Projection</h3>
+                    {seasonProjectionLoading ? (
+                      <div className={`animate-pulse rounded-lg h-16 ${isDarkMode ? 'bg-slate-800' : 'bg-slate-100'}`} />
+                    ) : !seasonProjection?.available ? (
+                      <div className={`rounded-lg border p-8 text-center ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-50 border-slate-200'}`}>
+                        <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>No season projection available for this player yet.</p>
+                      </div>
+                    ) : (
+                      <div className={`rounded-lg p-4 border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-slate-50 border-slate-200'}`}>
+                        <p className={`text-xs mb-3 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>AI full-season estimate • {scoringLabel} redraft</p>
+                        <div className="flex items-center justify-between py-3 bg-blue-500/10 -mx-4 px-4 rounded-lg">
+                          <span className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Projected {scoringLabel} Points</span>
+                          <span className="font-bold text-blue-400 text-lg">
+                            {seasonProjection.projectedPoints != null ? seasonProjection.projectedPoints.toFixed(1) : '—'}
+                          </span>
+                        </div>
+                        {(seasonProjection.overallRank != null || seasonProjection.positionRank != null) && (
+                          <div className={`flex items-center justify-between py-2 mt-1 text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                            <span>Overall Rank</span>
+                            <span className={`font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>
+                              {seasonProjection.overallRank != null ? `#${seasonProjection.overallRank}` : '—'}
+                              {seasonProjection.positionRank != null && ` (${player.position}${seasonProjection.positionRank})`}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </div>
                 );
               })()}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -21,6 +21,7 @@ export type {
   Player,
   PlayerWeeklyStats,
   PlayerProjection,
+  PlayerSeasonProjection,
   PlayerNews,
   PlayersResponse,
   PlayerStatsResponse,

--- a/src/services/players.ts
+++ b/src/services/players.ts
@@ -78,6 +78,18 @@ export interface PlayerProjection {
   projRecTDs?: number | null;
 }
 
+export interface PlayerSeasonProjection {
+  available: boolean;
+  projectedPoints?: number | null;
+  overallRank?: number | null;
+  positionRank?: number | null;
+  tier?: number | null;
+  scoringFormat?: string;
+  superflex?: boolean;
+  season?: number;
+  generatedAt?: string | null;
+}
+
 export interface PlayerNews {
   id: string;
   playerId: string;
@@ -243,6 +255,25 @@ export const playerService = {
     const query = searchParams.toString();
     return api.get<{ projections: PlayerProjection[] }>(
       `/players/${playerId}/projections${query ? `?${query}` : ''}`
+    );
+  },
+
+  // Get a player's full-season AI-projected point total (redraft variant).
+  getPlayerSeasonProjection: async (
+    playerId: string,
+    params?: { scoring?: string; superflex?: boolean; season?: number }
+  ): Promise<PlayerSeasonProjection> => {
+    const searchParams = new URLSearchParams();
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined) {
+          searchParams.append(key, String(value));
+        }
+      });
+    }
+    const query = searchParams.toString();
+    return api.get<PlayerSeasonProjection>(
+      `/players/${playerId}/season-projection${query ? `?${query}` : ''}`
     );
   },
 


### PR DESCRIPTION
## Summary
TODO.md flagged "Season projections — full-season projected totals per player; current pipeline is weekly-props-derived only." The gap was real, but the fix isn't a new prediction model: Draft Rankings' redraft AI batch already generates a full-season `projectedPoints` per player (alongside overall/position rank and tier) — it just wasn't exposed anywhere outside that one page. Building an independent season-total model would risk two disagreeing "season projection" numbers in the app.

## Changes
- **`GET /players/:id/season-projection`** (new route in `server/src/routes/players.ts`) — looks up the player's current `draft_rankings` row for the `redraft` variant at the requested scoring format/superflex/season, returning `projectedPoints`, `overallRank`, `positionRank`, `tier`. Returns `{ available: false }` for players outside the redraft batch's ~200-player cutoff (deep bench, inactive) rather than erroring.
- **`playerService.getPlayerSeasonProjection`** + `PlayerSeasonProjection` type, exported through the services barrel.
- **`PlayerCard.tsx`** — new "Season Projection" card on the Averages tab, right below the existing week-derived "Week N Projection" card, clearly labeled ("AI full-season estimate") to avoid confusion between the two numbers (one is this-week props-derived, the other is the whole-season AI estimate).

## Verification
- `npm run typecheck` ✓ (frontend + server)
- `npm test` ✓ (43 tests, no regressions)
- `npm run build` ✓