### PR TITLE
Hotfix: remove temperature param breaking every Sonnet 5 AI call

### DIFF
--- a/server/src/routes/draftRankings.ts
+++ b/server/src/routes/draftRankings.ts
@@ -299,7 +299,6 @@ draftRankingsRoutes.post('/ask', authMiddleware, requireTier('pro', 'Ask AI'), r
           buildDraftAskSystemPrompt(rankingType, scoringFormat, contextBlock),
         ),
         messages: [...recentHistory, { role: 'user', content: question }],
-        temperature: 0.4,
       }),
       signal: AbortSignal.timeout(30000),
     });

--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -1431,7 +1431,6 @@ ${newsBlock}`;
             max_tokens: 600,
             system: buildCachedSystemBlocks(PLAYER_ANALYSIS_SYSTEM_PROMPT),
             messages: [{ role: 'user', content: dataBlock }],
-            temperature: 0.4,
           }),
           signal: AbortSignal.timeout(30000),
         });
@@ -1678,7 +1677,6 @@ playerRoutes.post(
             buildPlayersAskSystemPrompt(week, season, scoringLabel, contextBlock),
           ),
           messages: [...recentHistory, { role: 'user', content: question }],
-          temperature: 0.4,
         }),
         signal: AbortSignal.timeout(30000),
       });

--- a/server/src/routes/tradeHistory.ts
+++ b/server/src/routes/tradeHistory.ts
@@ -1112,7 +1112,6 @@ Provide your JSON analysis. Weight the ACTUAL OUTCOME block more heavily than th
         max_tokens: 2048,
         system: systemPrompt,
         messages: [{ role: 'user', content: userMessage }],
-        temperature: 0.3,
       }),
       signal: AbortSignal.timeout(45000),
     });

--- a/server/src/routes/trades.ts
+++ b/server/src/routes/trades.ts
@@ -506,7 +506,6 @@ tradesRoutes.post(
             ...recentHistory,
             { role: 'user', content: question },
           ],
-          temperature: 0.4,
         }),
         signal: AbortSignal.timeout(30000),
       });

--- a/server/src/services/draftRankings.ts
+++ b/server/src/services/draftRankings.ts
@@ -607,7 +607,6 @@ export async function submitDraftRankingsBatch(
         model: ANTHROPIC_MODEL,
         max_tokens: MAX_TOKENS,
         messages: [{ role: 'user', content: prompt }],
-        temperature: 0.3,
       },
     });
     metas.push({

--- a/server/src/services/tradeAnalyzer.ts
+++ b/server/src/services/tradeAnalyzer.ts
@@ -427,7 +427,6 @@ Respond with the JSON schema described in the system prompt.`;
         max_tokens: 2048,
         system: systemBlocks,
         messages: [{ role: 'user', content: userMessage }],
-        temperature: 0.3,
       }),
       signal: AbortSignal.timeout(45000),
     });


### PR DESCRIPTION
## Bug
Ask AI (draft rankings + players board), AI trade analysis, trade history follow-ups, and per-player AI takes were **all** returning "AI request failed" in production.

## Root cause
Every Anthropic call site still sent a non-default `temperature` (0.3 or 0.4) — a leftover from before #244's `claude-sonnet-4-6` → `claude-sonnet-5` model swap. `claude-sonnet-4-6` allowed non-default sampling parameters; `claude-sonnet-5` (like Opus 4.7/4.8) **rejects** them with a 400. Each route's generic `if (!res.ok)` branch swallowed that 400 and surfaced the same generic "AI request failed" message everywhere, which is why it looked like a single bug but actually hit every AI feature at once.

## Fix
Removed the `temperature` field from all 7 Anthropic API call sites (letting the model use its default sampling behavior):
- `server/src/services/draftRankings.ts` (Monday ranking batch generation)
- `server/src/routes/draftRankings.ts` (`/draft-rankings/ask`)
- `server/src/routes/players.ts` (per-player analysis + `/players/ask`)
- `server/src/services/tradeAnalyzer.ts` (AI trade analysis)
- `server/src/routes/tradeHistory.ts` (trade history follow-up chat)
- `server/src/routes/trades.ts` (trade follow-up questions)

Confirmed via the current Anthropic API model-migration reference: `claude-sonnet-5` is a valid, correct model ID (not the bug) that specifically added the "non-default temperature/top_p/top_k → 400" behavior change from the 4.6 family.

## Verification
- `npm run typecheck` ✓ (frontend + server)
- `npm test` ✓ (43 tests, no regressions)