### PR TITLE
Add real weather forecasts for outdoor NFL games

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -66,7 +66,10 @@ history accrues from the first daily cron.
 - [ ] Practice reports / injury designations (nflverse or ESPN, free)
 - [ ] Usage data: snap %, target share, red-zone touches (nflverse, free)
 - [ ] Depth charts (Sleeper fields already synced upstream — store/expose)
-- [ ] Weather for outdoor games (Open-Meteo/NWS, free)
+- [x] Weather for outdoor games (Open-Meteo, free) — `POST /api/admin/sync-weather`
+  fetches temperature/wind/precip-chance forecasts for upcoming outdoor
+  games and merges them into `nfl_games.weather`; runs on the existing
+  4-hour cron during the season. Surfaced on GameSlateView + GameDetailModal.
 - [ ] Redraft ADP (Sleeper/Underdog)
 - [ ] Feed projection-accuracy history back into AI prompts
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -330,9 +330,10 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
     await callSync('/api/admin/sync-stats', { weeks: weeksToSync });
     await callSync('/api/admin/sync-projections', { week: currentWeek });
 
-    // Sync current odds during NFL season
+    // Sync current odds and outdoor-stadium weather forecasts during NFL season
     if (currentWeek <= 18) {
       await callSync('/api/admin/sync-odds');
+      await callSync('/api/admin/sync-weather');
     }
   } else if (event.cron === '0 */6 * * *') {
     // Every 6 hours: sync all news sources

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -937,7 +937,11 @@ adminRoutes.post('/sync-games', async (c) => {
                 overUnder: existing.overUnder ?? null,
               });
             }
