### PR TITLE
Surface Sleeper depth chart order in the UI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,9 @@ history accrues from the first daily cron.
 
 - [ ] Practice reports / injury designations (nflverse or ESPN, free)
 - [ ] Usage data: snap %, target share, red-zone touches (nflverse, free)
-- [ ] Depth charts (Sleeper fields already synced upstream — store/expose)
+- [x] Depth charts — Sleeper `depth_chart_order` was already synced and
+  stored but never surfaced; now shown on the player profile bio strip and
+  team roster bench rows
 - [ ] Weather for outdoor games (Open-Meteo/NWS, free)
 - [ ] Redraft ADP (Sleeper/Underdog)
 - [ ] Feed projection-accuracy history back into AI prompts

--- a/src/components/PlayerProfileView.tsx
+++ b/src/components/PlayerProfileView.tsx
@@ -54,7 +54,12 @@ interface PlayerDetail extends ApiPlayer {
   height?: string;
   weight?: number;
   college?: string;
-  depthChartOrder?: number;
+}
+
+function ordinal(n: number): string {
+  const suffixes = ['th', 'st', 'nd', 'rd'];
+  const rem = n % 100;
+  return `${n}${suffixes[(rem - 20) % 10] || suffixes[rem] || suffixes[0]}`;
 }
 
 function formatTimeAgo(dateString: string | Date): string {
@@ -379,6 +384,7 @@ export function PlayerProfileView({
               {player.weight != null && <span><span className={`font-semibold ${bodyColor}`}>{player.weight}</span> lbs</span>}
               {player.college && <span><span className={`font-semibold ${bodyColor}`}>{player.college}</span></span>}
               {player.yearsExp != null && <span><span className={`font-semibold ${bodyColor}`}>{player.yearsExp}</span> yrs exp</span>}
+              {player.depthChartOrder != null && <span><span className={`font-semibold ${bodyColor}`}>{ordinal(player.depthChartOrder)}</span> on depth chart</span>}
             </div>
 
             {player.injuryNote && (

--- a/src/components/TeamView.tsx
+++ b/src/components/TeamView.tsx
@@ -397,6 +397,7 @@ export function TeamView({ onPlayerClick, isDarkMode }: TeamViewProps) {
                           </div>
                           <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
                             {player.team} • {player.position}
+                            {player.depthChartOrder != null ? ` • Depth #${player.depthChartOrder}` : ''}
                             {avgPoints ? ` • Avg: ${avgPoints.toFixed(1)}` : ''}
                           </div>
                         </div>

--- a/src/context/LeagueContext.tsx
+++ b/src/context/LeagueContext.tsx
@@ -69,6 +69,7 @@ export interface RosterPlayer {
   byeWeek?: number;
   imageUrl?: string;
   lastWeekPoints?: number;
+  depthChartOrder?: number | null;
   seasonStats?: {
     games: number;
     gamesPlayed?: number;
@@ -336,6 +337,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
           byeWeek?: number;
           headshotUrl?: string;
           imageUrl?: string;
+          depthChartOrder?: number | null;
           seasonStats?: RosterPlayer['seasonStats'];
         };
       }
@@ -357,6 +359,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
         injuryBodyPart: spot.player.injuryBodyPart,
         byeWeek: spot.player.byeWeek,
         imageUrl: spot.player.headshotUrl || spot.player.imageUrl,
+        depthChartOrder: spot.player.depthChartOrder ?? null,
         seasonStats: spot.player.seasonStats || undefined,
       });
 
@@ -431,6 +434,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
                 byeWeek?: number;
                 headshotUrl?: string;
                 imageUrl?: string;
+                depthChartOrder?: number | null;
                 seasonStats?: RosterPlayer['seasonStats'];
               };
             }
@@ -450,6 +454,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
               injuryBodyPart: spot.player.injuryBodyPart,
               byeWeek: spot.player.byeWeek,
               imageUrl: spot.player.headshotUrl || spot.player.imageUrl,
+              depthChartOrder: spot.player.depthChartOrder ?? null,
               seasonStats: spot.player.seasonStats || undefined,
             });
             if (oppResponse.roster.starters) {

--- a/src/services/players.ts
+++ b/src/services/players.ts
@@ -18,6 +18,7 @@ export interface Player {
   headshotUrl?: string;
   age?: number;
   yearsExp?: number;
+  depthChartOrder?: number | null;
 }
 
 export interface PlayerWeeklyStats {


### PR DESCRIPTION
## Summary

Picks off the TODO.md P2 item: **"Depth charts (Sleeper fields already synced upstream — store/expose)"**.

`depth_chart_order` was already synced from Sleeper into `nfl_players` and already fed several backend consumers (draft rankings AI prompts, trade-context AI prompts, roster bench sort order), but no screen ever displayed it to a user. It was also already present in the `/players/:id` and `/teams/:id/roster` API payloads (both spread the full player row, no column restriction), so no backend/API change was needed — this was purely a frontend gap.

## Changes

- `src/services/players.ts` — add `depthChartOrder` to the `Player` type.
- `src/context/LeagueContext.tsx` — thread `depthChartOrder` through both roster-mapping paths (own team + opponent team) into `RosterPlayer`.
- `src/components/PlayerProfileView.tsx` — render "Nth on depth chart" in the bio strip when present.
- `src/components/TeamView.tsx` — render "Depth #N" on bench roster rows.
- `TODO.md` — check off the item.

No database migration needed — `depth_chart_order` has existed on `nfl_players` since an earlier migration and is already populated by the Sleeper sync in `server/src/services/sleeper.ts`.

## Verified

- `npm run typecheck` (frontend) — clean
- `cd server && npx tsc --noEmit` (backend) — clean
- `npm test` (Vitest) — 43 tests passing
- `npm run build` — succeeds

## Owner notes

Nothing further required — no migration, no config, no secrets involved. Depth chart numbers will show up wherever players already have a synced `depthChartOrder` (most active skill-position players).

---
_Generated by [Claude Code](https://claude.ai/code/session_018R2UWcGjTJNh4cgwLtJWKA)_