### PR TITLE
Feed projection-accuracy history into the per-player AI take prompt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -68,7 +68,10 @@ history accrues from the first daily cron.
 - [ ] Depth charts (Sleeper fields already synced upstream — store/expose)
 - [ ] Weather for outdoor games (Open-Meteo/NWS, free)
 - [ ] Redraft ADP (Sleeper/Underdog)
-- [ ] Feed projection-accuracy history back into AI prompts
+- [x] Feed projection-accuracy history back into AI prompts —
+  `services/projections.ts` computes season-to-date MAE + positional bias
+  from `playerProjections`/`playerWeeklyStats` (6h cache), appended to the
+  per-player AI take system prompt in `routes/players.ts`
 
 ## P3 — Blocked on external data sources / platform sync
 

--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -14,7 +14,7 @@ import {
   buildCachedSystemBlocks,
   type ConversationTurn,
 } from '../utils/prompt';
-import { buildProjectionsFromProps } from '../services/projections';
+import { buildProjectionsFromProps, getProjectionAccuracySummary } from '../services/projections';
 import type { Env, Variables } from '../index';
 
 // Rate limits for player routes
@@ -1242,8 +1242,10 @@ async function resolvePlayerRow(db: any, idParam: string) {
   return db.query.nflPlayers.findFirst({ where: eq(lookupColumn, idParam) });
 }
 
