### PR TITLE
Audit ProfileView, fix subscription-cancel state lost on reload

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -263,6 +263,7 @@
 - [x] **Audit SettingsView + FeedbackWidget** - Fixed 33 issues
 - [x] **Audit PlayoffPredictorView** - Fixed 18 issues (ties in records, findIndex guards, dynamic playoff weeks, memoization, tied scores, ARIA tabs, aria-labels, error display, unused vars)
 - [x] **Audit TradeHistoryView** - Fixed 11 issues (fetchAll race condition w/ cancellation token, handleIngest/handleGrade stale-league races, double fetch on league change, ingestNotice/error persistence across league switches, defensive seasons sort, dead callerTeamId field, dead aiAnalysis optional fields, label htmlFor, aria-pressed on season tabs, aria-expanded + aria-label on trade row expand button, clearing expanded set on league change)
+- [x] **Audit ProfileView** - Fixed a real bug where cancelling a subscription only recorded the "cancelled, access until X" state in local component state — reloading the page lost it and showed a misleading "Renews {date}" message for an already-cancelled plan. Added a persisted `subscriptionCancelAtPeriodEnd` flag on `users` (migration `0042`), kept in sync from Stripe on our own `/billing/cancel` call and from the `customer.subscription.updated`/`.deleted` webhooks (so portal-initiated cancel/reactivate stays correct too), and switched ProfileView to read it via `refreshUser()` instead of local-only state.
 
 **Views — Not yet audited:**
 - [ ] **Audit TeamView** - Roster display, player cards, team stats
@@ -270,7 +271,6 @@
 - [ ] **Audit GameSlateView + GameDetailModal** - NFL schedule, live scores, game detail overlay
 - [ ] **Audit TrendsView** - Roster trends, projection movers
 - [ ] **Audit AllPlayersView** - Full player list with filters, pagination
-- [ ] **Audit ProfileView** - User profile, password change, Google link status
 - [ ] **Audit LoginView + RegisterView + ForgotPasswordView** - Auth forms, rate limiting, Google OAuth
 - [ ] **Audit PlayerCard** - Player detail modal, game log, stats, matchup grade, projections
 

