### PR TITLE
Audit WaiversView: keyboard access, table semantics, QB stat parity

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -263,10 +263,10 @@
 - [x] **Audit SettingsView + FeedbackWidget** - Fixed 33 issues
 - [x] **Audit PlayoffPredictorView** - Fixed 18 issues (ties in records, findIndex guards, dynamic playoff weeks, memoization, tied scores, ARIA tabs, aria-labels, error display, unused vars)
 - [x] **Audit TradeHistoryView** - Fixed 11 issues (fetchAll race condition w/ cancellation token, handleIngest/handleGrade stale-league races, double fetch on league change, ingestNotice/error persistence across league switches, defensive seasons sort, dead callerTeamId field, dead aiAnalysis optional fields, label htmlFor, aria-pressed on season tabs, aria-expanded + aria-label on trade row expand button, clearing expanded set on league change)
+- [x] **Audit WaiversView** - Fixed 3 issues (main table rows were mouse-only — clicking opened the player modal but there was no keyboard path in; added `role="button"`/`tabIndex`/`aria-label`/`onKeyDown` matching the pattern already used in AllPlayersView/PlayerTable; added missing `scope="col"` on table headers; the local `convertToPlayer` had drifted from the shared `convertAPIPlayerToPlayer` in `utils/playerUtils.ts` and was missing the dual-threat-QB rushing-stats fix, so QB rushing production silently didn't show in the modal keyLine when opened from Waivers — brought it back in parity, kept the scoring-format-aware avg fallback since the shared helper doesn't support that)
 
 **Views — Not yet audited:**
 - [ ] **Audit TeamView** - Roster display, player cards, team stats
-- [ ] **Audit WaiversView** - Waiver claims, player search, bid management
 - [ ] **Audit GameSlateView + GameDetailModal** - NFL schedule, live scores, game detail overlay
 - [ ] **Audit TrendsView** - Roster trends, projection movers
 - [ ] **Audit AllPlayersView** - Full player list with filters, pagination

--- a/src/components/WaiversView.tsx
+++ b/src/components/WaiversView.tsx
@@ -140,7 +140,11 @@ export function WaiversView({ onPlayerClick, onViewAll, isDarkMode }: WaiversVie
     if (player.seasonStats) {
       const stats = player.seasonStats;
       if (player.position === 'QB') {
-        keyLine = `${stats.passYards} yds, ${stats.passTDs} TD`;
+        // Include rushing stats for dual-threat QBs so points are explainable
+        // (matches convertAPIPlayerToPlayer in utils/playerUtils.ts).
+        const rushPart = stats.rushYards > 0 ? `, ${stats.rushYards} rush` : '';
+        const rushTDPart = stats.rushTDs > 0 ? `, ${stats.rushTDs} rTD` : '';
+        keyLine = `${stats.passYards} yds, ${stats.passTDs} TD${rushPart}${rushTDPart}`;
       } else if (player.position === 'RB') {
         keyLine = `${stats.rushYards} rush, ${stats.receivingYards} rec`;
       } else if (player.position === 'WR' || player.position === 'TE') {
@@ -286,12 +290,12 @@ export function WaiversView({ onPlayerClick, onViewAll, isDarkMode }: WaiversVie
                 <table className="w-full text-left border-collapse">
                   <thead>
                     <tr className={`border-b ${isDarkMode ? 'bg-slate-800/50 border-slate-700' : 'bg-slate-50 border-slate-200'}`}>
-                      <th className={`px-6 py-4 text-xs font-medium w-12 text-center ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>#</th>
-                      <th className={`px-4 py-4 text-xs font-medium ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Player</th>
-                      <th className={`px-4 py-4 text-xs font-medium w-16 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Pos</th>
-                      <th className={`px-4 py-4 text-xs font-medium text-right w-16 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>GP</th>
-                      <th className={`px-4 py-4 text-xs font-medium text-right w-20 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Avg</th>
-                      <th className={`px-6 py-4 text-xs font-medium text-right w-20 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+                      <th scope="col" className={`px-6 py-4 text-xs font-medium w-12 text-center ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>#</th>
+                      <th scope="col" className={`px-4 py-4 text-xs font-medium ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Player</th>
+                      <th scope="col" className={`px-4 py-4 text-xs font-medium w-16 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Pos</th>
+                      <th scope="col" className={`px-4 py-4 text-xs font-medium text-right w-16 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>GP</th>
+                      <th scope="col" className={`px-4 py-4 text-xs font-medium text-right w-20 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>Avg</th>
+                      <th scope="col" className={`px-6 py-4 text-xs font-medium text-right w-20 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
                         {pointsType === 'actual' ? 'Pts' : 'Proj'}
                       </th>
                     </tr>
@@ -305,7 +309,16 @@ export function WaiversView({ onPlayerClick, onViewAll, isDarkMode }: WaiversVie
                       return (
                         <tr
                           key={player.id}
+                          tabIndex={0}
+                          role="button"
+                          aria-label={`${player.name}, ${player.position}, ${player.team}`}
                           onClick={() => onPlayerClick(convertToPlayer(player, index))}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              onPlayerClick(convertToPlayer(player, index));
+                            }
+                          }}
                           className={`group cursor-pointer transition-colors ${isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-slate-50'}`}
                         >
                           <td className={`px-6 py-4 text-sm text-center font-mono ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>


### PR DESCRIPTION
## What

Picks off the BACKLOG.md "Code Audits" item: **"Audit WaiversView — Waiver claims, player search, bid management."**

Note: this run initially picked TODO.md's "Server-side test harness" item, but discovered mid-implementation that an earlier scheduled run had already opened an equivalent, more thorough open PR (#252) for it. To avoid shipping a duplicate, this run switched to a different, still-unclaimed backlog item — the WaiversView audit, which no open PR currently touches.

Reviewed `src/components/WaiversView.tsx` against the audit checklist (bugs, accessibility, type safety, code reuse) and fixed 3 real issues:

- **Keyboard access** — the main player-rows table used `onClick` only; there was no keyboard path to open the player modal. Added `role="button"`, `tabIndex={0}`, `aria-label`, and `onKeyDown` (Enter/Space), matching the exact pattern already used in `AllPlayersView.tsx` and `PlayerTable.tsx`.
- **Table semantics** — the `<th>` header cells were missing `scope="col"`, also matching the convention used in the already-audited table components.
- **QB stat-parity bug** — `WaiversView` maintains its own local `convertToPlayer` (rather than the shared `convertAPIPlayerToPlayer` in `utils/playerUtils.ts`, which it can't drop in as-is because it needs a scoring-format-aware average that the shared helper doesn't support). That local copy had drifted and was missing the "BUG-008" dual-threat-QB rushing-stats fix already shipped in the shared helper — so a QB's rushing yards/TDs silently didn't show in the player-modal `keyLine` specifically when opened from the Waivers page. Brought it back to parity.

## Verified

- `npm run typecheck` (frontend) — clean
- `cd server && npx tsc --noEmit` — clean
- `npm test` (repo root, Vitest) — 43 passing, unaffected
- `npm run build` — succeeds

## Owner follow-up

None — pure frontend fix, no schema/migration/config changes, nothing needing a manual step on merge.

BACKLOG.md's Code Audits checklist updated to mark WaiversView audited in this same commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQxCxZFaJ65LyKzSzbGuqP)_