### PR TITLE
Surface depth chart order for players

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,10 @@ history accrues from the first daily cron.
 
 - [ ] Practice reports / injury designations (nflverse or ESPN, free)
 - [ ] Usage data: snap %, target share, red-zone touches (nflverse, free)
-- [ ] Depth charts (Sleeper fields already synced upstream — store/expose)
+- [x] Depth charts — `depthChartOrder` (already synced from Sleeper into
+  `nfl_players`) is now exposed on the players list/detail API and the team
+  roster API, and surfaced in PlayerCard, the Board (PlayerTable), and
+  TeamView as e.g. "RB2" for QB/RB/WR/TE.
 - [ ] Weather for outdoor games (Open-Meteo/NWS, free)
 - [ ] Redraft ADP (Sleeper/Underdog)
 - [ ] Feed projection-accuracy history back into AI prompts

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,6 +190,7 @@ export interface Player {
   weekChange: number;
   weeklyProjectedPoints?: number;
   headshotUrl?: string | null;
+  depthChartOrder?: number | null;
 }
 
 // URL path <-> view mapping for client-side routing (BUG-001/002 fix)

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -8,6 +8,7 @@ import type { PlayerNews, MatchupGradeResponse, PlayerProjection } from '../serv
 import { useWatchlist } from '../hooks/useWatchlist';
 import { useAuth } from '../context/AuthContext';
 import { buildPlayerProfilePath } from '../utils/slug';
+import { formatPositionWithDepth } from '../utils/playerUtils';
 import { NewsSnippet } from './NewsSnippet';
 
 
@@ -116,6 +117,8 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
 
   // Some callers pass richer player objects than App's Player interface declares.
   const playerExtras = player as Player & { status?: string; externalId?: string };
+
+  const depthChartLabel = formatPositionWithDepth(player.position, player.depthChartOrder);
 
   // --- Quick actions: Watch + Share ---
   const watchlist = useWatchlist();
@@ -480,7 +483,7 @@ export function PlayerCard({ player, onClose, isDarkMode, seasonYear: propsSeaso
                       )}
                     </div>
                     <div className={`flex items-center gap-1.5 text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-                      <span>{player.team} • {player.position} •</span>
+                      <span>{player.team} • {depthChartLabel} •</span>
                       <select
                         value={selectedWeek}
                         onChange={(e) => setSelectedWeek(Number(e.target.value))}

--- a/src/components/PlayerTable.tsx
+++ b/src/components/PlayerTable.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '../context/AuthContext';
 import api from '../services/api';
 import { useOdds } from '../hooks/useOdds';
 import { usePlayerProps, formatPropLine } from '../hooks/usePlayerProps';
-import { type APIPlayer, convertAPIPlayerToPlayer, getEffectiveSeason, scoringToFormat, NFL_WEEKS } from '../utils/playerUtils';
+import { type APIPlayer, convertAPIPlayerToPlayer, formatPositionWithDepth, getEffectiveSeason, scoringToFormat, NFL_WEEKS } from '../utils/playerUtils';
 import type { EnrichedPlayerFields } from '../services/players';
 import { AdUnit } from './AdUnit';
 import { Breadcrumb } from './shared/Breadcrumb';
@@ -99,7 +99,7 @@ const PlayerRow = memo(function PlayerRow({ player, onToggleExpand, onOpenCard, 
             )}
           </div>
           <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
-            {player.team} · {player.position}
+            {player.team} · {formatPositionWithDepth(player.position, player.depthChartOrder)}
             {oddsDisplay && (
               <div className={`text-xs ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>
                 {oddsDisplay}

--- a/src/components/TeamView.tsx
+++ b/src/components/TeamView.tsx
@@ -4,6 +4,7 @@ import { Player } from '../App';
 import { useLeagueContext } from '../context/LeagueContext';
 
 import { sortByPosition } from '../utils/rosterPositions';
+import { formatPositionWithDepth } from '../utils/playerUtils';
 import { calculateGrade, getMatchupGradeLabel, getMatchupGradeColor } from '../utils/matchupGrades';
 
 interface TeamViewProps {
@@ -142,6 +143,7 @@ export function TeamView({ onPlayerClick, isDarkMode }: TeamViewProps) {
     keyLine: `Proj: ${(rosterPlayer.projectedPoints ?? 0).toFixed(1)} pts`,
     projectedPoints: rosterPlayer.projectedPoints || 0,
     weekChange: 0,
+    depthChartOrder: rosterPlayer.depthChartOrder,
   });
 
   // Calculate max point for chart scaling
@@ -319,7 +321,7 @@ export function TeamView({ onPlayerClick, isDarkMode }: TeamViewProps) {
                                   {getStatusIndicator(player.status)}
                                 </div>
                                 <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
-                                  {player.team} • {player.position}
+                                  {player.team} • {formatPositionWithDepth(player.position, player.depthChartOrder)}
                                   {player.seasonStats?.gamesPlayed ?? player.seasonStats?.games ? ` • ${(player.seasonStats?.gamesPlayed ?? player.seasonStats?.games)} GP` : ''}
                                 </div>
                               </div>
@@ -396,7 +398,7 @@ export function TeamView({ onPlayerClick, isDarkMode }: TeamViewProps) {
                             {getStatusIndicator(player.status)}
                           </div>
                           <div className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
-                            {player.team} • {player.position}
+                            {player.team} • {formatPositionWithDepth(player.position, player.depthChartOrder)}
                             {avgPoints ? ` • Avg: ${avgPoints.toFixed(1)}` : ''}
                           </div>
                         </div>

--- a/src/context/LeagueContext.tsx
+++ b/src/context/LeagueContext.tsx
@@ -69,6 +69,7 @@ export interface RosterPlayer {
   byeWeek?: number;
   imageUrl?: string;
   lastWeekPoints?: number;
+  depthChartOrder?: number | null;
   seasonStats?: {
     games: number;
     gamesPlayed?: number;
@@ -336,6 +337,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
           byeWeek?: number;
           headshotUrl?: string;
           imageUrl?: string;
+          depthChartOrder?: number | null;
           seasonStats?: RosterPlayer['seasonStats'];
         };
       }
@@ -357,6 +359,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
         injuryBodyPart: spot.player.injuryBodyPart,
         byeWeek: spot.player.byeWeek,
         imageUrl: spot.player.headshotUrl || spot.player.imageUrl,
+        depthChartOrder: spot.player.depthChartOrder,
         seasonStats: spot.player.seasonStats || undefined,
       });
 
@@ -431,6 +434,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
                 byeWeek?: number;
                 headshotUrl?: string;
                 imageUrl?: string;
+                depthChartOrder?: number | null;
                 seasonStats?: RosterPlayer['seasonStats'];
               };
             }