-// Static instructions for the per-player AI take. Byte-identical across all
-// requests so the cache_control marker in buildCachedSystemBlocks applies.
+// Static instructions for the per-player AI take. A projection-accuracy note
+// (see getProjectionAccuracySummary) is appended at call time — it only
+// changes a few times a day, so the cache_control marker in
+// buildCachedSystemBlocks still gets Anthropic cache hits between refreshes.
 const PLAYER_ANALYSIS_SYSTEM_PROMPT = `You are FilmRoom's fantasy football analyst writing a concise weekly "AI take" on a single NFL player for fantasy managers.
 
 You will receive a data block from our live database: player bio, season stats to date, recent weekly fantasy scores, the current-week projection, the upcoming opponent, Vegas game context (spread, total, implied team total), and recent news headlines.
@@ -1419,6 +1421,11 @@ ${newsBlock}`;
       // ── Generate via Anthropic (30s timeout, graceful 503 on failure) ──
       let analysis: string;
       try {
+        const accuracyNote = await getProjectionAccuracySummary(db);
+        const systemPrompt = accuracyNote
+          ? `${PLAYER_ANALYSIS_SYSTEM_PROMPT}\n\n${accuracyNote}`
+          : PLAYER_ANALYSIS_SYSTEM_PROMPT;
+
         const res = await fetch('https://api.anthropic.com/v1/messages', {
           method: 'POST',
           headers: {
@@ -1429,7 +1436,7 @@ ${newsBlock}`;
           body: JSON.stringify({
             model: AI_MODEL,
             max_tokens: 600,
-            system: buildCachedSystemBlocks(PLAYER_ANALYSIS_SYSTEM_PROMPT),
+            system: buildCachedSystemBlocks(systemPrompt),
             messages: [{ role: 'user', content: dataBlock }],
           }),
           signal: AbortSignal.timeout(30000),

--- a/server/src/services/projections.ts
+++ b/server/src/services/projections.ts
@@ -1,8 +1,8 @@
-import { eq, and } from 'drizzle-orm';
+import { eq, and, gt } from 'drizzle-orm';
 import * as schema from '../db/schema';
 import type { PlayerProps } from '../db/schema';
 import { generateId } from '../utils/id';
-import { invalidateCache } from '../utils/cache';
+import { cached, invalidateCache } from '../utils/cache';
 
 /**
  * Convert player prop lines (from sportsbooks) into projected fantasy points.
@@ -426,4 +426,82 @@ export async function generateProjectionsFromProps(
 
   console.log(`[projections] Generated ${generated}, updated ${updated} from ${projections.length} player prop lines`);
   return { generated, updated };
+}
+
+/**
+ * Compare this season's PPR projections against what actually happened, so AI
+ * prompts can calibrate their confidence instead of treating a projection as
+ * gospel. Only counts player-weeks where the player actually took a snap
+ * (offSnaps > 0) — otherwise byes/inactives would pad the sample with
+ * trivially "accurate" 0-vs-0 rows.
+ */
+async function computeProjectionAccuracySummary(db: any): Promise<string | null> {
+  const now = new Date();
+  // NFL season spans Sep–Feb; Jan/Feb still belongs to the season that started
+  // the previous calendar year.
+  const seasonYear = now.getMonth() <= 1 ? now.getFullYear() - 1 : now.getFullYear();
+
+  const rows = await db
+    .select({
+      position: schema.nflPlayers.position,
+      projected: schema.playerProjections.projectedPoints,
+      actual: schema.playerWeeklyStats.fantasyPointsPPR,
+    })
+    .from(schema.playerProjections)
+    .innerJoin(
+      schema.playerWeeklyStats,
+      and(
+        eq(schema.playerProjections.playerId, schema.playerWeeklyStats.playerId),
+        eq(schema.playerProjections.week, schema.playerWeeklyStats.week),
+        eq(schema.playerProjections.seasonYear, schema.playerWeeklyStats.seasonYear)
+      )
+    )
+    .innerJoin(schema.nflPlayers, eq(schema.nflPlayers.id, schema.playerProjections.playerId))
+    .where(
+      and(
+        eq(schema.playerProjections.seasonYear, seasonYear),
+        eq(schema.playerProjections.scoringFormat, 'ppr'),
+        gt(schema.playerWeeklyStats.offSnaps, 0)
+      )
+    );
+
+  if (rows.length < 20) return null; // not enough finalized weeks yet to say anything meaningful
+
+  let sumAbsError = 0;
+  const byPosition = new Map<string, { sumError: number; count: number }>();
+  for (const row of rows) {
+    const projected = row.projected ?? 0;
+    const actual = row.actual ?? 0;
+    const error = actual - projected; // positive = player outperformed projection
+    sumAbsError += Math.abs(error);
+
+    const bucket = byPosition.get(row.position) ?? { sumError: 0, count: 0 };
+    bucket.sumError += error;
+    bucket.count += 1;
+    byPosition.set(row.position, bucket);
+  }
+
+  const meanAbsError = sumAbsError / rows.length;
+  const biasNotes = [...byPosition.entries()]
+    .filter(([, v]) => v.count >= 10)
+    .map(([position, v]) => {
+      const avgBias = v.sumError / v.count;
+      if (Math.abs(avgBias) < 0.5) return null;
+      const direction = avgBias > 0 ? 'under-projected' : 'over-projected';
+      return `${position} ${direction} by ${Math.abs(avgBias).toFixed(1)} pts/gm on average`;
+    })
+    .filter((n): n is string => n != null);
+
+  return `Season ${seasonYear} projection accuracy so far (${rows.length} player-weeks, PPR): mean absolute error ${meanAbsError.toFixed(1)} pts/gm.${
+    biasNotes.length ? ` Positional bias observed — ${biasNotes.join('; ')}.` : ''
+  } Treat projections as a directional estimate, not a guarantee.`;
+}
+
+/**
+ * Cached wrapper (6h TTL) around computeProjectionAccuracySummary — the
+ * underlying join is cheap but there's no reason to recompute it on every
+ * AI request when the input data only changes a few times a day.
+ */
+export async function getProjectionAccuracySummary(db: any): Promise<string | null> {
+  return cached('projection-accuracy-summary', 6 * 60 * 60 * 1000, () => computeProjectionAccuracySummary(db));
 }


### PR DESCRIPTION
## What

Picks off the TODO.md P2 item: **"Feed projection-accuracy history back into AI prompts"**.

The per-player "AI take" (`GET /players/:id/analysis`) tells the model this week's projected points as if they were exact, but our own historical data already shows how far off those projections tend to run. This surfaces that context to the model so it can calibrate confidence instead of overstating precision.

## How

- `server/src/services/projections.ts`: added `getProjectionAccuracySummary(db)`, which joins `playerProjections` against `playerWeeklyStats` for the current season (PPR, snap-filtered to `offSnaps > 0` so byes/inactives don't pad the sample with trivial 0-vs-0 matches) and computes a season-to-date mean absolute error plus per-position over/under bias (e.g. "RB under-projected by 1.2 pts/gm on average"). Bails out (`null`) if there's fewer than 20 qualifying player-weeks so far this season. Wrapped in the existing `cached()` helper with a 6h TTL — the join is cheap, but there's no reason to recompute it on every analysis request.
- `server/src/routes/players.ts`: the `/players/:id/analysis` handler now fetches that summary and appends it to `PLAYER_ANALYSIS_SYSTEM_PROMPT` before calling `buildCachedSystemBlocks`. Since the summary only changes a few times a day (6h cache), the system prompt stays byte-identical within any Anthropic prompt-cache window, so cache hits are unaffected in practice.
- No schema change, no new external API — this is entirely derived from data already in D1.

## Verified

- `npm run typecheck` (frontend) — clean
- `cd server && npx tsc --noEmit` (backend) — clean
- `npm test` (Vitest, frontend) — 5 files / 43 tests passing
- `npm run build` — succeeds

No backend test harness exists in this repo yet (separate open TODO item), so the new join/aggregation logic wasn't unit-tested in isolation beyond type-checking.

## Owner follow-up

None required — no new env vars, secrets, or migrations. The accuracy note is `null` (and the system prompt falls back to its original static text) until there are at least 20 played-and-projected player-weeks recorded for the current season, so behavior is unchanged until enough data has accrued.

Updated `TODO.md` to check off the item.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYUT1RMii1SCtdojvJphBD)_