### PR TITLE
Fix mobile sidebar drawer bleeding at viewport edges

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2507,7 +2507,14 @@ html {
   }
 }
 
-/* Sidebar open state (mobile overlay) */
+/* Sidebar open state (mobile overlay).
+   Height is pinned via dvh (not just top:0/bottom:0) so the drawer always
+   fills the real visible viewport, even while Safari's address bar is
+   animating in/out — otherwise the page behind it "bleeds" through a gap
+   at the top or bottom edge during that transition. Safe-area padding
+   keeps the logo/nav/League Manager content clear of a notch or the home
+   indicator; the fixed background still extends underneath since padding
+   is inside the background's paint area. */
 .sidebar-open {
   display: flex;
   flex-direction: column;
@@ -2515,6 +2522,9 @@ html {
   top: 0;
   bottom: 0;
   left: 0;
+  height: 100dvh;
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   /* Above the cookie consent banner (z-[70]) so it covers it on mobile. */
   z-index: 80;
 }
@@ -2583,6 +2593,10 @@ html {
 }
 .z-mobile-backdrop {
   z-index: 75;
+  /* Pin to the real visible viewport (see .sidebar-open) so the backdrop
+     never leaves a gap at the top/bottom edge while Safari's address bar
+     animates, which would let the page behind it bleed through. */
+  height: 100dvh;
 }
 .z-mobile-sidebar {
   z-index: 80;


### PR DESCRIPTION
## Summary
- The mobile sidebar drawer (`.sidebar-open`) and its backdrop (`.z-mobile-backdrop`) were sized with `position: fixed; top: 0; bottom: 0`, which doesn't account for mobile Safari's dynamic address bar resizing the visible viewport. This is a common source of the drawer "bleeding" — the page behind it peeking through a gap at the top/bottom edge while the browser chrome animates in/out.
- Pinned both to `height: 100dvh` (matching the `h-dvh` pattern already used elsewhere in `App.tsx`) so they always fill the real visible viewport.
- Added `env(safe-area-inset-left)` / `env(safe-area-inset-bottom)` padding to the drawer so its nav/logo/League Manager content stays clear of a notch or home indicator — the fixed background still fills that area since padding is inside the background paint box.

## Test plan
- [x] `npm run typecheck` passes
- [x] Verified in a headless mobile viewport (390×844) that the drawer still renders at the correct 256px width, full height, and correct z-index stacking above the backdrop, with no layout regression
- [ ] Would appreciate a check on a real iOS Safari device to confirm the address-bar-resize bleed is gone, since that's hard to reproduce in a headless browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019RY8nEZEBWPRCNoAgtaXkZ)_