### PR TITLE
Expose depth chart order on Team roster and Player Profile page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,9 @@ history accrues from the first daily cron.
 
 - [ ] Practice reports / injury designations (nflverse or ESPN, free)
 - [ ] Usage data: snap %, target share, red-zone touches (nflverse, free)
-- [ ] Depth charts (Sleeper fields already synced upstream — store/expose)
+- [x] Depth charts (Sleeper fields already synced upstream — store/expose) —
+  `depthChartOrder` was already stored + returned by the API; exposed it in
+  the Team roster bench view and the standalone Player Profile page.
 - [ ] Weather for outdoor games (Open-Meteo/NWS, free)
 - [ ] Redraft ADP (Sleeper/Underdog)
 - [ ] Feed projection-accuracy history back into AI prompts

--- a/src/components/PlayerProfileView.tsx
+++ b/src/components/PlayerProfileView.tsx
@@ -379,6 +379,7 @@ export function PlayerProfileView({
               {player.weight != null && <span><span className={`font-semibold ${bodyColor}`}>{player.weight}</span> lbs</span>}
               {player.college && <span><span className={`font-semibold ${bodyColor}`}>{player.college}</span></span>}
               {player.yearsExp != null && <span><span className={`font-semibold ${bodyColor}`}>{player.yearsExp}</span> yrs exp</span>}
+              {player.depthChartOrder != null && <span>Depth <span className={`font-semibold ${bodyColor}`}>#{player.depthChartOrder}</span></span>}
             </div>
 
             {player.injuryNote && (

--- a/src/components/TeamView.tsx
+++ b/src/components/TeamView.tsx
@@ -397,6 +397,7 @@ export function TeamView({ onPlayerClick, isDarkMode }: TeamViewProps) {
                           </div>
                           <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
                             {player.team} • {player.position}
+                            {player.depthChartOrder != null ? ` • Depth #${player.depthChartOrder}` : ''}
                             {avgPoints ? ` • Avg: ${avgPoints.toFixed(1)}` : ''}
                           </div>
                         </div>

--- a/src/context/LeagueContext.tsx
+++ b/src/context/LeagueContext.tsx
@@ -69,6 +69,8 @@ export interface RosterPlayer {
   byeWeek?: number;
   imageUrl?: string;
   lastWeekPoints?: number;
+  /** Position within the team's depth chart (1 = starter-most). Sparse — Sleeper doesn't populate it for every player. */
+  depthChartOrder?: number | null;
   seasonStats?: {
     games: number;
     gamesPlayed?: number;
@@ -336,6 +338,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
           byeWeek?: number;
           headshotUrl?: string;
           imageUrl?: string;
+          depthChartOrder?: number | null;
           seasonStats?: RosterPlayer['seasonStats'];
         };
       }
@@ -357,6 +360,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
         injuryBodyPart: spot.player.injuryBodyPart,
         byeWeek: spot.player.byeWeek,
         imageUrl: spot.player.headshotUrl || spot.player.imageUrl,
+        depthChartOrder: spot.player.depthChartOrder ?? null,
         seasonStats: spot.player.seasonStats || undefined,
       });
 


### PR DESCRIPTION
## Backlog item

TODO.md, P2 — Data feeds: **Depth charts** (`Sleeper fields already synced upstream — store/expose`).

## What I found

The "sync upstream" half of this item was already done: `depthChartOrder` has existed on the `nfl_players` table since the very first migration, `server/scripts/sync-players.mjs` / `server/src/services/sleeper.ts` already populate it from Sleeper's `depth_chart_order` field, and both `GET /teams/:id/roster` and `GET /players*` already return it in their JSON responses (they spread the full player row). Only the "expose" half — actually showing it in the UI — was missing.

## What changed

- `src/context/LeagueContext.tsx` — added `depthChartOrder` to the `RosterPlayer` type and threaded it through the existing `/teams/:id/roster` mapping (`mapPlayer`), since the field was already present in the API response but dropped during mapping.
- `src/components/TeamView.tsx` — bench row subline now shows `• Depth #N` when available, next to team/position. This is the primary use case: judging whether a bench player is a real handcuff or buried on the depth chart.
- `src/components/PlayerProfileView.tsx` — added `Depth #N` to the bio strip (age / height / weight / college / experience), which already had an unused `depthChartOrder` field declared on its local type.

No backend or migration changes — the data was already stored and served; this is a frontend-only change.

Note: Sleeper's `depth_chart_order` is known to be sparse (frequently `null` for backups, rookies, or right after roster moves), so all three spots render conditionally and simply omit the badge when the value is missing.

## Verified

- [x] `npm run typecheck` (frontend) — clean
- [x] `cd server && npx tsc --noEmit` (backend) — clean
- [x] `npm test` (Vitest) — 43/43 passing
- [x] `npm run build` — succeeds

## Owner follow-ups

None — no config, secrets, or remote migrations involved.

## TODO.md

Checked off the "Depth charts" item under P2 — Data feeds. (Not present in BACKLOG.md, so nothing to sync there.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDEqbtFZEQ4wqNdDw8c2fB)_