### PR TITLE
Surface depth chart order on player detail views

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,10 @@ history accrues from the first daily cron.
 
 - [ ] Practice reports / injury designations (nflverse or ESPN, free)
 - [ ] Usage data: snap %, target share, red-zone touches (nflverse, free)
-- [ ] Depth charts (Sleeper fields already synced upstream — store/expose)
+- [x] Depth charts (Sleeper fields already synced upstream — store/expose) —
+  `depthChartOrder` was already synced from Sleeper and returned by the
+  `/players` API; now surfaced as a "RB2"-style badge on PlayerCard and the
+  player profile page.
 - [ ] Weather for outdoor games (Open-Meteo/NWS, free)
 - [ ] Redraft ADP (Sleeper/Underdog)
 - [ ] Feed projection-accuracy history back into AI prompts

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,6 +190,8 @@ export interface Player {
   weekChange: number;
   weeklyProjectedPoints?: number;
   headshotUrl?: string | null;
+  /** Position depth chart order within the player's team (1 = starter), synced from Sleeper. */
+  depthChartOrder?: number | null;
 }
 
 // URL path <-> view mapping for client-side routing (BUG-001/002 fix)

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -480,7 +480,13 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
                       )}
                     </div>
                     <div className={`flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-                      <span>{player.team} • {player.position} •</span>
+                      <span>
+                        {player.team} • {player.position}
+                        {player.depthChartOrder != null && ['QB', 'RB', 'WR', 'TE'].includes(player.position) && (
+                          <> ({player.position}{player.depthChartOrder})</>
+                        )}
+                        {' '}•
+                      </span>
                       <select
                         value={selectedWeek}
                         onChange={(e) => setSelectedWeek(Number(e.target.value))}

--- a/src/components/PlayerProfileView.tsx
+++ b/src/components/PlayerProfileView.tsx
@@ -54,7 +54,6 @@ interface PlayerDetail extends ApiPlayer {
   height?: string;
   weight?: number;
   college?: string;
-  depthChartOrder?: number;
 }
 
 function formatTimeAgo(dateString: string | Date): string {
@@ -358,6 +357,12 @@ export function PlayerProfileView({
               <span className="font-semibold">{player.team}</span>
               <span className={muted}>•</span>
               <span className="font-semibold">{position}</span>
+              {player.depthChartOrder != null && ['QB', 'RB', 'WR', 'TE'].includes(position) && (
+                <>
+                  <span className={muted}>•</span>
+                  <span className="font-semibold">{position}{player.depthChartOrder}</span>
+                </>
+              )}
               {player.jerseyNumber != null && (
                 <>
                   <span className={muted}>•</span>

--- a/src/services/players.ts
+++ b/src/services/players.ts
@@ -18,6 +18,8 @@ export interface Player {
   headshotUrl?: string;
   age?: number;
   yearsExp?: number;
+  /** Position depth chart order within the player's team (1 = starter), synced from Sleeper. */
+  depthChartOrder?: number | null;
 }
 
 export interface PlayerWeeklyStats {

--- a/src/utils/playerUtils.ts
+++ b/src/utils/playerUtils.ts
@@ -13,6 +13,7 @@ export interface APIPlayer {
   projectedPoints: number;
   weeklyProjectedPoints?: number;
   isRostered: boolean;
+  depthChartOrder?: number | null;
   seasonStats?: {
     games: number;
     gamesPlayed?: number;
@@ -74,6 +75,7 @@ export function convertAPIPlayerToPlayer(player: APIPlayer, index: number): Play
     weekChange: 0,
     weeklyProjectedPoints: player.weeklyProjectedPoints,
     headshotUrl: player.headshotUrl ?? null,
+    depthChartOrder: player.depthChartOrder ?? null,
   };
 }
 


### PR DESCRIPTION
## TODO.md item

P2 — Data feeds: **Depth charts** (`Sleeper fields already synced upstream — store/expose`)

## Summary

`depthChartOrder` was already being synced from Sleeper into `nfl_players` (`server/src/services/sleeper.ts`) and was already present in every `GET /players` and `GET /players/:id` response (the routes spread the full DB row). Nothing on the frontend read or rendered it, though — the field wasn't declared on any of the frontend `Player` types.

This change:
- Adds `depthChartOrder` to the frontend `Player` types (`src/App.tsx`, `src/services/players.ts`, `src/utils/playerUtils.ts`) and threads it through `convertAPIPlayerToPlayer`.
- Renders a small `RB2`-style badge next to the position on `PlayerCard` and the player profile page (`PlayerProfileView`), gated to skill positions (QB/RB/WR/TE) where depth chart order is meaningful.

No backend changes — the data was already there, this is purely additive frontend wiring.

## What I verified

- `npm run typecheck` (frontend) — clean
- `cd server && npx tsc --noEmit` (backend) — clean
- `npm test` — 5 files / 43 tests passing
- `npm run build` — succeeds

## Owner follow-ups

None. No migration, no new env vars, no cron changes — the underlying data has been flowing since the existing Sleeper sync job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg9zgbjU4fiwYNt1bxEd6g)_