### PR TITLE
Surface depth chart order on player profile and team roster

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,11 @@ history accrues from the first daily cron.
 
 - [ ] Practice reports / injury designations (nflverse or ESPN, free)
 - [ ] Usage data: snap %, target share, red-zone touches (nflverse, free)
-- [ ] Depth charts (Sleeper fields already synced upstream — store/expose)
+- [x] Depth charts (Sleeper fields already synced upstream — store/expose) —
+  `depthChartOrder` was already synced from Sleeper and returned by the
+  `/players/:id` and `/teams/:id/roster` APIs; it just wasn't typed or
+  rendered on the frontend. Now shown on the standalone player page and
+  on bench rows in Team view.
 - [ ] Weather for outdoor games (Open-Meteo/NWS, free)
 - [ ] Redraft ADP (Sleeper/Underdog)
 - [ ] Feed projection-accuracy history back into AI prompts

--- a/src/components/PlayerProfileView.tsx
+++ b/src/components/PlayerProfileView.tsx
@@ -54,7 +54,6 @@ interface PlayerDetail extends ApiPlayer {
   height?: string;
   weight?: number;
   college?: string;
-  depthChartOrder?: number;
 }
 
 function formatTimeAgo(dateString: string | Date): string {
@@ -379,6 +378,7 @@ export function PlayerProfileView({
               {player.weight != null && <span><span className={`font-semibold ${bodyColor}`}>{player.weight}</span> lbs</span>}
               {player.college && <span><span className={`font-semibold ${bodyColor}`}>{player.college}</span></span>}
               {player.yearsExp != null && <span><span className={`font-semibold ${bodyColor}`}>{player.yearsExp}</span> yrs exp</span>}
+              {player.depthChartOrder != null && <span>Depth Chart: <span className={`font-semibold ${bodyColor}`}>#{player.depthChartOrder}</span></span>}
             </div>
 
             {player.injuryNote && (

--- a/src/components/TeamView.tsx
+++ b/src/components/TeamView.tsx
@@ -397,6 +397,7 @@ export function TeamView({ onPlayerClick, isDarkMode }: TeamViewProps) {
                           </div>
                           <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
                             {player.team} • {player.position}
+                            {player.depthChartOrder != null ? ` • Depth ${player.depthChartOrder}` : ''}
                             {avgPoints ? ` • Avg: ${avgPoints.toFixed(1)}` : ''}
                           </div>
                         </div>

--- a/src/context/LeagueContext.tsx
+++ b/src/context/LeagueContext.tsx
@@ -69,6 +69,7 @@ export interface RosterPlayer {
   byeWeek?: number;
   imageUrl?: string;
   lastWeekPoints?: number;
+  depthChartOrder?: number | null;
   seasonStats?: {
     games: number;
     gamesPlayed?: number;
@@ -336,6 +337,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
           byeWeek?: number;
           headshotUrl?: string;
           imageUrl?: string;
+          depthChartOrder?: number | null;
           seasonStats?: RosterPlayer['seasonStats'];
         };
       }
@@ -357,6 +359,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
         injuryBodyPart: spot.player.injuryBodyPart,
         byeWeek: spot.player.byeWeek,
         imageUrl: spot.player.headshotUrl || spot.player.imageUrl,
+        depthChartOrder: spot.player.depthChartOrder,
         seasonStats: spot.player.seasonStats || undefined,
       });
 

--- a/src/services/players.ts
+++ b/src/services/players.ts
@@ -18,6 +18,7 @@ export interface Player {
   headshotUrl?: string;
   age?: number;
   yearsExp?: number;
+  depthChartOrder?: number | null;
 }
 
 export interface PlayerWeeklyStats {


### PR DESCRIPTION
## Backlog item

TODO.md, P2 — Data feeds: **"Depth charts (Sleeper fields already synced upstream — store/expose)"**

## Summary

Investigated the "store" half of this item and found it was already done: `depthChartOrder` (Sleeper's `depth_chart_order` field) has been synced into the `nfl_players` table since the very first migration, and was already being returned over the wire by both `GET /players/:id` and `GET /teams/:id/roster` (both spread the full player row into their JSON response). The only missing piece was the "expose" half — the frontend never typed or rendered the field.

This PR closes that gap:
- `src/services/players.ts` — added `depthChartOrder` to the shared `Player` type.
- `src/context/LeagueContext.tsx` — threaded `depthChartOrder` through the `/teams/:id/roster` response mapping into `RosterPlayer`.
- `src/components/TeamView.tsx` — bench rows now show `• Depth N` next to team/position, so backups/handcuffs are visible at a glance.
- `src/components/PlayerProfileView.tsx` — the standalone player page bio strip now shows `Depth Chart: #N` when available (also removed a now-redundant duplicate field declaration on the local `PlayerDetail` type).

No backend changes, no new migration, no new dependencies — purely additive frontend typing + rendering of data that was already flowing through the existing APIs.

## Verified

- `npm run typecheck` — passes (one pre-existing, unrelated `tsconfig.json` `baseUrl` deprecation warning present on `main` before this change too)
- `cd server && npx tsc --noEmit` — passes clean (no backend files touched)
- `npm test` — 5 files / 43 tests passing
- `npm run build` — succeeds

## Owner follow-ups

None — this is a self-contained frontend change with no config, secrets, or migration to apply.


---
_Generated by [Claude Code](https://claude.ai/code/session_018YaC1AFt5bDwdJPjfc2izq)_