--- a/server/migrations/0042_add_subscription_cancel_flag.sql
+++ b/server/migrations/0042_add_subscription_cancel_flag.sql
@@ -1,0 +1,6 @@
+-- Track whether a paid subscription is set to cancel at the end of the
+-- current billing period. Without this, subscriptionExpiresAt alone can't
+-- distinguish "will renew on this date" from "access ends on this date" —
+-- ProfileView showed a misleading "Renews {date}" message after a page
+-- reload even though the user had already cancelled.
+ALTER TABLE users ADD COLUMN subscription_cancel_at_period_end INTEGER NOT NULL DEFAULT 0;

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -22,6 +22,7 @@ export const users = sqliteTable('users', {
   stripeCustomerId: text('stripe_customer_id'),
   stripeSubscriptionId: text('stripe_subscription_id'),
   subscriptionExpiresAt: text('subscription_expires_at'),
+  subscriptionCancelAtPeriodEnd: integer('subscription_cancel_at_period_end', { mode: 'boolean' }).notNull().default(false),
   role: text('role').notNull().default('user'), // 'user' | 'admin'
   emailVerifiedAt: integer('email_verified_at', { mode: 'timestamp' }), // null = unverified
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -378,6 +378,7 @@ authRoutes.get('/me', authMiddleware, async (c) => {
       hasPassword: !!user.passwordHash,
       subscriptionTier: user.subscriptionTier ?? 'free',
       subscriptionExpiresAt: user.subscriptionExpiresAt ?? null,
+      subscriptionCancelAtPeriodEnd: user.subscriptionCancelAtPeriodEnd ?? false,
       role: user.role ?? 'user',
       emailVerifiedAt: user.emailVerifiedAt ?? null,
     },

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -302,6 +302,7 @@ billingRoutes.post('/create-portal', authMiddleware, async (c) => {
 // Cancels the user's subscription at the end of the current billing period
 billingRoutes.post('/cancel', authMiddleware, async (c) => {
   const user = c.get('user');
+  const db = c.get('db');
 
   if (!user) {
     return c.json({ error: 'Not authenticated' }, 401);
@@ -339,6 +340,11 @@ billingRoutes.post('/cancel', authMiddleware, async (c) => {
     }
 
     const sub = await cancelResponse.json() as { cancel_at_period_end: boolean; current_period_end: number };
+
+    await db
+      .update(schema.users)
+      .set({ subscriptionCancelAtPeriodEnd: true })
+      .where(eq(schema.users.id, user.id));
 
     return c.json({
       cancelled: true,
@@ -441,6 +447,7 @@ billingRoutes.post('/webhook', async (c) => {
               subscriptionExpiresAt: new Date(
                 Date.now() + 365 * 24 * 60 * 60 * 1000
               ).toISOString(),
+              subscriptionCancelAtPeriodEnd: false,
             })
             .where(eq(schema.users.id, user.id));
           console.log(`[billing] User ${user.id} upgraded to ${tier}`);
@@ -456,9 +463,12 @@ billingRoutes.post('/webhook', async (c) => {
       const subStatus = event.data.object.status;
 
       if (customerId && (subStatus === 'active' || subStatus === 'trialing')) {
-        // Re-fetch subscription to get updated tier
+        // Re-fetch subscription to get updated tier and cancellation state.
+        // This webhook fires for portal-initiated cancel/reactivate too, not
+        // just our own /billing/cancel endpoint, so it's the source of truth.
         const subscriptionId = event.data.object.id;
         let tier = 'pro';
+        let cancelAtPeriodEnd = false;
         if (subscriptionId && stripeSecretKey) {
           try {
             const subResponse = await fetch(
@@ -471,11 +481,13 @@ billingRoutes.post('/webhook', async (c) => {
             if (subResponse.ok) {
               const sub = await subResponse.json() as {
                 items?: { data?: { price?: { id: string } }[] };
+                cancel_at_period_end?: boolean;
               };
               const priceId = sub.items?.data?.[0]?.price?.id;
               if (priceId && PRICE_TO_TIER[priceId]) {
                 tier = PRICE_TO_TIER[priceId];
               }
+              cancelAtPeriodEnd = sub.cancel_at_period_end ?? false;
             }
           } catch (err) {
             console.error('[billing] Failed to fetch subscription on update:', err);
@@ -490,9 +502,9 @@ billingRoutes.post('/webhook', async (c) => {
         if (users.length > 0) {
           await db
             .update(schema.users)
-            .set({ subscriptionTier: tier })
+            .set({ subscriptionTier: tier, subscriptionCancelAtPeriodEnd: cancelAtPeriodEnd })
             .where(eq(schema.users.id, users[0].id));
-          console.log(`[billing] User ${users[0].id} subscription updated to ${tier}`);
+          console.log(`[billing] User ${users[0].id} subscription updated to ${tier} (cancelAtPeriodEnd=${cancelAtPeriodEnd})`);
         }
       }
     }
@@ -515,6 +527,7 @@ billingRoutes.post('/webhook', async (c) => {
               subscriptionTier: 'free',
               stripeSubscriptionId: null,
               subscriptionExpiresAt: null,
+              subscriptionCancelAtPeriodEnd: false,
             })
             .where(eq(schema.users.id, user.id));
           console.log(`[billing] User ${user.id} subscription cancelled, reverted to free`);

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -10,16 +10,19 @@ interface ProfileViewProps {
 }
 
 export function ProfileView({ isDarkMode = true, onLogout, onNavigate }: ProfileViewProps) {
-  const { user, updateProfile } = useAuth();
+  const { user, updateProfile, refreshUser } = useAuth();
   // Subscription management
   const [portalLoading, setPortalLoading] = useState(false);
   const [portalError, setPortalError] = useState('');
   const [cancelLoading, setCancelLoading] = useState(false);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
-  const [cancelledUntil, setCancelledUntil] = useState<string | null>(null);
 
   const tier = user?.subscriptionTier || 'free';
   const isPaid = tier === 'pro' || tier === 'elite';
+  // Persisted server-side, so this survives a page reload — unlike local
+  // component state, which would otherwise lose the cancellation notice and
+  // show a misleading "Renews {date}" message for an already-cancelled plan.
+  const isCancelled = !!user?.subscriptionCancelAtPeriodEnd;
 
   const handleManageSubscription = async () => {
     setPortalError('');
@@ -39,8 +42,8 @@ export function ProfileView({ isDarkMode = true, onLogout, onNavigate }: Profile
     setPortalError('');
     setCancelLoading(true);
     try {
-      const response = await api.post<{ cancelled: boolean; accessUntil: string }>('/billing/cancel', {});
-      setCancelledUntil(response.accessUntil);
+      await api.post<{ cancelled: boolean; accessUntil: string }>('/billing/cancel', {});
+      await refreshUser(); // picks up the persisted subscriptionCancelAtPeriodEnd flag
       setShowCancelConfirm(false);
     } catch (err) {
       setPortalError(err instanceof Error ? err.message : 'Failed to cancel subscription');
@@ -318,9 +321,9 @@ export function ProfileView({ isDarkMode = true, onLogout, onNavigate }: Profile
 
           {isPaid ? (
             <div className="space-y-3">
-              {cancelledUntil ? (
+              {isCancelled && user?.subscriptionExpiresAt ? (
                 <p className={`text-xs ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`}>
-                  Subscription cancelled. You have access until {new Date(cancelledUntil).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}.
+                  Subscription cancelled. You have access until {new Date(user.subscriptionExpiresAt).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}.
                 </p>
               ) : user?.subscriptionExpiresAt ? (
                 <p className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
@@ -342,7 +345,7 @@ export function ProfileView({ isDarkMode = true, onLogout, onNavigate }: Profile
                   <>Manage subscription</>
                 )}
               </button>
-              {!cancelledUntil && (
+              {!isCancelled && (
                 <>
                   {showCancelConfirm ? (
                     <div className={`p-3 rounded-lg border space-y-3 ${isDarkMode ? 'bg-slate-800/50 border-slate-700' : 'bg-slate-50 border-slate-200'}`}>

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -17,6 +17,7 @@ export interface User {
   hasPassword?: boolean;
   subscriptionTier?: 'free' | 'pro' | 'elite';
   subscriptionExpiresAt?: string;
+  subscriptionCancelAtPeriodEnd?: boolean;
   role?: 'user' | 'admin';
   /** ISO timestamp; null/undefined means email not yet verified. */
   emailVerifiedAt?: string | null;


### PR DESCRIPTION
## What

Picks off the BACKLOG.md item: **"Audit ProfileView - User profile, password change, Google link status"** (Code Audits section — one of the remaining unaudited views).

## Bug found

Cancelling a subscription (`handleCancelSubscription`) only recorded the "cancelled, access until X" notice in a local `useState`. Reloading the page — or just navigating away and back to Profile — lost that state entirely. Since `subscriptionTier` and `subscriptionExpiresAt` don't change until the billing period actually ends, the UI would then fall back to showing **"Renews {date}"**, incorrectly implying the card would be charged again on an already-cancelled subscription.

## Fix

- New `subscriptionCancelAtPeriodEnd` boolean on `users` (migration `0042_add_subscription_cancel_flag.sql`), persisted instead of relying on component state.
- Set `true` immediately in `POST /billing/cancel` after the Stripe call succeeds.
- Kept in sync from the `customer.subscription.updated` and `customer.subscription.deleted` Stripe webhooks too, so cancelling or reactivating directly through the Stripe billing portal (the "Manage subscription" button skips our own `/cancel` endpoint entirely) stays correct, not just cancels initiated in-app.
- Reset to `false` on new checkout completion.
- Exposed on `GET /auth/me` and the frontend `User` type.
- `ProfileView` now derives the cancelled state from `user.subscriptionCancelAtPeriodEnd` and calls the existing `refreshUser()` after a successful cancel, instead of holding its own copy that a reload would discard.

Rest of the component (validation, a11y roles, edit-account flow, Google-linked indicator) looked correct — no other issues found worth changing.

## Verified

- `npm run typecheck` (frontend) — clean
- `cd server && npx tsc --noEmit` — clean
- `npm test` (repo root, Vitest) — 43 passing, unaffected
- `npm run build` — succeeds
- `cd server && npm run db:migrate` — migration `0042` applies cleanly to local D1

## Owner follow-up

- Migration `0042` will auto-apply to the remote D1 on merge via the deploy pipeline (not run here, per instructions).
- No other manual steps — additive column + webhook sync only, no Stripe dashboard changes needed.

BACKLOG.md item checked off in this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L1tgxn5ANMRiQr2MgXvYfn)_