### PR TITLE
Surface depth chart position on player detail views

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,11 @@ history accrues from the first daily cron.
 
 - [ ] Practice reports / injury designations (nflverse or ESPN, free)
 - [ ] Usage data: snap %, target share, red-zone touches (nflverse, free)
-- [ ] Depth charts (Sleeper fields already synced upstream — store/expose)
+- [x] Depth charts (Sleeper fields already synced upstream — store/expose) —
+  `depthChartOrder` was already stored via Sleeper sync and used internally
+  (AI prompts, trade context, roster sort) but never shown in the UI. Now
+  surfaced as "Depth {POS}{N}" on the PlayerCard modal and the standalone
+  player profile page's bio strip.
 - [ ] Weather for outdoor games (Open-Meteo/NWS, free)
 - [ ] Redraft ADP (Sleeper/Underdog)
 - [ ] Feed projection-accuracy history back into AI prompts

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,6 +190,7 @@ export interface Player {
   weekChange: number;
   weeklyProjectedPoints?: number;
   headshotUrl?: string | null;
+  depthChartOrder?: number | null;
 }
 
 // URL path <-> view mapping for client-side routing (BUG-001/002 fix)

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -480,7 +480,10 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
                       )}
                     </div>
                     <div className={`flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-                      <span>{player.team} • {player.position} •</span>
+                      <span>
+                        {player.team} • {player.position}
+                        {player.depthChartOrder != null && player.position !== 'DEF' ? ` • Depth ${player.position}${player.depthChartOrder}` : ''} •
+                      </span>
                       <select
                         value={selectedWeek}
                         onChange={(e) => setSelectedWeek(Number(e.target.value))}

--- a/src/components/PlayerProfileView.tsx
+++ b/src/components/PlayerProfileView.tsx
@@ -379,6 +379,9 @@ export function PlayerProfileView({
               {player.weight != null && <span><span className={`font-semibold ${bodyColor}`}>{player.weight}</span> lbs</span>}
               {player.college && <span><span className={`font-semibold ${bodyColor}`}>{player.college}</span></span>}
               {player.yearsExp != null && <span><span className={`font-semibold ${bodyColor}`}>{player.yearsExp}</span> yrs exp</span>}
+              {player.depthChartOrder != null && position !== 'DEF' && (
+                <span>Depth Chart: <span className={`font-semibold ${bodyColor}`}>{position}{player.depthChartOrder}</span></span>
+              )}
             </div>
 
             {player.injuryNote && (

--- a/src/utils/playerUtils.ts
+++ b/src/utils/playerUtils.ts
@@ -13,6 +13,7 @@ export interface APIPlayer {
   projectedPoints: number;
   weeklyProjectedPoints?: number;
   isRostered: boolean;
+  depthChartOrder?: number | null;
   seasonStats?: {
     games: number;
     gamesPlayed?: number;
@@ -74,6 +75,7 @@ export function convertAPIPlayerToPlayer(player: APIPlayer, index: number): Play
     weekChange: 0,
     weeklyProjectedPoints: player.weeklyProjectedPoints,
     headshotUrl: player.headshotUrl ?? null,
+    depthChartOrder: player.depthChartOrder ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary

Picks off the TODO.md P2 item: **Depth charts (Sleeper fields already synced upstream — store/expose)**.

The "store" half was already done — `nflPlayers.depthChartOrder` is synced from Sleeper and already used internally (draft rankings AI prompts, trade context bios, roster sort order in `rosters.ts`). The "expose" half was missing: the number was fetched into every player API response but never rendered anywhere in the UI.

This change threads it through the frontend types and surfaces it as `Depth {POS}{N}` (e.g. `Depth RB2`) in two places:

- **PlayerCard modal** — added to the team/position line in the header.
- **Standalone player profile page** (`/players/:slug-:id`) — added to the bio strip.

No backend changes were needed — `GET /players/:id` and `GET /players` already return the full `nflPlayers` row, `depthChartOrder` included.

### Files touched
- `src/App.tsx` — added `depthChartOrder` to the shared `Player` interface.
- `src/utils/playerUtils.ts` — threaded the field through `APIPlayer` and `convertAPIPlayerToPlayer` (covers the Board and All Players list → PlayerCard path).
- `src/components/PlayerCard.tsx` — renders the depth chart badge.
- `src/components/PlayerProfileView.tsx` — renders it in the bio strip.
- `TODO.md` — checked off the item.

Note: a handful of other views (TeamView, WaiversView, MatchupView, HomeView, Header search) each have their own local, narrower `convertToPlayer` mapping that doesn't currently pass this field through to PlayerCard — same pre-existing gap that already exists for e.g. `status` in those paths. Left those untouched to keep this diff focused; the two primary list-browsing surfaces (Board, All Players) and the standalone profile page are covered.

## Verified

- `npm run typecheck` — clean
- `cd server && npx tsc --noEmit` — clean (no backend changes, included for completeness)
- `npm test` — 43/43 passing
- `npm run build` — succeeds

## Owner follow-ups

None — this is a pure frontend UI change with no new env vars, migrations, or config.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XimHa6fw2YQPxWVK6AZjjs)_