-            await db.update(schema.nflGames).set(values).where(eq(schema.nflGames.id, row.id));
+            // ESPN doesn't report weather for future outdoor games — don't
+            // clobber a forecast already synced by /sync-weather.
+            const updateValues: Record<string, any> = { ...values };
+            if (updateValues.weather == null && existing.weather) delete updateValues.weather;
+            await db.update(schema.nflGames).set(updateValues).where(eq(schema.nflGames.id, row.id));
             updated++;
           } else {
             await db.insert(schema.nflGames).values(values);
@@ -959,6 +963,65 @@ adminRoutes.post('/sync-games', async (c) => {
     });
   } catch (err) {
     console.error('Sync games error:', err);
+    return c.json(
+      {
+        error: 'Sync failed',
+        message: err instanceof Error ? err.message : 'Unknown error',
+      },
+      500
+    );
+  }
+});
+
+/**
+ * POST /api/admin/sync-weather
+ * Fetches free Open-Meteo forecasts (temperature, wind, precipitation
+ * chance) for upcoming outdoor games and merges them into the `weather`
+ * JSON column on nfl_games. Indoor-stadium teams and games more than ~15
+ * days out are skipped — they keep the generic Indoor/Outdoor fallback.
+ * Requires X-Admin-Key header matching SYNC_SECRET env var.
+ */
+adminRoutes.post('/sync-weather', async (c) => {
+  const db = c.get('db');
+
+  try {
+    const { fetchStadiumForecast, isIndoorStadium } = await import('../services/weather');
+    const now = new Date();
+
+    const games = await db.query.nflGames.findMany({
+      where: eq(schema.nflGames.isComplete, false),
+      columns: { id: true, homeTeam: true, gameTime: true },
+    });
+
+    let updated = 0;
+    let skipped = 0;
+
+    for (const game of games) {
+      const gameTime = game.gameTime instanceof Date ? game.gameTime : new Date(game.gameTime);
+      if (gameTime < now || isIndoorStadium(game.homeTeam)) {
+        skipped++;
+        continue;
+      }
+      const forecast = await fetchStadiumForecast(game.homeTeam, gameTime);
+      if (!forecast) {
+        skipped++;
+        continue;
+      }
+      await db
+        .update(schema.nflGames)
+        .set({ weather: JSON.stringify(forecast) })
+        .where(eq(schema.nflGames.id, game.id));
+      updated++;
+    }
+
+    return c.json({
+      success: true,
+      message: 'Weather sync completed',
+      updated,
+      skipped,
+    });
+  } catch (err) {
+    console.error('Sync weather error:', err);
     return c.json(
       {
         error: 'Sync failed',

--- a/server/src/routes/games.ts
+++ b/server/src/routes/games.ts
@@ -47,6 +47,9 @@ async function persistGamesToDb(
       if (values.tvNetwork == null && existing.tvNetwork) delete values.tvNetwork;
       if (values.spread == null && existing.spread != null) delete values.spread;
       if (values.overUnder == null && existing.overUnder != null) delete values.overUnder;
+      // ...and ESPN reports no weather for future outdoor games — don't clobber
+      // a forecast already synced by /sync-weather.
+      if (values.weather == null && existing.weather) delete values.weather;
       await db.update(schema.nflGames).set(values).where(eq(schema.nflGames.id, row.id));
     } else {
       await db.insert(schema.nflGames).values(values);
@@ -64,7 +67,7 @@ function normalizeTeam(abbrev: string): string {
 
 // Helper: map a DB game row to the slate API response shape
 function dbGameToSlateGame(g: any) {
-  let weather = g.weather ? (JSON.parse(g.weather) as { displayValue: string; temperature?: number }) : null;
+  let weather = g.weather ? (JSON.parse(g.weather) as { displayValue: string; temperature?: number; windMph?: number; precipChance?: number }) : null;
   const gameTime = new Date(g.gameTime);
   const nowMs = Date.now();
   const kickoffMs = gameTime.getTime();
@@ -411,6 +414,27 @@ gameRoutes.get('/espn/scoreboard', espnProxyRateLimit, optionalAuthMiddleware, a
     );
     const db = c.get('db');
     await persistGamesToDb(db, dbRows);
+
+    // ESPN reports no weather for most future games — overlay any forecast
+    // already synced by /sync-weather (Open-Meteo) for games missing one.
+    const missingWeatherIds = games.filter(g => !g.weather).map(g => g.id);
+    if (missingWeatherIds.length > 0) {
+      const stored = await db.query.nflGames.findMany({
+        where: inArray(schema.nflGames.id, missingWeatherIds),
+        columns: { id: true, weather: true },
+      });
+      const weatherById = new Map(stored.map(r => [r.id, r.weather]));
+      for (const g of games) {
+        const raw = weatherById.get(g.id);
+        if (!g.weather && raw) {
+          try {
+            g.weather = JSON.parse(raw);
+          } catch {
+            // Malformed stored weather — leave as null.
+          }
+        }
+      }
+    }
 
     return c.json({
       week: w,

--- a/server/src/services/espn.ts
+++ b/server/src/services/espn.ts
@@ -108,7 +108,7 @@ export interface EspnSlateGame {
   favoredTeam: 'home' | 'away';
   overUnder: number | null;
   tvNetwork: string;
-  weather: { displayValue: string; temperature?: number } | null;
+  weather: { displayValue: string; temperature?: number; windMph?: number; precipChance?: number } | null;
   homeScore?: number;
   awayScore?: number;
   status?: string;

--- a/server/src/services/weather.ts
+++ b/server/src/services/weather.ts
@@ -1,0 +1,142 @@
+/**
+ * Open-Meteo forecast integration for outdoor NFL stadiums.
+ * Free, no API key required. Forecast window is ~16 days out — games
+ * further away than that return null and keep the generic "Outdoor" label.
+ */
+
+// NFL teams that play in indoor / dome / retractable-roof stadiums — these
+// never need a weather forecast (fixed 72°F "Indoor" fallback elsewhere).
+export const INDOOR_TEAMS = new Set(['NO', 'DET', 'MIN', 'LV', 'IND', 'ATL', 'DAL', 'HOU', 'ARI']);
+
+export function isIndoorStadium(teamAbbrev: string): boolean {
+  return INDOOR_TEAMS.has(teamAbbrev);
+}
+
+// Approximate stadium coordinates for every NFL team (WSH/WAS both present
+// since ESPN and our own team data disagree on the abbreviation).
+export const TEAM_STADIUM_COORDS: Record<string, { lat: number; lon: number }> = {
+  ARI: { lat: 33.5276, lon: -112.2626 },
+  ATL: { lat: 33.7554, lon: -84.4008 },
+  BAL: { lat: 39.2780, lon: -76.6227 },
+  BUF: { lat: 42.7738, lon: -78.7870 },
+  CAR: { lat: 35.2258, lon: -80.8528 },
+  CHI: { lat: 41.8623, lon: -87.6167 },
+  CIN: { lat: 39.0954, lon: -84.5160 },
+  CLE: { lat: 41.5061, lon: -81.6995 },
+  DAL: { lat: 32.7473, lon: -97.0945 },
+  DEN: { lat: 39.7439, lon: -105.0201 },
+  DET: { lat: 42.3400, lon: -83.0456 },
+  GB: { lat: 44.5013, lon: -88.0622 },
+  HOU: { lat: 29.6847, lon: -95.4107 },
+  IND: { lat: 39.7601, lon: -86.1639 },
+  JAX: { lat: 30.3239, lon: -81.6373 },
+  KC: { lat: 39.0489, lon: -94.4839 },
+  LAC: { lat: 33.9535, lon: -118.3392 },
+  LAR: { lat: 33.9535, lon: -118.3392 },
+  LV: { lat: 36.0909, lon: -115.1833 },
+  MIA: { lat: 25.9580, lon: -80.2389 },
+  MIN: { lat: 44.9738, lon: -93.2575 },
+  NE: { lat: 42.0909, lon: -71.2643 },
+  NO: { lat: 29.9511, lon: -90.0812 },
+  NYG: { lat: 40.8135, lon: -74.0745 },
+  NYJ: { lat: 40.8135, lon: -74.0745 },
+  PHI: { lat: 39.9008, lon: -75.1675 },
+  PIT: { lat: 40.4468, lon: -80.0158 },
+  SEA: { lat: 47.5952, lon: -122.3316 },
+  SF: { lat: 37.4032, lon: -121.9698 },
+  TB: { lat: 27.9759, lon: -82.5033 },
+  TEN: { lat: 36.1665, lon: -86.7713 },
+  WAS: { lat: 38.9076, lon: -76.8645 },
+  WSH: { lat: 38.9076, lon: -76.8645 },
+};
+
+const OPEN_METEO_URL = 'https://api.open-meteo.com/v1/forecast';
+
+export interface StadiumForecast {
+  displayValue: string;
+  temperature: number;
+  windMph: number;
+  precipChance: number;
+}
+
+// Simplified WMO weather-code -> short label mapping (matches the subset
+// GameSlateView's WeatherIcon already keys off: rain/snow/sunny/clear).
+function describeWeatherCode(code: number | undefined): string {
+  if (code == null) return 'Outdoor';
+  if (code === 0) return 'Clear';
+  if (code <= 3) return 'Cloudy';
+  if (code === 45 || code === 48) return 'Fog';
+  if (code >= 51 && code <= 57) return 'Drizzle';
+  if ((code >= 61 && code <= 67) || (code >= 80 && code <= 82)) return 'Rain';
+  if ((code >= 71 && code <= 77) || code === 85 || code === 86) return 'Snow';
+  if (code >= 95) return 'Thunderstorm';
+  return 'Outdoor';
+}
+
+interface OpenMeteoResponse {
+  hourly?: {
+    time: string[];
+    temperature_2m: number[];
+    precipitation_probability: number[];
+    wind_speed_10m: number[];
+    weather_code: number[];
+  };
+}
+
+/**
+ * Fetch the hourly forecast closest to kickoff for a team's home stadium.
+ * Returns null for indoor teams, unknown teams, and games outside
+ * Open-Meteo's ~16-day forecast window (caller keeps the generic label).
+ */
+export async function fetchStadiumForecast(
+  teamAbbrev: string,
+  gameTime: Date
+): Promise<StadiumForecast | null> {
+  if (isIndoorStadium(teamAbbrev)) return null;
+  const coords = TEAM_STADIUM_COORDS[teamAbbrev];
+  if (!coords) return null;
+
+  const daysOut = (gameTime.getTime() - Date.now()) / 86_400_000;
+  if (daysOut < -0.25 || daysOut > 15) return null;
+
+  const params = new URLSearchParams({
+    latitude: String(coords.lat),
+    longitude: String(coords.lon),
+    hourly: 'temperature_2m,precipitation_probability,wind_speed_10m,weather_code',
+    temperature_unit: 'fahrenheit',
+    wind_speed_unit: 'mph',
+    timezone: 'UTC',
+    forecast_days: '16',
+  });
+
+  try {
+    const res = await fetch(`${OPEN_METEO_URL}?${params}`);
+    if (!res.ok) return null;
+    const data = (await res.json()) as OpenMeteoResponse;
+    const hourly = data.hourly;
+    if (!hourly?.time?.length) return null;
+
+    const targetMs = gameTime.getTime();
+    let bestIdx = 0;
+    let bestDiff = Infinity;
+    for (let i = 0; i < hourly.time.length; i++) {
+      const diff = Math.abs(new Date(`${hourly.time[i]}Z`).getTime() - targetMs);
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        bestIdx = i;
+      }
+    }
+
+    const temperature = hourly.temperature_2m[bestIdx];
+    if (temperature == null) return null;
+
+    return {
+      displayValue: describeWeatherCode(hourly.weather_code?.[bestIdx]),
+      temperature: Math.round(temperature),
+      windMph: Math.round(hourly.wind_speed_10m[bestIdx] ?? 0),
+      precipChance: Math.round(hourly.precipitation_probability[bestIdx] ?? 0),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/components/GameDetailModal.tsx
+++ b/src/components/GameDetailModal.tsx
@@ -184,6 +184,8 @@ export function GameDetailModal({ game, onClose, onPlayerClick, isDarkMode }: Ga
                 <span className={isDarkMode ? 'text-sky-200' : 'text-sky-800'}>
                   {game.weather.displayValue}
                   {game.weather.temperature != null && ` • ${game.weather.temperature}°F`}
+                  {game.weather.windMph != null && ` • ${game.weather.windMph} mph wind`}
+                  {game.weather.precipChance != null && game.weather.precipChance > 0 && ` • ${game.weather.precipChance}% precip`}
                 </span>
               </div>
             )}

--- a/src/components/GameSlateView.tsx
+++ b/src/components/GameSlateView.tsx
@@ -382,6 +382,8 @@ export function GameSlateView({ onSelectGame, isDarkMode = true }: GameSlateView
                   <span className={`text-sm ${isDarkMode ? 'text-sky-200' : 'text-sky-800'}`}>
                     {game.weather.displayValue}
                     {game.weather.temperature != null && ` • ${game.weather.temperature}°F`}
+                    {game.weather.windMph != null && ` • ${game.weather.windMph} mph wind`}
+                    {game.weather.precipChance != null && game.weather.precipChance > 0 && ` • ${game.weather.precipChance}% precip`}
                   </span>
                 </div>
               )}

--- a/src/services/games.ts
+++ b/src/services/games.ts
@@ -32,6 +32,8 @@ export interface EspnScoreboardGame {
     temperature?: number;
     highTemperature?: number;
     conditionId?: string;
+    windMph?: number;
+    precipChance?: number;
   } | null;
   homeScore?: number;
   awayScore?: number;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -16,6 +16,8 @@ export interface Game {
     displayValue: string;
     temperature?: number;
     highTemperature?: number;
+    windMph?: number;
+    precipChance?: number;
   } | null;
   homeScore?: number;
   awayScore?: number;


### PR DESCRIPTION
## Summary

Picks off the TODO.md P2 item: **Weather for outdoor games (Open-Meteo/NWS, free)**.

Before this change, outdoor games only showed a generic "Outdoor" label with no temperature until ESPN's own weather data appeared close to kickoff — useless for pregame lineup/start-sit decisions on games more than a few hours out.

- New `server/src/services/weather.ts`: NFL stadium coordinates for all 32 teams + a thin wrapper around Open-Meteo's free forecast API (no key required) that returns temperature, wind speed, precipitation chance, and a short condition label (Clear/Cloudy/Rain/Snow/etc.) for the hour closest to kickoff. Indoor-stadium teams and games outside Open-Meteo's ~16-day forecast window are skipped.
- New `POST /api/admin/sync-weather` admin endpoint that fetches forecasts for upcoming, non-indoor games and merges them into the existing `nfl_games.weather` JSON column (no schema change needed).
- Wired into the existing in-season 4-hour cron (`0 */4 * * *`), alongside the odds sync.
- The ESPN scoreboard proxy (`/games/espn/scoreboard`, what `GameSlateView` actually renders) now overlays this DB-synced forecast for any game where ESPN itself hasn't reported weather yet — otherwise the enrichment would never reach the UI, since that endpoint normally returns ESPN's own (usually null, for future games) weather object.
- Fixed both places that persist ESPN game rows (`games.ts`'s `persistGamesToDb` and `admin.ts`'s `/sync-games`) so a `null` ESPN weather value no longer clobbers a forecast already written by the new job — same pattern already used there for `tvNetwork`/`spread`/`overUnder`.
- Surfaced wind speed and precipitation chance (when present) on `GameSlateView` and `GameDetailModal`, alongside the existing temperature display.

## What I verified

- `npm run typecheck` (frontend) — passes (pre-existing `tsconfig.json` `baseUrl` deprecation warning is unrelated, present on `main` too)
- `cd server && npx tsc --noEmit` — passes
- `npm test` — 43/43 passing
- `npm run build` — succeeds

## Owner notes

- No database migration — this reuses the existing `nfl_games.weather` text column.
- No new secrets/config — Open-Meteo requires no API key.
- No `wrangler.toml` changes — the new sync piggybacks on the existing 4-hour cron trigger, so nothing extra needs to be (re)deployed beyond the normal merge-to-deploy pipeline.
- TODO.md updated to check off the item.



---
_Generated by [Claude Code](https://claude.ai/code/session_019o25oL51Vri2GUT8XKG1m2)_