### PR TITLE
Add email delivery for notifications via digest cron

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,6 +11,11 @@
 > `docs/COMPLETION_PLAN.md` for the plan and `TODO.md` for what remains
 > (owner-blocked credentials, external data sources, premium roadmap).
 > Checkboxes below are historical; `TODO.md` is the live list.
+>
+> **Follow-up:** notifications now have email delivery (a digest cron via
+> the existing Resend integration), gated on the Settings notifications
+> toggle + verified email. Web push is still open, blocked on VAPID keys.
+> See `TODO.md` → "Shipped since the completion sprint".
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,17 @@ Deploy notes: migrations `0037`–`0041` auto-apply on merge; superflex +
 ceiling/floor data appears after the next Monday ranking batch; rank
 history accrues from the first daily cron.
 
+## Shipped since the completion sprint
+
+- Notification email delivery: a digest cron (`sendPendingNotificationEmails`)
+  emails users a summary of their unread notifications via the existing
+  Resend integration — no new owner credential needed. Gated on the
+  existing Settings "Notifications" toggle + verified email; one digest
+  email per user (not one per notification) to avoid inbox spam.
+  Migration `0043` adds `notifications.emailed_at` and backfills existing
+  rows so the historical backlog isn't mass-emailed on deploy. Web push
+  still needs VAPID keys (owner action) and is not part of this.
+
 ---
 
 ## P0 — Owner action required (not code)
@@ -51,8 +62,10 @@ history accrues from the first daily cron.
 
 ## P1 — Remaining feature gaps
 
-- [ ] **Push notifications** — in-app notifications shipped; web push /
-  email delivery (and waiver/trade/lineup-lock event types) remain.
+- [ ] **Web push notifications** — email delivery shipped (see above); web
+  push still needs a `push_subscriptions` table, a service worker, and a
+  VAPID keypair (owner action — `wrangler secret put`). Waiver/trade/
+  lineup-lock event types (beyond the existing injury type) also remain.
 - [ ] **Season projections** — full-season projected totals per player;
   current pipeline is weekly-props-derived only.
 - [ ] **PlayerCard Alert/Pin/Compare actions** — deliberately skipped in