@@ -450,6 +454,7 @@ export function LeagueProvider({ children }: { children: ReactNode }) {
               injuryBodyPart: spot.player.injuryBodyPart,
               byeWeek: spot.player.byeWeek,
               imageUrl: spot.player.headshotUrl || spot.player.imageUrl,
+              depthChartOrder: spot.player.depthChartOrder,
               seasonStats: spot.player.seasonStats || undefined,
             });
             if (oppResponse.roster.starters) {

--- a/src/services/players.ts
+++ b/src/services/players.ts
@@ -18,6 +18,7 @@ export interface Player {
   headshotUrl?: string;
   age?: number;
   yearsExp?: number;
+  depthChartOrder?: number | null;
 }
 
 export interface PlayerWeeklyStats {

--- a/src/utils/playerUtils.ts
+++ b/src/utils/playerUtils.ts
@@ -13,6 +13,7 @@ export interface APIPlayer {
   projectedPoints: number;
   weeklyProjectedPoints?: number;
   isRostered: boolean;
+  depthChartOrder?: number | null;
   seasonStats?: {
     games: number;
     gamesPlayed?: number;
@@ -31,6 +32,17 @@ export interface APIPlayer {
 
 /** Valid fantasy positions */
 const VALID_POSITIONS = new Set<Player['position']>(['QB', 'RB', 'WR', 'TE', 'K', 'DEF', 'FLEX']);
+
+/** Positions where depth chart order is meaningful to display (e.g. "RB2"). */
+const DEPTH_CHART_POSITIONS = new Set(['QB', 'RB', 'WR', 'TE']);
+
+/**
+ * Format a position with its depth chart order for skill positions (e.g. "RB2"),
+ * falling back to the bare position when the order is unknown or not applicable.
+ */
+export function formatPositionWithDepth(position: string, depthChartOrder?: number | null): string {
+  return depthChartOrder && DEPTH_CHART_POSITIONS.has(position) ? `${position}${depthChartOrder}` : position;
+}
 
 /**
  * Convert an API player to the app's display Player format.
@@ -74,6 +86,7 @@ export function convertAPIPlayerToPlayer(player: APIPlayer, index: number): Play
     weekChange: 0,
     weeklyProjectedPoints: player.weeklyProjectedPoints,
     headshotUrl: player.headshotUrl ?? null,
+    depthChartOrder: player.depthChartOrder ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary

Picks off the `TODO.md` P2 item: **Depth charts (Sleeper fields already synced upstream — store/expose)**.

`depthChartOrder` (Sleeper's `depth_chart_order`) has been synced into the `nfl_players` table for a while and already used internally — AI prompts (`draftRankings.ts`, `tradeContext.ts`), trade player enrichment, and bench sorting in the roster API — but it was never threaded through to the frontend, so end users had no way to see it. The players list/detail API (`GET /players`, `GET /players/:id`) and team roster API (`GET /teams/:id/roster`) already returned the raw column since they select full player rows; only the frontend types and display code were dropping it.

This change threads `depthChartOrder` through the frontend `Player`/`APIPlayer`/`RosterPlayer` types and displays it as e.g. `RB2` next to team/position for QB/RB/WR/TE:
- `PlayerCard` header subline
- Board (`PlayerTable`) row subline
- `TeamView` starters and bench row sublines

Added a small shared `formatPositionWithDepth()` helper in `src/utils/playerUtils.ts` so the three display sites share one formatting rule instead of duplicating it.

No backend changes were needed — the column already exists on `nfl_players` and is already selected by the relevant endpoints, so there's no new migration and nothing new to deploy.

## What I verified

- `npm run typecheck` — clean
- `cd server && npx tsc --noEmit` — clean
- `npm test` — 43 tests passing (5 files)
- `npm run build` — succeeds

## Notes for the owner

- No migration, no deploy-time action needed — this only surfaces data that was already being synced and stored.
- `depthChartOrder` is nullable and often unset for players Sleeper hasn't ranked on a depth chart; the label falls back to the bare position (e.g. `WR` instead of `WR3`) in that case, so there's no broken/blank state.
- Checked off the item in `TODO.md`; there was no corresponding entry in `BACKLOG.md` to sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuDEfdedtK78GcBPxpHmQN)_