### PR TITLE
Audit NewsPanel/NewsSnippet/BiggestMovers, fix bust-performer bug

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -263,6 +263,7 @@
 - [x] **Audit SettingsView + FeedbackWidget** - Fixed 33 issues
 - [x] **Audit PlayoffPredictorView** - Fixed 18 issues (ties in records, findIndex guards, dynamic playoff weeks, memoization, tied scores, ARIA tabs, aria-labels, error display, unused vars)
 - [x] **Audit TradeHistoryView** - Fixed 11 issues (fetchAll race condition w/ cancellation token, handleIngest/handleGrade stale-league races, double fetch on league change, ingestNotice/error persistence across league switches, defensive seasons sort, dead callerTeamId field, dead aiAnalysis optional fields, label htmlFor, aria-pressed on season tabs, aria-expanded + aria-label on trade row expand button, clearing expanded set on league change)
+- [x] **Audit NewsPanel + NewsSnippet + BiggestMovers** - Fixed 5 issues (BiggestMovers dropped real zero-point bust performances from Over/Under Performers via a stray `actual > 0` filter; trimmed a discarded-data probe request from limit=5 to limit=1; NewsPanel loading skeleton lacked a `role="status"` announcement for screen readers; removed a redundant post-fetch `.slice(0, 3)`; `PlayerNews` type didn't reflect that the aggregated feed's `playerId` can be null and can carry `isArticle`/`players`, so NewsPanel had to re-declare the shape inline instead of using the shared type)
 
 **Views — Not yet audited:**
 - [ ] **Audit TeamView** - Roster display, player cards, team stats
@@ -278,7 +279,6 @@
 - [ ] **Audit Sidebar** - Navigation, responsive collapse, active state
 - [ ] **Audit Header + LeagueManager** - Search bar, league switcher dropdown, notifications bell
 - [ ] **Audit PlayerAvatar** - Image loading, fallback initials
-- [ ] **Audit NewsPanel + NewsSnippet + BiggestMovers** - News feed, player movers widget
 - [ ] **Audit ErrorBoundary** - Error catch/display, recovery
 - [ ] **Audit App.tsx** - Routing, state management, context wiring, page transitions
 

--- a/src/components/BiggestMovers.tsx
+++ b/src/components/BiggestMovers.tsx
@@ -53,7 +53,7 @@ export function BiggestMovers({ currentWeek, isDarkMode }: BiggestMoversProps) {
           weekComplete?: boolean;
           pointsType?: 'actual' | 'projected';
         }>(
-          `/players?page=1&limit=5&includeStats=true&week=${currentWeek}&season=${seasonYear}&sortBy=projectedPoints&sortOrder=desc${league?.id ? `&leagueId=${league.id}` : ''}`
+          `/players?page=1&limit=1&includeStats=true&week=${currentWeek}&season=${seasonYear}&sortBy=projectedPoints&sortOrder=desc${league?.id ? `&leagueId=${league.id}` : ''}`
         );
 
         if (cancelled) return;