--- a/server/migrations/0043_add_notification_emailed_at.sql
+++ b/server/migrations/0043_add_notification_emailed_at.sql
@@ -1,0 +1,12 @@
+-- Tracks whether an in-app notification has been (or was attempted to be)
+-- delivered by email, so the digest-email cron never reprocesses a row.
+-- NULL = not yet attempted.
+ALTER TABLE `notifications` ADD COLUMN `emailed_at` integer;
+
+-- Backfill every pre-existing row as already-processed. Without this, the
+-- entire historical notification backlog would read as "pending" on the
+-- first cron tick after deploy, mass-emailing users about old injury news
+-- instead of only ever emailing notifications created from here on.
+UPDATE `notifications` SET `emailed_at` = `created_at` WHERE `emailed_at` IS NULL;
+
+CREATE INDEX IF NOT EXISTS `idx_notifications_email_pending` ON `notifications` (`emailed_at`);

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -691,11 +691,16 @@ export const notifications = sqliteTable('notifications', {
   link: text('link'),
   dedupeKey: text('dedupe_key'),
   isRead: integer('is_read', { mode: 'boolean' }).notNull().default(false),
+  // null = email delivery not yet attempted (or not applicable, e.g. the
+  // recipient has notifications/email disabled at send time). Set once an
+  // email send is attempted so the digest cron never reprocesses a row.
+  emailedAt: integer('emailed_at', { mode: 'timestamp' }),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
 }, (table) => ({
   notificationsDedupe: uniqueIndex('idx_notifications_dedupe').on(table.userId, table.dedupeKey),
   notificationsUserCreated: index('idx_notifications_user_created').on(table.userId, table.createdAt),
   notificationsUserUnread: index('idx_notifications_user_unread').on(table.userId, table.isRead),
+  notificationsEmailPending: index('idx_notifications_email_pending').on(table.emailedAt),
 }));
 
 /**

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,7 +7,7 @@ import * as schema from './db/schema';
 // Import utilities
 import { cleanupExpiredRateLimits } from './middleware/rateLimit';
 import { snapshotRankHistory } from './services/draftRankings';
-import { generateInjuryNewsNotifications } from './services/notifications';
+import { generateInjuryNewsNotifications, sendPendingNotificationEmails } from './services/notifications';
 
 // Import routes
 import { authRoutes } from './routes/auth';
@@ -303,6 +303,18 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
       console.error('[cron] injury notification generation failed:', err);
     }
 
+    // Email any not-yet-emailed notifications (this run's + any left over from
+    // a prior tick). Idempotent via emailedAt; a missing RESEND_API_KEY just
+    // logs a warning and no-ops, same convention as auth.ts's account emails.
+    try {
+      const db = drizzle(env.DB, { schema });
+      const appUrl = env.APP_URL || 'http://localhost:5173';
+      const emailRes = await sendPendingNotificationEmails(db, env.RESEND_API_KEY, appUrl);
+      console.log(`[cron] notification emails: ${emailRes.usersEmailed} users emailed, ${emailRes.notificationsMarked} rows marked`);
+    } catch (err) {
+      console.error('[cron] notification email digest failed:', err);
+    }
+
     // Snapshot current draft rankings into rank_history for movement deltas
     // and trend sparklines. Idempotent per UTC day (existence check + unique
     // index), so retried cron runs are no-ops.
@@ -348,6 +360,15 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
       console.log(`[cron] injury notifications: ${res.attempted} rows for ${res.relevantNews} news items (${res.scannedNews} scanned)`);
     } catch (err) {
       console.error('[cron] injury notification generation failed:', err);
+    }
+
+    try {
+      const db = drizzle(env.DB, { schema });
+      const appUrl = env.APP_URL || 'http://localhost:5173';
+      const emailRes = await sendPendingNotificationEmails(db, env.RESEND_API_KEY, appUrl);
+      console.log(`[cron] notification emails: ${emailRes.usersEmailed} users emailed, ${emailRes.notificationsMarked} rows marked`);
+    } catch (err) {
+      console.error('[cron] notification email digest failed:', err);
     }
   } else if (event.cron === '0 13 * * 1') {
     // Weekly Monday 8 AM EST (13:00 UTC): submit an Anthropic batch per

--- a/server/src/services/notifications.ts
+++ b/server/src/services/notifications.ts
@@ -1,5 +1,5 @@
 import { drizzle } from 'drizzle-orm/d1';
-import { desc, eq, gte, inArray } from 'drizzle-orm';
+import { desc, eq, gte, inArray, isNull } from 'drizzle-orm';
 import * as schema from '../db/schema';
 import { generateId } from '../utils/id';
 
@@ -62,6 +62,17 @@ function slugifyName(text: string): string {
 function truncate(text: string, max: number): string {
   const t = text.trim();
   return t.length <= max ? t : `${t.slice(0, max - 1).trimEnd()}…`;
+}
+
+/** Notification title/body ultimately come from RSS/news headlines — untrusted
+ * external text — so it must be escaped before landing in an HTML email body. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function chunk<T>(arr: T[], size: number): T[][] {
@@ -286,4 +297,180 @@ export async function generateInjuryNewsNotifications(db: DB): Promise<InjuryNot
     recipients,
     attempted: rows.length,
   };
+}
+
+// ── Email delivery ───────────────────────────────────────────────────
+
+/** Cap on notification rows scanned per digest run. */
+const MAX_PENDING_EMAIL_ROWS = 500;
+/** Cap on items listed in a single digest email; the rest are summarized as "and N more". */
+const MAX_ITEMS_PER_EMAIL = 5;
+
+export interface NotificationEmailResult {
+  usersEmailed: number;
+  notificationsMarked: number;
+  skippedNoApiKey: boolean;
+}
+
+type PendingNotification = {
+  id: string;
+  userId: string;
+  title: string;
+  body: string | null;
+  link: string | null;
+};
+
+async function sendNotificationDigestEmail(
+  to: string,
+  items: PendingNotification[],
+  appUrl: string,
+  resendApiKey: string,
+): Promise<boolean> {
+  const shown = items.slice(0, MAX_ITEMS_PER_EMAIL);
+  const overflow = items.length - shown.length;
+  const subject = items.length === 1
+    ? `FilmRoom: ${shown[0].title}`
+    : `FilmRoom: ${items.length} new notifications`;
+
+  const itemsHtml = shown.map((item) => {
+    const href = item.link ? `${appUrl}${item.link}` : appUrl;
+    return `
+      <div style="padding: 12px 0; border-bottom: 1px solid #e2e8f0;">
+        <a href="${href}" style="color: #2563eb; font-weight: 600; text-decoration: none;">${escapeHtml(item.title)}</a>
+        ${item.body ? `<p style="color: #475569; margin: 4px 0 0; font-size: 14px;">${escapeHtml(item.body)}</p>` : ''}
+      </div>
+    `;
+  }).join('');
+
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${resendApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: 'FilmRoom <noreply@filmroomfantasy.com>',
+        to: [to],
+        subject,
+        html: `
+          <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 40px 20px;">
+            <h2 style="color: #1e293b; margin-bottom: 16px;">You have new updates</h2>
+            ${itemsHtml}
+            ${overflow > 0 ? `<p style="color: #94a3b8; font-size: 14px;">And ${overflow} more.</p>` : ''}
+            <a href="${appUrl}" style="display: inline-block; background: #2563eb; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; margin: 24px 0;">
+              Open FilmRoom
+            </a>
+            <p style="color: #94a3b8; font-size: 14px; line-height: 1.5;">
+              You're receiving this because notifications are enabled on your account. Turn them off anytime in Settings.
+            </p>
+          </div>
+        `,
+      }),
+    });
+    if (!res.ok) {
+      console.error('[notifications] Resend digest send failed:', res.status, await res.text().catch(() => ''));
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error('[notifications] Resend digest send error:', err);
+    return false;
+  }
+}
+
+/**
+ * Emails a digest of any not-yet-emailed notification rows, one email per
+ * user. Only sent to users with notificationsEnabled and a verified email;
+ * rows for ineligible users are still marked processed so this query never
+ * rescans them, but users become eligible again for any NEW notification
+ * created after they enable/verify.
+ *
+ * On a per-user send failure, that user's rows are left unmarked so the next
+ * cron tick retries. No-ops (logging a warning) when RESEND_API_KEY is unset,
+ * same convention as the password-reset/verification emails in routes/auth.ts.
+ */
+export async function sendPendingNotificationEmails(
+  db: DB,
+  resendApiKey: string | undefined,
+  appUrl: string,
+): Promise<NotificationEmailResult> {
+  if (!resendApiKey) {
+    console.warn('[notifications] No RESEND_API_KEY configured — skipping email digest.');
+    return { usersEmailed: 0, notificationsMarked: 0, skippedNoApiKey: true };
+  }
+
+  const pending: PendingNotification[] = await db
+    .select({
+      id: schema.notifications.id,
+      userId: schema.notifications.userId,
+      title: schema.notifications.title,
+      body: schema.notifications.body,
+      link: schema.notifications.link,
+    })
+    .from(schema.notifications)
+    .where(isNull(schema.notifications.emailedAt))
+    .orderBy(desc(schema.notifications.createdAt))
+    .limit(MAX_PENDING_EMAIL_ROWS);
+
+  if (pending.length === 0) {
+    return { usersEmailed: 0, notificationsMarked: 0, skippedNoApiKey: false };
+  }
+
+  const userIds = [...new Set(pending.map((p) => p.userId))];
+  const userRows: { id: string; email: string; notificationsEnabled: boolean | null; emailVerifiedAt: Date | null }[] = [];
+  for (const ids of chunk(userIds, IN_CHUNK)) {
+    const rows = await db
+      .select({
+        id: schema.users.id,
+        email: schema.users.email,
+        notificationsEnabled: schema.users.notificationsEnabled,
+        emailVerifiedAt: schema.users.emailVerifiedAt,
+      })
+      .from(schema.users)
+      .where(inArray(schema.users.id, ids));
+    userRows.push(...rows);
+  }
+  const eligibleUsers = new Map(
+    userRows.filter((u) => u.notificationsEnabled && u.emailVerifiedAt != null).map((u) => [u.id, u]),
+  );
+
+  const byUser = new Map<string, PendingNotification[]>();
+  for (const item of pending) {
+    const list = byUser.get(item.userId);
+    if (list) list.push(item);
+    else byUser.set(item.userId, [item]);
+  }
+
+  let usersEmailed = 0;
+  const sentIds: string[] = [];
+  const skippedIds: string[] = [];
+
+  for (const [userId, items] of byUser) {
+    const user = eligibleUsers.get(userId);
+    if (!user) {
+      // Not currently eligible (disabled / unverified) — mark processed so
+      // these specific rows aren't rescanned every run.
+      skippedIds.push(...items.map((i) => i.id));
+      continue;
+    }
+    const ok = await sendNotificationDigestEmail(user.email, items, appUrl, resendApiKey);
+    if (ok) {
+      usersEmailed++;
+      sentIds.push(...items.map((i) => i.id));
+    }
+    // On failure, leave emailedAt null so the next cron tick retries.
+  }
+
+  const toMark = [...sentIds, ...skippedIds];
+  if (toMark.length > 0) {
+    const now = new Date();
+    for (const ids of chunk(toMark, IN_CHUNK)) {
+      await db.update(schema.notifications)
+        .set({ emailedAt: now })
+        .where(inArray(schema.notifications.id, ids));
+    }
+  }
+
+  return { usersEmailed, notificationsMarked: toMark.length, skippedNoApiKey: false };
 }

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -608,7 +608,7 @@ export function SettingsView({ isDarkMode = true, onToggleDarkMode, onLeagueSync
           <div className="flex items-center justify-between">
             <div>
               <div id="notifications-label" className={`font-medium mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Notifications</div>
-              <div className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Receive alerts for injuries and lineup changes</div>
+              <div className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Receive alerts for injuries and lineup changes, plus an email summary when there's news</div>
             </div>
             <label className="relative inline-flex items-center cursor-pointer">
               <input


### PR DESCRIPTION
## Summary
In-app notifications (injury-news fan-out) shipped in the completion sprint, but the only delivery channel was the header bell — users had to be looking at the app to see anything. This adds email delivery for the P1 "Push notifications" gap's email half, reusing the Resend integration already used for password-reset/verification emails rather than standing up a new provider. Web push (the other half) is NOT part of this — it needs a VAPID keypair (owner-provided credential) plus a service worker and subscriptions table; left as a separate follow-up.

## Changes
- **`notifications.emailedAt`** (migration `0043`) — tracks whether a row has been (or was attempted to be) emailed. **Critically, existing rows are backfilled to already-processed** (`emailed_at = created_at`) — without this, the entire historical notification backlog would read as "pending" on the first cron tick after deploy and mass-email users about old injury news. Only notifications created from here on are ever "pending".
- **`sendPendingNotificationEmails`** (`server/src/services/notifications.ts`) — one digest email per user (not one per notification, to avoid inbox spam), capped at 5 items shown + "and N more" for the rest. Only sent to users with the existing Settings "Notifications" toggle enabled and a verified email. Per-user send failures leave their rows unmarked so the next cron tick retries; a missing `RESEND_API_KEY` logs a warning and no-ops (same convention as `routes/auth.ts`'s account emails).
- **Security:** notification title/body ultimately originate from RSS headlines (untrusted external text) — added `escapeHtml` so they can't inject markup into the email body.
- Wired into both cron ticks that already generate injury notifications (daily 12 PM UTC + every-6h).
- `SettingsView.tsx` — updated the existing "Notifications" toggle copy to mention it now also gates the email digest.
- `TODO.md`/`BACKLOG.md` mirrored.

## Verification
- `npm run typecheck` ✓ (frontend + server)
- `npm test` ✓ (43 tests, no regressions — this PR is backend-only)
- `npm run build` ✓

## Deploy notes
Migration `0043` auto-applies on merge via the existing CI pipeline.