@@ -74,9 +74,11 @@ export function BiggestMovers({ currentWeek, isDarkMode }: BiggestMoversProps) {
           // and weeklyProjectedPoints = the real pre-game projection
           const performers: PerformerData[] = players
             .filter((p: APIPlayer) => {
-              const actual = p.seasonStats?.fantasyPointsPPR || 0;
+              // Only require a projection — a real zero-point outing (e.g. a
+              // player who left with an injury) is the most extreme kind of
+              // underperformer and should still show up here.
               const projected = p.weeklyProjectedPoints || 0;
-              return actual > 0 && projected > 0;
+              return projected > 0;
             })
             .map((p: APIPlayer) => {
               const projected = p.weeklyProjectedPoints || 0;

--- a/src/components/NewsPanel.tsx
+++ b/src/components/NewsPanel.tsx
@@ -25,7 +25,7 @@ function formatTimeAgo(dateString: string): string {
 }
 
 export function NewsPanel({ isDarkMode }: NewsPanelProps) {
-  const [news, setNews] = useState<(PlayerNews & { source?: string; isArticle?: boolean; players?: Array<{ id: string; name: string; position: string; team: string }> })[]>([]);
+  const [news, setNews] = useState<PlayerNews[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -60,7 +60,7 @@ export function NewsPanel({ isDarkMode }: NewsPanelProps) {
       <h3 className={`font-bold mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>News & Notes</h3>
 
       {isLoading ? (
-        <div className="space-y-4">
+        <div className="space-y-4" role="status" aria-label="Loading news">
           {[1, 2, 3].map((i) => (
             <div key={i} className={`animate-pulse border-b pb-4 last:border-0 last:pb-0 ${isDarkMode ? 'border-slate-800' : 'border-slate-100'}`}>
               <div className={`h-3 w-16 rounded mb-2 ${isDarkMode ? 'bg-slate-700' : 'bg-slate-200'}`} />
@@ -78,7 +78,7 @@ export function NewsPanel({ isDarkMode }: NewsPanelProps) {
         <p className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>No news available</p>
       ) : (
         <div className="space-y-4">
-          {news.slice(0, 3).map((item) => {
+          {news.map((item) => {
             const articleUrl = item.isArticle ? getSafeNewsUrl(item.sourceUrl) : null;
             return (
             <div key={item.id} className={`border-b pb-4 last:border-0 last:pb-0 ${isDarkMode ? 'border-slate-800' : 'border-slate-100'}`}>

--- a/src/services/players.ts
+++ b/src/services/players.ts
@@ -80,7 +80,9 @@ export interface PlayerProjection {
 
 export interface PlayerNews {
   id: string;
-  playerId: string;
+  // Aggregated feeds (GET /players/news) mix in FilmRoom articles, which can
+  // link to zero or several players — playerId is null in that case.
+  playerId: string | null;
   headline: string;
   content: string;
   source?: string;
@@ -89,6 +91,9 @@ export interface PlayerNews {
   impactLevel?: 'high' | 'medium' | 'low';
   publishedAt: string;
   player?: Player;
+  // Present only on GET /players/news items sourced from published articles.
+  isArticle?: boolean;
+  players?: Array<{ id: string; name: string; position: string; team: string }>;
 }
 
 /** Aggregated season stats returned by GET /players when includeStats=true */


### PR DESCRIPTION
## Summary

Picked the BACKLOG.md "Code Audits" item **Audit NewsPanel + NewsSnippet + BiggestMovers** (News feed, player movers widget) — the last unaudited item that's small, frontend-only, and doesn't depend on a data feed or paid API.

Found and fixed:

- **Real correctness bug in `BiggestMovers`**: the "Over/Under Performers" widget filtered candidates with `actual > 0 && projected > 0`. A player who genuinely scored zero fantasy points in a game they took the field for (e.g. left with an injury, or was a dud) was silently excluded — exactly the kind of extreme bust the widget exists to surface. Now only `projected > 0` is required.
- **Wasted request**: the "is this week complete?" probe request fetched `limit=5` players just to read two boolean/enum flags off the response, discarding the player array entirely. Dropped to `limit=1`.
- **Accessibility gap in `NewsPanel`**: the loading skeleton had no `role="status"`/`aria-label`, unlike the sibling `BiggestMovers` loading state. Added `role="status" aria-label="Loading news"` for parity.
- **Dead code**: removed a redundant `.slice(0, 3)` in `NewsPanel` — the fetch already requests `getAllNews(3)`.
- **Type-safety gap**: the shared `PlayerNews` type declared `playerId: string` (non-nullable) and had no `isArticle`/`players` fields, even though the aggregate `GET /players/news` endpoint can return article-derived items with `playerId: null` and those extra fields. `NewsPanel` was working around this by re-declaring the shape inline on every fetch. Widened `PlayerNews.playerId` to `string | null` and added the optional `isArticle`/`players` fields to the shared type, then simplified `NewsPanel` to use it directly. Checked all other consumers of `PlayerNews.playerId` (`HomeView`) — already null-safe, so this is a pure accuracy fix with no behavior change there.

`NewsSnippet.tsx` was audited too; no issues found worth changing.

## Verified

- `npm run typecheck` — clean (pre-existing `tsconfig.json` `baseUrl` deprecation notice only, confirmed present on `main` before this change too)
- `cd server && npx tsc --noEmit` — clean
- `npm test` — 43/43 passing
- `npm run build` — succeeds

## Owner follow-ups

None — this is a self-contained frontend fix with no schema, migration, or config changes. `BACKLOG.md` updated in the same commit to check off the item.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5VYyS7dedRe2f8uXFS23t)_